### PR TITLE
Add custom types

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,31 @@ node examples/eventlog.js
 
 More examples at [examples](https://github.com/orbitdb/orbit-db/tree/master/examples).
 
+### Custom Store Types
+
+You can add custom store types to OrbitDB:
+
+```javascript
+// define custom store type
+class CustomStore extends DocumentStore {
+  constructor (ipfs, id, dbname, options) {
+    super(ipfs, id, dbname, options)
+    this._type = CustomStore.type
+  }
+
+  static get type () {
+    return 'custom'
+  }
+}
+
+// add custom type to orbitdb
+OrbitDB.addDatabaseType(CustomStore.type, CustomStore)
+
+// instantiate custom store
+let orbitdb = new OrbitDB(ipfs, dbPath)
+let store = orbitdb.create(name, CustomStore.type)
+```
+
 ## Development
 
 #### Run Tests

--- a/src/OrbitDB.js
+++ b/src/OrbitDB.js
@@ -18,7 +18,7 @@ const logger = Logger.create("orbit-db")
 Logger.setLogLevel('NONE')
 
 // Mapping for 'database type' -> Class
-const databaseTypes = {
+let databaseTypes = {
   'counter': CounterStore,
   'eventlog': EventStore,
   'feed': FeedStore,
@@ -343,6 +343,11 @@ class OrbitDB {
 
   static isValidType (type) {
     return Object.keys(databaseTypes).includes(type)
+  }
+
+  static addDatabaseType (type, store) {
+    if (databaseTypes[type]) throw new Error(`Type already exists: ${type}`)
+    databaseTypes[type] = store
   }
 
   static create () {

--- a/test/create-type.test.js
+++ b/test/create-type.test.js
@@ -1,0 +1,59 @@
+'use strict'
+
+const assert = require('assert')
+const config = require('./utils/config')
+const DocumentStore = require('orbit-db-docstore')
+const OrbitDB = require('../src/OrbitDB')
+const rmrf = require('rimraf')
+const startIpfs = require('./utils/start-ipfs')
+
+const dbPath = './orbitdb/tests/create-open'
+const ipfsPath = './orbitdb/tests/create-open/ipfs'
+
+
+class CustomStore extends DocumentStore {
+  constructor (ipfs, id, dbname, options) {
+    super(ipfs, id, dbname, options)
+    this._type = CustomStore.type
+  }
+
+  static get type () {
+    return 'custom'
+  }
+}
+
+describe('orbit-db - Create custom type', function () {
+  this.timeout(config.timeout)
+
+  let ipfs, orbitdb
+
+  before(async () => {
+    config.daemon1.repo = ipfsPath
+    rmrf.sync(config.daemon1.repo)
+    rmrf.sync(dbPath)
+    ipfs = await startIpfs(config.daemon1)
+    orbitdb = new OrbitDB(ipfs, dbPath)
+  })
+
+  after(async () => {
+    if(orbitdb) orbitdb.stop()
+    if (ipfs) await ipfs.stop()
+  })
+
+  describe('addDatabaseType', function () {
+    it('should have the correct custom type', async () => {
+      OrbitDB.addDatabaseType(CustomStore.type, CustomStore)
+      let store = await orbitdb.create(dbPath, CustomStore.type)
+      assert.equal(store._type, CustomStore.type)
+    })
+
+    it('cannot be overwritten', async () => {
+      try {
+        OrbitDB.addDatabaseType(CustomStore.type, CustomStore)
+        throw new Error('This should not run.')
+      } catch (e) {
+        assert(e.message.indexOf('already exists') > -1)
+      }
+    })
+  })
+})


### PR DESCRIPTION
Add an `.addType(name, store)` method that updates the `databaseTypes` object so that OrbitDB can pre-process them like other store types.

Addresses https://github.com/orbitdb/orbit-db/issues/307