### PR TITLE
Create a mapping for database types

### DIFF
--- a/test/create-open.test.js
+++ b/test/create-open.test.js
@@ -200,7 +200,7 @@ describe('orbit-db - Create & Open', function() {
       } catch (e) {
         err = e.toString()
       }
-      assert.equal(err, "Error: Database type not provided! Provide a type with 'options.type' (eventlog|feed|docstore|counter|keyvalue)")
+      assert.equal(err, `Error: Database type not provided! Provide a type with 'options.type' (${OrbitDB.databaseTypes.join('|')})`)
     })
 
     it('opens a database - name only', async () => {


### PR DESCRIPTION
  This PR will add a mapping objet from "database type" -> Class. 

In addition, this PR will add `.databaseTypes` property to OrbitDB class, refactor the internal _createStore() function and remove _openDatabase().
  