### PR TITLE
Build debug build by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ build: test
 	cp dist/orbitdb.min.js examples/browser/lib/orbitdb.min.js
 	cp node_modules/ipfs/dist/index.min.js examples/browser/lib/ipfs.min.js
 	cp dist/orbitdb.js examples/browser/lib/orbitdb.js
+	cp dist/orbitdb.js.map examples/browser/lib/orbitdb.js.map
 	cp node_modules/ipfs/dist/index.js examples/browser/lib/ipfs.js
 	@echo "Build success!"
 	@echo "Output: 'dist/', 'examples/browser/'"

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "build": "npm run build:es5 && npm run build:debug && npm run build:dist && npm run build:examples",
     "build:examples": "webpack --config conf/webpack.example.config.js --sort-modules-by size",
     "build:dist": "webpack --config conf/webpack.config.js --sort-modules-by size && mkdir -p examples/browser/lib && cp dist/orbitdb.min.js examples/browser/lib/orbitdb.min.js",
-    "build:debug": "webpack --config conf/webpack.debug.config.js --sort-modules-by size && mkdir -p examples/browser/lib && cp dist/orbitdb.js examples/browser/lib/orbitdb.js",
+    "build:debug": "webpack --config conf/webpack.debug.config.js --sort-modules-by size && mkdir -p examples/browser/lib && cp dist/orbitdb.js examples/browser/lib/orbitdb.js && cp dist/orbitdb.js.map examples/browser/lib/orbitdb.js.map",
     "build:es5": "babel src --out-dir ./dist/es5/ --presets babel-preset-es2015 --plugins babel-plugin-transform-runtime"
   }
 }

--- a/package.json
+++ b/package.json
@@ -49,10 +49,10 @@
     "examples:node": "node examples/eventlog.js",
     "examples:browser": "open examples/browser/browser.html",
     "test": "mocha",
-    "build": "npm run build:es5 && npm run build:dist && npm run build:examples",
+    "build": "npm run build:es5 && npm run build:debug && npm run build:dist && npm run build:examples",
     "build:examples": "webpack --config conf/webpack.example.config.js --sort-modules-by size",
     "build:dist": "webpack --config conf/webpack.config.js --sort-modules-by size && mkdir -p examples/browser/lib && cp dist/orbitdb.min.js examples/browser/lib/orbitdb.min.js",
-    "build:debug": "webpack --config conf/webpack.debug.config.js --sort-modules-by size && mkdir -p examples/browser/lib && cp dist/orbitdb.js examples/browser/lib/orbitdb.min.js",
+    "build:debug": "webpack --config conf/webpack.debug.config.js --sort-modules-by size && mkdir -p examples/browser/lib && cp dist/orbitdb.js examples/browser/lib/orbitdb.js",
     "build:es5": "babel src --out-dir ./dist/es5/ --presets babel-preset-es2015 --plugins babel-plugin-transform-runtime"
   }
 }


### PR DESCRIPTION
This PR will add `npm run build:debug` to the default build script resulting in debug (non-minified) build being built by default. The debug build and sourcemaps are copied to the browser examples directory.

Fixes #294 