### PR TITLE
Update to latest orbit-db-cache

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1380,7 +1380,7 @@
         "glob": "7.1.2",
         "graceful-fs": "4.1.11",
         "lru-cache": "4.1.1",
-        "mississippi": "1.3.0",
+        "mississippi": "1.3.1",
         "mkdirp": "0.5.1",
         "move-concurrently": "1.0.1",
         "promise-inflight": "1.0.1",
@@ -1551,7 +1551,7 @@
       "dev": true,
       "requires": {
         "multibase": "0.3.4",
-        "multicodec": "0.2.5",
+        "multicodec": "0.2.6",
         "multihashes": "0.4.13"
       }
     },
@@ -1840,7 +1840,7 @@
         "cipher-base": "1.0.4",
         "inherits": "2.0.3",
         "ripemd160": "2.0.1",
-        "sha.js": "2.4.9"
+        "sha.js": "2.4.10"
       }
     },
     "create-hmac": {
@@ -1854,7 +1854,7 @@
         "inherits": "2.0.3",
         "ripemd160": "2.0.1",
         "safe-buffer": "5.1.1",
-        "sha.js": "2.4.9"
+        "sha.js": "2.4.10"
       }
     },
     "cross-spawn": {
@@ -2093,6 +2093,11 @@
         "repeating": "2.0.1"
       }
     },
+    "detect-libc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+      "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
+    },
     "detect-node": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.3.tgz",
@@ -2163,9 +2168,9 @@
       }
     },
     "domain-browser": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz",
-      "integrity": "sha1-hnqksJP6oF8d4IwG9NeyH9+GmLw=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
+      "integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==",
       "dev": true
     },
     "dot-prop": {
@@ -2512,7 +2517,7 @@
             "keccak": "1.4.0",
             "rlp": "2.0.0",
             "safe-buffer": "5.1.1",
-            "secp256k1": "3.4.0"
+            "secp256k1": "3.5.0"
           }
         }
       }
@@ -2545,7 +2550,7 @@
             "keccak": "1.4.0",
             "rlp": "2.0.0",
             "safe-buffer": "5.1.1",
-            "secp256k1": "3.4.0"
+            "secp256k1": "3.5.0"
           }
         }
       }
@@ -2560,7 +2565,7 @@
         "create-hash": "1.1.3",
         "keccakjs": "0.2.1",
         "rlp": "2.0.0",
-        "secp256k1": "3.4.0"
+        "secp256k1": "3.5.0"
       }
     },
     "ethjs-util": {
@@ -2677,9 +2682,9 @@
       "dev": true
     },
     "file-type": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-7.4.0.tgz",
-      "integrity": "sha1-KnyU9ioAMBULt9m2xwz6HT51nIY=",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-7.5.0.tgz",
+      "integrity": "sha512-siGSLPCL9mJM10TaTswSF2Ry60stJaemPbAf2StSGOcjlfVIA2V/wX3Qg8IiTHmGLMch0ZaM9DhszSo5rfIulg==",
       "dev": true
     },
     "filename-regex": {
@@ -3857,7 +3862,7 @@
             "mkdirp": "0.5.1",
             "nopt": "4.0.1",
             "npmlog": "4.1.2",
-            "rc": "1.2.4",
+            "rc": "1.2.5",
             "request": "2.83.0",
             "rimraf": "2.6.2",
             "semver": "5.5.0",
@@ -4499,7 +4504,7 @@
         "byteman": "1.3.5",
         "cids": "0.5.2",
         "debug": "3.1.0",
-        "file-type": "7.4.0",
+        "file-type": "7.5.0",
         "filesize": "3.5.11",
         "fsm-event": "2.1.0",
         "get-folder-size": "1.0.1",
@@ -4507,26 +4512,26 @@
         "hapi": "16.6.2",
         "hapi-set-header": "1.0.2",
         "hoek": "5.0.2",
-        "ipfs-api": "17.3.0",
+        "ipfs-api": "17.5.0",
         "ipfs-bitswap": "0.18.0",
         "ipfs-block": "0.6.1",
         "ipfs-block-service": "0.13.0",
         "ipfs-multipart": "0.1.0",
-        "ipfs-repo": "0.18.5",
+        "ipfs-repo": "0.18.7",
         "ipfs-unixfs": "0.1.14",
         "ipfs-unixfs-engine": "0.24.2",
         "ipld-resolver": "0.14.1",
         "is-ipfs": "0.3.2",
         "is-stream": "1.1.0",
-        "joi": "13.1.0",
-        "libp2p": "0.15.1",
+        "joi": "13.1.1",
+        "libp2p": "0.15.2",
         "libp2p-circuit": "0.1.4",
         "libp2p-floodsub": "0.13.1",
-        "libp2p-kad-dht": "0.6.0",
-        "libp2p-mdns": "0.9.1",
+        "libp2p-kad-dht": "0.6.3",
+        "libp2p-mdns": "0.9.2",
         "libp2p-multiplex": "0.5.1",
         "libp2p-railing": "0.7.1",
-        "libp2p-secio": "0.9.0",
+        "libp2p-secio": "0.9.1",
         "libp2p-tcp": "0.11.2",
         "libp2p-webrtc-star": "0.13.3",
         "libp2p-websocket-star": "0.7.2",
@@ -4542,9 +4547,9 @@
         "multihashes": "0.4.13",
         "once": "1.4.0",
         "path-exists": "3.0.0",
-        "peer-book": "0.5.2",
-        "peer-id": "0.10.4",
-        "peer-info": "0.11.4",
+        "peer-book": "0.5.4",
+        "peer-id": "0.10.5",
+        "peer-info": "0.11.6",
         "progress": "2.0.0",
         "prom-client": "10.2.2",
         "prometheus-gc-stats": "0.5.0",
@@ -4567,14 +4572,14 @@
         "temp": "0.8.3",
         "through2": "2.0.3",
         "update-notifier": "2.3.0",
-        "yargs": "10.1.1",
+        "yargs": "10.1.2",
         "yargs-parser": "8.1.0"
       }
     },
     "ipfs-api": {
-      "version": "17.3.0",
-      "resolved": "https://registry.npmjs.org/ipfs-api/-/ipfs-api-17.3.0.tgz",
-      "integrity": "sha512-o4Qqchv+tY4dtZM6crD/3KNCItbxTRQBd5tgWMmPlHLZNJnhgSR66QVh9V4GZ7yzCNxY9Q2TjdcXiKmi/i7xYQ==",
+      "version": "17.5.0",
+      "resolved": "https://registry.npmjs.org/ipfs-api/-/ipfs-api-17.5.0.tgz",
+      "integrity": "sha512-1LMao28nKBCUrvc6BUCsA3GEQ2TAoKx4Jy3BeUR3o5MVcx+dJDtXfEYDKg6WE/PWzfJF1uZGWgR9Dm2OLITR6w==",
       "dev": true,
       "requires": {
         "async": "2.6.0",
@@ -4594,18 +4599,30 @@
         "multihashes": "0.4.13",
         "ndjson": "1.5.0",
         "once": "1.4.0",
-        "peer-id": "0.10.4",
-        "peer-info": "0.11.4",
+        "peer-id": "0.10.5",
+        "peer-info": "0.11.6",
         "promisify-es6": "1.0.3",
         "pull-defer": "0.2.2",
         "pull-pushable": "2.1.2",
-        "pump": "1.0.3",
+        "pump": "2.0.1",
         "qs": "6.5.1",
         "readable-stream": "2.3.3",
         "stream-http": "2.8.0",
         "stream-to-pull-stream": "1.7.2",
         "streamifier": "0.1.1",
         "tar-stream": "1.5.5"
+      },
+      "dependencies": {
+        "pump": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
+          "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+          "dev": true,
+          "requires": {
+            "end-of-stream": "1.4.1",
+            "once": "1.4.0"
+          }
+        }
       }
     },
     "ipfs-bitswap": {
@@ -4629,7 +4646,7 @@
         "lodash.uniqwith": "4.5.0",
         "lodash.values": "4.3.0",
         "moving-average": "1.0.0",
-        "multicodec": "0.2.5",
+        "multicodec": "0.2.6",
         "multihashing-async": "0.4.7",
         "protons": "1.0.1",
         "pull-defer": "0.2.2",
@@ -4693,13 +4710,14 @@
       }
     },
     "ipfs-repo": {
-      "version": "0.18.5",
-      "resolved": "https://registry.npmjs.org/ipfs-repo/-/ipfs-repo-0.18.5.tgz",
-      "integrity": "sha512-QELzb2fLqM2t9WQuiD60iRbC8KrxQ3GKODAOxTSnfrT+KKWls/2n/yw70mW80eemCRz6/9HSWXZdjmG2eISSaA==",
+      "version": "0.18.7",
+      "resolved": "https://registry.npmjs.org/ipfs-repo/-/ipfs-repo-0.18.7.tgz",
+      "integrity": "sha512-a1gXPX2UA/8rE63/E5X7+QB7jvmNYD+mVHSX0ypb7ZIsMoc0ewiq5Bwc2NXQAN7PCNWksxp1tDGWzq6bAPm9vg==",
       "dev": true,
       "requires": {
         "async": "2.6.0",
         "base32.js": "0.1.0",
+        "big.js": "5.0.3",
         "cids": "0.5.2",
         "datastore-core": "0.4.0",
         "datastore-fs": "0.4.2",
@@ -4713,7 +4731,8 @@
         "lodash.get": "4.4.2",
         "lodash.has": "4.5.2",
         "lodash.set": "4.3.2",
-        "multiaddr": "3.0.2"
+        "multiaddr": "3.0.2",
+        "pull-stream": "3.6.1"
       },
       "dependencies": {
         "abstract-leveldown": {
@@ -4724,6 +4743,12 @@
           "requires": {
             "xtend": "4.0.1"
           }
+        },
+        "big.js": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.0.3.tgz",
+          "integrity": "sha512-av8LNZGBl4cg2r4ZhWqghJOxi2P8UCcWhdmrFgcHPMmUJ6jx1FbnyxjwL4URYzMK3QJg60qeMefQhv9G14oYKA==",
+          "dev": true
         },
         "level-js": {
           "version": "github:timkuijsten/level.js#18e03adab34c49523be7d3d58fafb0c632f61303",
@@ -4852,7 +4877,7 @@
       "requires": {
         "async": "2.6.0",
         "cids": "0.5.2",
-        "multicodec": "0.2.5",
+        "multicodec": "0.2.6",
         "multihashes": "0.4.13",
         "multihashing-async": "0.4.7",
         "smart-buffer": "4.0.1",
@@ -4879,7 +4904,7 @@
         "interface-datastore": "0.4.2",
         "ipfs-block": "0.6.1",
         "ipfs-block-service": "0.13.0",
-        "ipfs-repo": "0.18.5",
+        "ipfs-repo": "0.18.7",
         "ipld-dag-cbor": "0.11.2",
         "ipld-dag-pb": "0.11.4",
         "ipld-ethereum": "1.4.4",
@@ -5157,9 +5182,9 @@
       "dev": true
     },
     "joi": {
-      "version": "13.1.0",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-13.1.0.tgz",
-      "integrity": "sha512-x6pGmDYI6hwNi3skP6irQqRaJntzeaWmZ4rsnjc/NTlf6P5Gp3Aw/O8REe8oLJ6wPhrzd9K3RW1m3Yz/Hx4Weg==",
+      "version": "13.1.1",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-13.1.1.tgz",
+      "integrity": "sha512-Y44bDwIoeCjFDRO18VaMRc0hIdPkLbZaF2VqU7t1tCcno3S3XzsmlYYpOu0Qk6nkzoI5RSao7W57NTvPKxbkcg==",
       "dev": true,
       "requires": {
         "hoek": "5.0.2",
@@ -5269,12 +5294,6 @@
         "json-schema": "0.2.3",
         "verror": "1.10.0"
       }
-    },
-    "jsrsasign": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-8.0.4.tgz",
-      "integrity": "sha1-P3uCOIRPEmtJanVW7J9LUR+V+GE=",
-      "dev": true
     },
     "k-bucket": {
       "version": "3.3.1",
@@ -5481,7 +5500,7 @@
         "bindings": "1.3.0",
         "fast-future": "1.0.2",
         "nan": "2.7.0",
-        "prebuild-install": "2.4.1"
+        "prebuild-install": "2.5.0"
       },
       "dependencies": {
         "abstract-leveldown": {
@@ -5529,19 +5548,19 @@
       }
     },
     "libp2p": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/libp2p/-/libp2p-0.15.1.tgz",
-      "integrity": "sha512-bsv3KWHIUowX8Sx+Eyxxva8Xp0Pd8MEJF9l7xcDRyYfNDzqjTGOVBSo09t7AbeIL3701wCCWaO/ESfZf/LDQnQ==",
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/libp2p/-/libp2p-0.15.2.tgz",
+      "integrity": "sha512-hJ9ho4j3XRfQuI+j4aL3F2Zci3eQnyGDMaZLKdc4wZy1CCe1J3AdmLtEmiGZjTmyaicJRk392rI7nSuv9zjv0g==",
       "dev": true,
       "requires": {
         "async": "2.6.0",
         "libp2p-ping": "0.6.0",
-        "libp2p-swarm": "0.35.0",
+        "libp2p-swarm": "0.35.1",
         "mafmt": "3.0.2",
         "multiaddr": "3.0.2",
-        "peer-book": "0.5.2",
-        "peer-id": "0.10.4",
-        "peer-info": "0.11.4"
+        "peer-book": "0.5.4",
+        "peer-id": "0.10.5",
+        "peer-info": "0.11.6"
       }
     },
     "libp2p-circuit": {
@@ -5558,8 +5577,8 @@
         "mafmt": "3.0.2",
         "multiaddr": "3.0.2",
         "multistream-select": "0.14.1",
-        "peer-id": "0.10.4",
-        "peer-info": "0.11.4",
+        "peer-id": "0.10.5",
+        "peer-info": "0.11.6",
         "protons": "1.0.1",
         "pull-abortable": "4.1.1",
         "pull-handshake": "1.1.4",
@@ -5569,19 +5588,19 @@
       }
     },
     "libp2p-crypto": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.11.0.tgz",
-      "integrity": "sha512-luq/FVGtSukPqUMF+1ZjEY5vkZrW+GE7uosbNU3QS2bixShPYZpQ0yuj2bOBgee9JUoX9HwIx9skm9CYRStJFA==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.12.0.tgz",
+      "integrity": "sha512-zVgdyEHHixhjccb/ehBUiGciOeMT/fx7x4F5Z4EvIHiQmrO8vS0cX7sVtnxAVb0mVjjYOjbOuRUCxRBs1Px0vg==",
       "dev": true,
       "requires": {
         "asn1.js": "5.0.0",
         "async": "2.6.0",
         "browserify-aes": "1.1.1",
         "bs58": "4.0.1",
-        "jsrsasign": "8.0.4",
         "keypair": "1.0.1",
         "libp2p-crypto-secp256k1": "0.2.2",
         "multihashing-async": "0.4.7",
+        "node-forge": "0.7.1",
         "pem-jwk": "1.5.1",
         "protons": "1.0.1",
         "rsa-pem-to-jwk": "1.1.3",
@@ -5599,7 +5618,7 @@
         "multihashing-async": "0.4.7",
         "nodeify": "1.0.1",
         "safe-buffer": "5.1.1",
-        "secp256k1": "3.4.0"
+        "secp256k1": "3.5.0"
       }
     },
     "libp2p-floodsub": {
@@ -5641,23 +5660,23 @@
       }
     },
     "libp2p-identify": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/libp2p-identify/-/libp2p-identify-0.6.2.tgz",
-      "integrity": "sha512-Z67kYAeEraYDElsH6h9lmpRNLLN2gJqj02UcvEYgQVxp4hURvmfNRQyKUKF8qX0Xfj58KXLZih/F4RagZYKfnw==",
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/libp2p-identify/-/libp2p-identify-0.6.3.tgz",
+      "integrity": "sha512-tCkobHxmK636lCF3PwIA/G8Ty7KGFVT/WW7zaNUUypMKJKT9gZg9U1d+BVTM2xA4TUYSnt8TTY6WgKeUfDffHg==",
       "dev": true,
       "requires": {
         "multiaddr": "3.0.2",
-        "peer-id": "0.10.4",
-        "peer-info": "0.11.4",
+        "peer-id": "0.10.5",
+        "peer-info": "0.11.6",
         "protons": "1.0.1",
         "pull-length-prefixed": "1.3.0",
         "pull-stream": "3.6.1"
       }
     },
     "libp2p-kad-dht": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/libp2p-kad-dht/-/libp2p-kad-dht-0.6.0.tgz",
-      "integrity": "sha512-oSmtLCkMkVYgq58T2MkdLwNiCtN2hY55Eh1Q05Tw34ab31YnT3NqoVw6l6srFDDjg5Ka/4TDbp/fTppgNulFRw==",
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/libp2p-kad-dht/-/libp2p-kad-dht-0.6.3.tgz",
+      "integrity": "sha512-fOYrObfGZY733DyD+5GOHmZJ/7oKU75k8S1gIv658G9434yxzb2t+QrZ8W3REo8CprwBVXwpYV4IbQUg6Kv6QQ==",
       "dev": true,
       "requires": {
         "async": "2.6.0",
@@ -5668,11 +5687,11 @@
         "heap": "0.2.6",
         "interface-datastore": "0.4.2",
         "k-bucket": "3.3.1",
-        "libp2p-crypto": "0.10.4",
+        "libp2p-crypto": "0.12.0",
         "libp2p-record": "0.5.1",
         "multihashing-async": "0.4.7",
-        "peer-id": "0.10.4",
-        "peer-info": "0.11.4",
+        "peer-id": "0.10.5",
+        "peer-info": "0.11.6",
         "priorityqueue": "0.2.0",
         "protons": "1.0.1",
         "pull-length-prefixed": "1.3.0",
@@ -5680,40 +5699,19 @@
         "safe-buffer": "5.1.1",
         "varint": "5.0.0",
         "xor-distance": "1.0.0"
-      },
-      "dependencies": {
-        "libp2p-crypto": {
-          "version": "0.10.4",
-          "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.10.4.tgz",
-          "integrity": "sha512-jNEs0/LouDqMGEE9hN1yRfkeFtDrgMbEGPy5xE/y2OVWr9WFU5S/u/tlpF3aeT0b/xhy/zCtSZ/PjzviJwuv5w==",
-          "dev": true,
-          "requires": {
-            "asn1.js": "5.0.0",
-            "async": "2.6.0",
-            "browserify-aes": "1.1.1",
-            "keypair": "1.0.1",
-            "libp2p-crypto-secp256k1": "0.2.2",
-            "multihashing-async": "0.4.7",
-            "pem-jwk": "1.5.1",
-            "protons": "1.0.1",
-            "rsa-pem-to-jwk": "1.1.3",
-            "tweetnacl": "1.0.0",
-            "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
-          }
-        }
       }
     },
     "libp2p-mdns": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/libp2p-mdns/-/libp2p-mdns-0.9.1.tgz",
-      "integrity": "sha512-nmbHsN3bX8aFo0XCdS12R9MTiC+x/D3PDQty5nF3MCYs2U/P77ez5Bg4eutChPs0LsqFbA4Uwea0lD5OWDbs4w==",
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/libp2p-mdns/-/libp2p-mdns-0.9.2.tgz",
+      "integrity": "sha512-g77yK3znf4bZl6466EOs1MGP9Pqv4gEcsCnuDaSiWtZ4bZOApkGS/gWQBY3vaCbP1faJ5m7b83uBlEeHiT61cA==",
       "dev": true,
       "requires": {
         "libp2p-tcp": "0.11.2",
         "multiaddr": "3.0.2",
-        "multicast-dns": "6.2.2",
-        "peer-id": "0.10.4",
-        "peer-info": "0.11.4"
+        "multicast-dns": "6.2.3",
+        "peer-id": "0.10.5",
+        "peer-info": "0.11.6"
       }
     },
     "libp2p-multiplex": {
@@ -5727,14 +5725,14 @@
         "pull-catch": "1.0.0",
         "pull-stream": "3.6.1",
         "pull-stream-to-stream": "1.3.4",
-        "pump": "2.0.0",
+        "pump": "2.0.1",
         "stream-to-pull-stream": "1.7.2"
       },
       "dependencies": {
         "pump": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.0.tgz",
-          "integrity": "sha512-6MYypjOvtiXhBSTOD0Zs5eNjCGfnqi5mPsCsW+dgKTxrZzQMZQNpBo3XRkLx7id753f3EeyHLBqzqqUymIolgw==",
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
+          "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
           "dev": true,
           "requires": {
             "end-of-stream": "1.4.1",
@@ -5785,8 +5783,8 @@
         "debug": "3.1.0",
         "lodash": "4.17.4",
         "multiaddr": "3.0.2",
-        "peer-id": "0.10.4",
-        "peer-info": "0.11.4"
+        "peer-id": "0.10.5",
+        "peer-info": "0.11.6"
       }
     },
     "libp2p-record": {
@@ -5800,23 +5798,23 @@
         "left-pad": "1.2.0",
         "multihashes": "0.4.13",
         "multihashing-async": "0.4.7",
-        "peer-id": "0.10.4",
+        "peer-id": "0.10.5",
         "protons": "1.0.1"
       }
     },
     "libp2p-secio": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/libp2p-secio/-/libp2p-secio-0.9.0.tgz",
-      "integrity": "sha512-t1yAI62MAJ7WEZXMgnV01Lh+VqQ3Z1cXLVkKriIZsl8H4RrRjXaPAAL6lAgbmd+u1ME6mCdU4ss4hF2ju/uAvw==",
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/libp2p-secio/-/libp2p-secio-0.9.1.tgz",
+      "integrity": "sha512-VuyvEMEOAPjSbHK7iLZ2qYaCdBpPltzTyP+ZaB9PYgBgBMoIiNTycghQb0hOqYjnbNgmDrLuAalpExjOJrXH4w==",
       "dev": true,
       "requires": {
         "async": "2.6.0",
         "debug": "3.1.0",
         "interface-connection": "0.3.2",
-        "libp2p-crypto": "0.11.0",
+        "libp2p-crypto": "0.12.0",
         "multihashing-async": "0.4.7",
-        "peer-id": "0.10.4",
-        "peer-info": "0.11.4",
+        "peer-id": "0.10.5",
+        "peer-info": "0.11.6",
         "protons": "1.0.1",
         "pull-defer": "0.2.2",
         "pull-handshake": "1.1.4",
@@ -5825,9 +5823,9 @@
       }
     },
     "libp2p-swarm": {
-      "version": "0.35.0",
-      "resolved": "https://registry.npmjs.org/libp2p-swarm/-/libp2p-swarm-0.35.0.tgz",
-      "integrity": "sha512-I4PhxgsOMtRuaIWLDr+DeN+2SzXL0Kh1eNRXkAyeAEvPgO5VR3sVa1TKh23w4klIVWVM6bADEM5tI6FS1dxlQA==",
+      "version": "0.35.1",
+      "resolved": "https://registry.npmjs.org/libp2p-swarm/-/libp2p-swarm-0.35.1.tgz",
+      "integrity": "sha512-FL511w/v7qziy3Xz/c53CZtTVwaeodkRfxAEmnHX8S6V/2BkZnNb7WZK1v8L+wB5TKzODGyqETypcA490fDELA==",
       "dev": true,
       "requires": {
         "async": "2.6.0",
@@ -5835,13 +5833,13 @@
         "interface-connection": "0.3.2",
         "ip-address": "5.8.9",
         "libp2p-circuit": "0.1.4",
-        "libp2p-identify": "0.6.2",
+        "libp2p-identify": "0.6.3",
         "lodash.includes": "4.3.0",
         "multiaddr": "3.0.2",
         "multistream-select": "0.14.1",
         "once": "1.4.0",
-        "peer-id": "0.10.4",
-        "peer-info": "0.11.4",
+        "peer-id": "0.10.5",
+        "peer-info": "0.11.6",
         "pull-stream": "3.6.1"
       }
     },
@@ -5879,10 +5877,10 @@
         "minimist": "1.2.0",
         "multiaddr": "3.0.2",
         "once": "1.4.0",
-        "peer-id": "0.10.4",
-        "peer-info": "0.11.4",
+        "peer-id": "0.10.5",
+        "peer-info": "0.11.6",
         "pull-stream": "3.6.1",
-        "simple-peer": "8.2.0",
+        "simple-peer": "8.3.0",
         "socket.io": "2.0.4",
         "socket.io-client": "2.0.4",
         "stream-to-pull-stream": "1.7.2",
@@ -5904,11 +5902,11 @@
         "merge-recursive": "0.0.3",
         "multiaddr": "3.0.2",
         "once": "1.4.0",
-        "peer-id": "0.10.4",
-        "peer-info": "0.11.4",
+        "peer-id": "0.10.5",
+        "peer-info": "0.11.6",
         "pull-stream": "3.6.1",
         "socket.io-client": "2.0.4",
-        "socket.io-pull-stream": "0.1.3",
+        "socket.io-pull-stream": "0.1.4",
         "uuid": "3.2.1"
       },
       "dependencies": {
@@ -6340,7 +6338,7 @@
             "keccak": "1.4.0",
             "rlp": "2.0.0",
             "safe-buffer": "5.1.1",
-            "secp256k1": "3.4.0"
+            "secp256k1": "3.5.0"
           }
         }
       }
@@ -6448,9 +6446,9 @@
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
     },
     "mississippi": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/mississippi/-/mississippi-1.3.0.tgz",
-      "integrity": "sha1-0gFYPrEjJ+PFwWQqQEqcrPlONPU=",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/mississippi/-/mississippi-1.3.1.tgz",
+      "integrity": "sha512-/6rB8YXFbAtsUVRphIRQqB0+9c7VaPHCjVtvto+JqwVxgz8Zz+I+f68/JgQ+Pb4VlZb2svA9OtdXnHHsZz7ltg==",
       "dev": true,
       "requires": {
         "concat-stream": "1.6.0",
@@ -6580,19 +6578,19 @@
       }
     },
     "multicast-dns": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-6.2.2.tgz",
-      "integrity": "sha512-xTO41ApiRHMVDBYhNL9bEhx7kRf1hq3OqPOnOy8bpTi0JZSxVPDre7ZRpTHLDlxmhf6d/FL+10E8VX1QRd+0DA==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-6.2.3.tgz",
+      "integrity": "sha512-ji6J5enbMyGRHIAkAOu3WdV8nggqviKCEKtXcOqfphZZtQrmHKycfynJ2V7eVPUA4NhJ6V7Wf4TmGbTwKE9B6g==",
       "dev": true,
       "requires": {
         "dns-packet": "1.3.1",
-        "thunky": "0.1.0"
+        "thunky": "1.0.2"
       }
     },
     "multicodec": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-0.2.5.tgz",
-      "integrity": "sha512-83MVRQi0j6cgYP0lqC+7HHbYKYpd074qy94OuzX/elmN8CTMF0/aH0Khb0pcRtALjD2ZFG3lgEy3bhwpCreO1g==",
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-0.2.6.tgz",
+      "integrity": "sha512-VGyRUDkxdJzWnj9x3C49MzI3+TtKKDYNfIBOaWBCNuPk6CE5CwwkL15gJtsLDfLay0fL4xTh4Af3kBbJSxSppw==",
       "dev": true,
       "requires": {
         "varint": "5.0.0"
@@ -6715,12 +6713,18 @@
       }
     },
     "node-abi": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.1.2.tgz",
-      "integrity": "sha512-hmUtb8m75RSi7N+zZLYqe75XDvZB+6LyTBPkj2DConvNgQet2e3BIqEwe1LLvqMrfyjabuT5ZOrTioLCH1HTdA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.2.0.tgz",
+      "integrity": "sha512-FqVC0WNNL8fQWQK3GYTESfwZXZKDbSIiEEIvufq7HV6Lj0IDDZRVa4CU/KTA0JVlqY9eTDSuPiC8FS9UfGVuzA==",
       "requires": {
         "semver": "5.5.0"
       }
+    },
+    "node-forge": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.1.tgz",
+      "integrity": "sha1-naYR6giYL0uUIGs760zJZl8gwwA=",
+      "dev": true
     },
     "node-libs-browser": {
       "version": "2.1.0",
@@ -6734,7 +6738,7 @@
         "console-browserify": "1.1.0",
         "constants-browserify": "1.0.0",
         "crypto-browserify": "3.12.0",
-        "domain-browser": "1.1.7",
+        "domain-browser": "1.2.0",
         "events": "1.1.1",
         "https-browserify": "1.0.0",
         "os-browserify": "0.3.0",
@@ -6746,7 +6750,7 @@
         "stream-browserify": "2.0.1",
         "stream-http": "2.8.0",
         "string_decoder": "1.0.3",
-        "timers-browserify": "2.0.4",
+        "timers-browserify": "2.0.6",
         "tty-browserify": "0.0.0",
         "url": "0.11.0",
         "util": "0.10.3",
@@ -6905,9 +6909,9 @@
       "dev": true
     },
     "orbit-db-cache": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/orbit-db-cache/-/orbit-db-cache-0.2.1.tgz",
-      "integrity": "sha512-8TzMxV+HoDgxOmcDij8943MuByBQtwSkXy3OAcxGbtmF2r7lDY4DESO6ODsdHEGp+8rxkgOe5unkaACQ5A10hg==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/orbit-db-cache/-/orbit-db-cache-0.2.2.tgz",
+      "integrity": "sha512-qJ4xv6Yozkgv5j9dw6a7lsGRTjolDSCFzdOr0Pusu62dXH1etG0XD2Uaqk6LoaHhoepXdYH7UIiHzfbxHNmMUA==",
       "requires": {
         "level-js": "2.2.4",
         "leveldown": "1.9.0",
@@ -7102,7 +7106,7 @@
       "dev": true,
       "requires": {
         "got": "6.7.1",
-        "registry-auth-token": "3.3.1",
+        "registry-auth-token": "3.3.2",
         "registry-url": "3.1.0",
         "semver": "5.5.0"
       }
@@ -7239,41 +7243,41 @@
         "create-hmac": "1.1.6",
         "ripemd160": "2.0.1",
         "safe-buffer": "5.1.1",
-        "sha.js": "2.4.9"
+        "sha.js": "2.4.10"
       }
     },
     "peer-book": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/peer-book/-/peer-book-0.5.2.tgz",
-      "integrity": "sha512-+BgRdGjVhPJo1AaIyBFPI/Nij1uvyBeowXT5CHGJVjVUlcONK3rl471l9t5oVf0Q31/wEtZTL68Y7l0TctFSHQ==",
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/peer-book/-/peer-book-0.5.4.tgz",
+      "integrity": "sha512-BuI/mO6OarE5839h9KLG+gSF8UPHlN8VIo6A9ZF4RlcYfOjAuOtDwgAmKIEpf3lTmVqqIkwD92KIij237yphaw==",
       "dev": true,
       "requires": {
         "bs58": "4.0.1",
-        "peer-id": "0.10.4",
-        "peer-info": "0.11.4"
+        "peer-id": "0.10.5",
+        "peer-info": "0.11.6"
       }
     },
     "peer-id": {
-      "version": "0.10.4",
-      "resolved": "https://registry.npmjs.org/peer-id/-/peer-id-0.10.4.tgz",
-      "integrity": "sha512-thim0ZOsFbMHeZVl+0+UHPy1OZCOVDr277MQYR2swsnWex0j/7beyXTafhqislkn1dWC9fo9uKWqxwe+GSvBqg==",
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/peer-id/-/peer-id-0.10.5.tgz",
+      "integrity": "sha512-5IDD0Py3vfmQ+k7E211OaZ+VRLXO9FoLBTx+Plus6bX8TialecMs971UnkV5FwpiMK8hHds9vYCfXdXzUrJgmQ==",
       "dev": true,
       "requires": {
         "async": "2.6.0",
-        "libp2p-crypto": "0.11.0",
+        "libp2p-crypto": "0.12.0",
         "lodash": "4.17.4",
         "multihashes": "0.4.13"
       }
     },
     "peer-info": {
-      "version": "0.11.4",
-      "resolved": "https://registry.npmjs.org/peer-info/-/peer-info-0.11.4.tgz",
-      "integrity": "sha512-p+NpRgZpnlz0BGz6ZLFF8vVlqOBDxGwN7AA+QCc4nCICxVpbf4PlmtzwePVtkDqlNwUXYCDKK8pG0FGC5E8B2g==",
+      "version": "0.11.6",
+      "resolved": "https://registry.npmjs.org/peer-info/-/peer-info-0.11.6.tgz",
+      "integrity": "sha512-xrVNiAF1IhVJNGEg5P2UQN+subaEkszT8YkC3zdy06MK0vTH3cMHB+HH+ZURkoSLssc3HbK58ecXeKpQ/4zq5w==",
       "dev": true,
       "requires": {
         "lodash.uniqby": "4.7.0",
         "multiaddr": "3.0.2",
-        "peer-id": "0.10.4"
+        "peer-id": "0.10.5"
       }
     },
     "pem-jwk": {
@@ -7389,20 +7393,21 @@
       }
     },
     "prebuild-install": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-2.4.1.tgz",
-      "integrity": "sha512-99TyEFYTTkBWANT+mwSptmLb9ZCLQ6qKIUE36fXSIOtShB0JNprL2hzBD8F1yIuT9btjFrFEwbRHXhqDi1HmRA==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-2.5.0.tgz",
+      "integrity": "sha512-3wlyZgmkeeyduOR8Ursu5gKr3yWAYObACa5aJOtt2farRRFV/+zXk/Y3wM6yQRMqmqHh+pHAwyKp5r82K699Rg==",
       "requires": {
+        "detect-libc": "1.0.3",
         "expand-template": "1.1.0",
         "github-from-package": "0.0.0",
         "minimist": "1.2.0",
         "mkdirp": "0.5.1",
-        "node-abi": "2.1.2",
+        "node-abi": "2.2.0",
         "noop-logger": "0.1.1",
         "npmlog": "4.1.2",
         "os-homedir": "1.0.2",
         "pump": "1.0.3",
-        "rc": "1.2.4",
+        "rc": "1.2.5",
         "simple-get": "1.4.3",
         "tar-fs": "1.16.0",
         "tunnel-agent": "0.6.0",
@@ -7804,13 +7809,13 @@
       "requires": {
         "duplexify": "3.5.3",
         "inherits": "2.0.3",
-        "pump": "2.0.0"
+        "pump": "2.0.1"
       },
       "dependencies": {
         "pump": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.0.tgz",
-          "integrity": "sha512-6MYypjOvtiXhBSTOD0Zs5eNjCGfnqi5mPsCsW+dgKTxrZzQMZQNpBo3XRkLx7id753f3EeyHLBqzqqUymIolgw==",
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
+          "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
           "dev": true,
           "requires": {
             "end-of-stream": "1.4.1",
@@ -7904,9 +7909,9 @@
       }
     },
     "rc": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.4.tgz",
-      "integrity": "sha1-oPYGyq4qO4YrvQ74VILAElsxX6M=",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.5.tgz",
+      "integrity": "sha1-J1zWh/bjs2zHVrqibf7oCnkDAf0=",
       "requires": {
         "deep-extend": "0.4.2",
         "ini": "1.3.5",
@@ -8005,12 +8010,12 @@
       }
     },
     "registry-auth-token": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.1.tgz",
-      "integrity": "sha1-+w0yie4Nmtosu1KvXf5mywcNMAY=",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.2.tgz",
+      "integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
       "dev": true,
       "requires": {
-        "rc": "1.2.4",
+        "rc": "1.2.5",
         "safe-buffer": "5.1.1"
       }
     },
@@ -8020,7 +8025,7 @@
       "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
       "dev": true,
       "requires": {
-        "rc": "1.2.4"
+        "rc": "1.2.5"
       }
     },
     "regjsgen": {
@@ -8208,9 +8213,9 @@
       }
     },
     "secp256k1": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.4.0.tgz",
-      "integrity": "sha512-eC120ESQ6MB3gMkxj0PVcSjv/9VtSUmm9uPGNc58yTs93iMCUQZ1xeGPidQMY1z1O4psbCtOxRu3vNqpbuck6Q==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.5.0.tgz",
+      "integrity": "sha512-e5QIJl8W7Y4tT6LHffVcZAxJjvpgE5Owawv6/XCYPQljE9aP2NFFddQ8OYMKhdLshNu88FfL3qCN3/xYkXGRsA==",
       "dev": true,
       "requires": {
         "bindings": "1.3.0",
@@ -8267,9 +8272,9 @@
       "dev": true
     },
     "sha.js": {
-      "version": "2.4.9",
-      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.9.tgz",
-      "integrity": "sha512-G8zektVqbiPHrylgew9Zg1VRB1L/DtXNUVAM6q4QLy8NE3qtHlFXTf8VLL4k1Yl6c7NMjtZUTdXV+X44nFaT6A==",
+      "version": "2.4.10",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.10.tgz",
+      "integrity": "sha512-vnwmrFDlOExK4Nm16J2KMWHLrp14lBrjxMxBJpu++EnsuBmpiYaM/MEs46Vxxm/4FvdP5yTwuCTO9it5FSjrqA==",
       "dev": true,
       "requires": {
         "inherits": "2.0.3",
@@ -8362,27 +8367,16 @@
       }
     },
     "simple-peer": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/simple-peer/-/simple-peer-8.2.0.tgz",
-      "integrity": "sha512-m3K7TJC7SjdzVB3KvvrcFkWfQknHYNF9d88aracdea/Jn/lreYQ6kGdD6+Rcjpq8w1Ai7dssd3XIYYWZ+Nt0qg==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/simple-peer/-/simple-peer-8.3.0.tgz",
+      "integrity": "sha512-GSSUXMFzKtAHu/PuNb0UWnwVKHTPGhq8EM78Saf25jG4k/aA3PJOvwlVSS/rchZJSrGxSUiH2qyJD2PgTqi4Qw==",
       "dev": true,
       "requires": {
-        "debug": "2.6.9",
+        "debug": "3.1.0",
         "get-browser-rtc": "1.0.2",
         "inherits": "2.0.3",
         "randombytes": "2.0.6",
         "readable-stream": "2.3.3"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
       }
     },
     "slash": {
@@ -8513,9 +8507,9 @@
       }
     },
     "socket.io-pull-stream": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/socket.io-pull-stream/-/socket.io-pull-stream-0.1.3.tgz",
-      "integrity": "sha512-6vK5knjAmypmg9UmtAONdXivBxgesmpbwkbtBzdupkCxiO1rAkVKm/Z3iF+jJV0oQ+csyYpEcliQUJpRAoCcgA==",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/socket.io-pull-stream/-/socket.io-pull-stream-0.1.4.tgz",
+      "integrity": "sha512-0xRi5HJciSzSqitQ+/sCdgWhrtn0eXCQ+36or0jmLhRmIj0D4rbXRZsJqJGkHUeIroGZym5CMFltDHPB3Di9cA==",
       "dev": true,
       "requires": {
         "data-queue": "0.0.3",
@@ -8987,9 +8981,9 @@
       }
     },
     "thunky": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/thunky/-/thunky-0.1.0.tgz",
-      "integrity": "sha1-vzAUaCTituZ7Dy16Ssi+smkIaE4=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.0.2.tgz",
+      "integrity": "sha1-qGLgGOP7HqLsP85dVWBc9X8kc3E=",
       "dev": true
     },
     "time-cache": {
@@ -9014,9 +9008,9 @@
       "dev": true
     },
     "timers-browserify": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.4.tgz",
-      "integrity": "sha512-uZYhyU3EX8O7HQP+J9fTVYwsq90Vr68xPEFo7yrVImIxYvHgukBEgOB/SgGoorWVTzGM/3Z+wUNnboA4M8jWrg==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.6.tgz",
+      "integrity": "sha512-HQ3nbYRAowdVd0ckGFvmJPPCOH/CHleFN/Y0YQCX1DVaB7t+KFvisuyN09fuP8Jtp1CpfSh8O8bMkHbdbPe6Pw==",
       "dev": true,
       "requires": {
         "setimmediate": "1.0.5"
@@ -9120,9 +9114,9 @@
       "integrity": "sha1-m7i6DoQfs/TPH+fCRenz+opf6Zw="
     },
     "uglify-es": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.3.7.tgz",
-      "integrity": "sha512-fGMnE6SsDRsCjxm78C+lv7MuXsse/dtF7QuTUT43BYf4jlxPjd+XTnGB8YjaCQJ3sv2LT4zk0mwpp9+QJocU6g==",
+      "version": "3.3.9",
+      "resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.3.9.tgz",
+      "integrity": "sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ==",
       "dev": true,
       "requires": {
         "commander": "2.13.0",
@@ -9145,9 +9139,9 @@
       "optional": true
     },
     "uglifyjs-webpack-plugin": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-1.1.6.tgz",
-      "integrity": "sha512-VUja+7rYbznEvUaeb8IxOCTUrq4BCb1ml0vffa+mfwKtrAwlqnU0ENF14DtYltV1cxd/HSuK51CCA/D/8kMQVw==",
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-1.1.8.tgz",
+      "integrity": "sha512-XG8/QmR1pyPeE1kj2aigo5kos8umefB31zW+PMvAAytHSB0T/vQvN6sqt8+Sh+y0b0A7zlmxNi2dzRnj0wcqGA==",
       "dev": true,
       "requires": {
         "cacache": "10.0.2",
@@ -9155,7 +9149,7 @@
         "schema-utils": "0.4.3",
         "serialize-javascript": "1.4.0",
         "source-map": "0.6.1",
-        "uglify-es": "3.3.7",
+        "uglify-es": "3.3.9",
         "webpack-sources": "1.1.0",
         "worker-farm": "1.5.2"
       },
@@ -9879,9 +9873,9 @@
       "dev": true
     },
     "yargs": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-10.1.1.tgz",
-      "integrity": "sha512-7uRL1HZdCbc1QTP+X8mehOPuCYKC/XTaqAPj7gABLfTt6pgLyVRn3QVte4qhtilZouWCvqd1kipgMKl5tKsFiw==",
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-10.1.2.tgz",
+      "integrity": "sha512-ivSoxqBGYOqQVruxD35+EyCFDYNEFL/Uo6FcOnz+9xZdZzK0Zzw4r4KhbrME1Oo2gOggwJod2MnsdamSG7H9ig==",
       "dev": true,
       "requires": {
         "cliui": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "logplease": "^1.2.14",
     "multihashes": "^0.4.12",
-    "orbit-db-cache": "~0.2.1",
+    "orbit-db-cache": "~0.2.2",
     "orbit-db-counterstore": "~1.2.0",
     "orbit-db-docstore": "~1.2.0",
     "orbit-db-eventstore": "~1.2.0",


### PR DESCRIPTION
This PR will update OrbitDB to use the latest local cache module. The updated version of the cache module fixes a bug where databases were don't load the persisted db in the browsers.

Closes #315.