### PR TITLE
Wait for database to close in tests

### DIFF
--- a/test/counterdb.test.js
+++ b/test/counterdb.test.js
@@ -51,12 +51,12 @@ describe('CounterStore', function() {
     orbitdb2 = new OrbitDB(ipfs2, './orbitdb/2')
   })
 
-  afterEach(() => {
+  afterEach(async () => {
     if (orbitdb1)
-      orbitdb1.stop()
+      await orbitdb1.stop()
 
     if (orbitdb2)
-      orbitdb2.stop()
+      await orbitdb2.stop()
   })
 
   describe('counters', function() {

--- a/test/create-open.test.js
+++ b/test/create-open.test.js
@@ -31,7 +31,7 @@ describe('orbit-db - Create & Open', function() {
 
   after(async () => {
     if(orbitdb) 
-      orbitdb.stop()
+      await orbitdb.stop()
 
     if (ipfs)
       await ipfs.stop()

--- a/test/create-type.test.js
+++ b/test/create-type.test.js
@@ -36,7 +36,7 @@ describe('orbit-db - Create custom type', function () {
   })
 
   after(async () => {
-    if(orbitdb) orbitdb.stop()
+    if (orbitdb) await orbitdb.stop()
     if (ipfs) await ipfs.stop()
   })
 

--- a/test/drop.test.js
+++ b/test/drop.test.js
@@ -27,7 +27,7 @@ describe('orbit-db - Drop Database', function() {
 
   after(async () => {
     if(orbitdb) 
-      orbitdb.stop()
+      await orbitdb.stop()
 
     if (ipfs)
       await ipfs.stop()
@@ -45,6 +45,6 @@ describe('orbit-db - Drop Database', function() {
     it('removes local database files', async () => {
       await db.drop()
       assert.equal(fs.existsSync(localDataPath), false)
-    })    
+    })
   })
 })


### PR DESCRIPTION
This PR will fix tests where db.stop() is called synchronously. Missing `await` was added where applicable.