### PR TITLE
emit update event when changing access rights

### DIFF
--- a/src/orbit-db-access-controllers/orbitdb-access-controller.js
+++ b/src/orbit-db-access-controllers/orbitdb-access-controller.js
@@ -124,6 +124,7 @@ class OrbitDBAccessController extends AccessController {
     this._capabilities[capability] = Array.from(capabilities)
     try {
       await this._db.put(capability, Array.from(capabilities))
+      this.emit('updated')
     } catch (e) {
       throw e
     }
@@ -140,6 +141,7 @@ class OrbitDBAccessController extends AccessController {
         delete this._capabilities[capability]
         await this._db.del(capability)
       }
+      this.emit('updated')
     } catch (e) {
       throw e
     }


### PR DESCRIPTION
It looks like the keys list in oplog isnt aware of access updates. We should emit an event when changing access capabilities