### PR TITLE
Use ipfs-pubsub-peer-monitor via latest orbit-db-pubsub

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -86,14 +86,15 @@
       "dev": true
     },
     "ajv": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.3.0.tgz",
-      "integrity": "sha1-FlCkERTvAFdMrBC4Ay2PTBSBLac=",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.4.0.tgz",
+      "integrity": "sha1-06/3jpJ3VJdx2vAWTP9ISCt1T8Y=",
       "dev": true,
       "requires": {
         "fast-deep-equal": "1.1.0",
         "fast-json-stable-stringify": "2.0.0",
-        "json-schema-traverse": "0.3.1"
+        "json-schema-traverse": "0.3.1",
+        "uri-js": "3.0.2"
       }
     },
     "ajv-keywords": {
@@ -1635,6 +1636,12 @@
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
       "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE="
     },
+    "ci-info": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.3.tgz",
+      "integrity": "sha512-SK/846h/Rcy8q9Z9CAwGBLfCJ6EkjJWdpelWDufQpqVDYq2Wnnv8zlSO6AMQap02jvhVruKKpEtQOufo3pFhLg==",
+      "dev": true
+    },
     "cids": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/cids/-/cids-0.5.3.tgz",
@@ -1865,9 +1872,9 @@
       }
     },
     "configstore": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.1.tgz",
-      "integrity": "sha512-5oNkD/L++l0O6xGXxb1EWS7SivtjfGQlRyxJsYgE0Z495/L81e2h4/d3r969hoPXuFItzNOKMtsXgYG4c7dYvw==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.2.tgz",
+      "integrity": "sha512-vtv5HtGjcYUgFrXc6Kx747B83MRRVS5R1VTEQoXvuP+kMI+if6uywV0nDGoiydJRy4yk7h9od5Og0kxx4zUXmw==",
       "dev": true,
       "requires": {
         "dot-prop": "4.2.0",
@@ -2123,7 +2130,7 @@
         "interface-datastore": "0.4.2",
         "left-pad": "1.2.0",
         "pull-many": "1.0.8",
-        "pull-stream": "3.6.2"
+        "pull-stream": "3.6.3"
       }
     },
     "datastore-fs": {
@@ -2138,7 +2145,7 @@
         "graceful-fs": "4.1.11",
         "interface-datastore": "0.4.2",
         "mkdirp": "0.5.1",
-        "pull-stream": "3.6.2",
+        "pull-stream": "3.6.3",
         "write-file-atomic": "2.3.0"
       },
       "dependencies": {
@@ -2166,7 +2173,7 @@
         "level-js": "2.2.4",
         "leveldown": "1.9.0",
         "levelup": "1.3.9",
-        "pull-stream": "3.6.2"
+        "pull-stream": "3.6.3"
       }
     },
     "date-now": {
@@ -5622,7 +5629,7 @@
       "requires": {
         "async": "2.6.0",
         "pull-defer": "0.2.2",
-        "pull-stream": "3.6.2",
+        "pull-stream": "3.6.3",
         "uuid": "3.2.1"
       }
     },
@@ -5744,7 +5751,7 @@
         "pull-paramap": "1.2.2",
         "pull-pushable": "2.2.0",
         "pull-sort": "1.0.1",
-        "pull-stream": "3.6.2",
+        "pull-stream": "3.6.3",
         "pull-stream-to-stream": "1.3.4",
         "pull-zip": "2.0.1",
         "read-pkg-up": "3.0.0",
@@ -5754,7 +5761,7 @@
         "tar-stream": "1.5.5",
         "temp": "0.8.3",
         "through2": "2.0.3",
-        "update-notifier": "2.3.0",
+        "update-notifier": "2.4.0",
         "yargs": "11.0.0",
         "yargs-parser": "9.0.2"
       },
@@ -5865,7 +5872,7 @@
         "pull-defer": "0.2.2",
         "pull-length-prefixed": "1.3.0",
         "pull-pushable": "2.2.0",
-        "pull-stream": "3.6.2",
+        "pull-stream": "3.6.3",
         "safe-buffer": "5.1.1",
         "varint-decoder": "0.1.1"
       },
@@ -5920,16 +5927,12 @@
         "safe-buffer": "5.1.1"
       }
     },
-    "ipfs-pubsub-room": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/ipfs-pubsub-room/-/ipfs-pubsub-room-1.2.0.tgz",
-      "integrity": "sha512-NPAyPF670n4S8Mse7wodVbbzxPwHVgHKV0QqIliO4NM8u88kZhttPi1/jume9MLtqAIgleSrnrYZ6qqaaoRP1A==",
+    "ipfs-pubsub-peer-monitor": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/ipfs-pubsub-peer-monitor/-/ipfs-pubsub-peer-monitor-0.0.2.tgz",
+      "integrity": "sha512-521TZNoUfQhVu1dJy+QTQwp/+icmx4pRGVxcOduXwzlGFKZl2UBh8I0LtVWuzm42+VdPUVaqAjYI1LDCActcYQ==",
       "requires": {
-        "hyperdiff": "2.0.4",
-        "lodash.clonedeep": "4.5.0",
-        "pull-pushable": "2.2.0",
-        "pull-stream": "3.6.2",
-        "safe-buffer": "5.1.1"
+        "hyperdiff": "2.0.4"
       }
     },
     "ipfs-repo": {
@@ -5955,7 +5958,7 @@
         "lodash.has": "4.5.2",
         "lodash.set": "4.3.2",
         "multiaddr": "3.1.0",
-        "pull-stream": "3.6.2"
+        "pull-stream": "3.6.3"
       },
       "dependencies": {
         "abstract-leveldown": {
@@ -5979,7 +5982,7 @@
           "requires": {
             "abstract-leveldown": "2.4.1",
             "idb-readable-stream": "0.0.4",
-            "ltgt": "2.2.0",
+            "ltgt": "2.2.1",
             "xtend": "4.0.1"
           }
         },
@@ -6024,7 +6027,7 @@
         "pull-paramap": "1.2.2",
         "pull-pause": "0.0.2",
         "pull-pushable": "2.2.0",
-        "pull-stream": "3.6.2",
+        "pull-stream": "3.6.3",
         "pull-traverse": "1.0.3",
         "pull-write": "1.1.4",
         "sparse-array": "1.3.1"
@@ -6064,7 +6067,7 @@
         "multihashes": "0.4.13",
         "pull-defer": "0.2.2",
         "pull-sort": "1.0.1",
-        "pull-stream": "3.6.2",
+        "pull-stream": "3.6.3",
         "pull-traverse": "1.0.3"
       }
     },
@@ -6112,7 +6115,7 @@
         "multihashes": "0.4.13",
         "multihashing-async": "0.4.8",
         "protons": "1.0.1",
-        "pull-stream": "3.6.2",
+        "pull-stream": "3.6.3",
         "pull-traverse": "1.0.3",
         "stable": "0.1.6"
       }
@@ -6246,6 +6249,15 @@
       "dev": true,
       "requires": {
         "builtin-modules": "1.1.1"
+      }
+    },
+    "is-ci": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.1.0.tgz",
+      "integrity": "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
+      "dev": true,
+      "requires": {
+        "ci-info": "1.1.3"
       }
     },
     "is-circular": {
@@ -6741,7 +6753,7 @@
         "abstract-leveldown": "0.12.4",
         "idb-wrapper": "1.7.2",
         "isbuffer": "0.0.0",
-        "ltgt": "2.2.0",
+        "ltgt": "2.2.1",
         "typedarray-to-buffer": "1.0.4",
         "xtend": "2.1.2"
       }
@@ -6874,7 +6886,7 @@
         "protons": "1.0.1",
         "pull-abortable": "4.1.1",
         "pull-handshake": "1.1.4",
-        "pull-stream": "3.6.2",
+        "pull-stream": "3.6.3",
         "safe-buffer": "5.1.1",
         "setimmediate": "1.0.5"
       }
@@ -6941,7 +6953,7 @@
         "peer-info": "0.11.6",
         "protons": "1.0.1",
         "pull-length-prefixed": "1.3.0",
-        "pull-stream": "3.6.2"
+        "pull-stream": "3.6.3"
       }
     },
     "libp2p-kad-dht": {
@@ -6966,7 +6978,7 @@
         "priorityqueue": "0.2.1",
         "protons": "1.0.1",
         "pull-length-prefixed": "1.3.0",
-        "pull-stream": "3.6.2",
+        "pull-stream": "3.6.3",
         "safe-buffer": "5.1.1",
         "varint": "5.0.0",
         "xor-distance": "1.0.0"
@@ -6982,7 +6994,7 @@
         "deepmerge": "1.5.2",
         "interface-datastore": "0.4.2",
         "libp2p-crypto": "0.12.1",
-        "pull-stream": "3.6.2",
+        "pull-stream": "3.6.3",
         "sanitize-filename": "1.6.1"
       }
     },
@@ -7008,7 +7020,7 @@
         "async": "2.6.0",
         "multiplex": "github:dignifiedquire/multiplex#b5d5edd30454e2c978ee8c52df86f5f4840d2eab",
         "pull-catch": "1.0.0",
-        "pull-stream": "3.6.2",
+        "pull-stream": "3.6.3",
         "pull-stream-to-stream": "1.3.4",
         "pump": "2.0.1",
         "stream-to-pull-stream": "1.7.2"
@@ -7022,7 +7034,7 @@
       "requires": {
         "libp2p-crypto": "0.12.1",
         "pull-handshake": "1.1.4",
-        "pull-stream": "3.6.2"
+        "pull-stream": "3.6.3"
       }
     },
     "libp2p-railing": {
@@ -7071,7 +7083,7 @@
         "pull-defer": "0.2.2",
         "pull-handshake": "1.1.4",
         "pull-length-prefixed": "1.3.0",
-        "pull-stream": "3.6.2"
+        "pull-stream": "3.6.3"
       }
     },
     "libp2p-switch": {
@@ -7092,7 +7104,7 @@
         "once": "1.4.0",
         "peer-id": "0.10.6",
         "peer-info": "0.11.6",
-        "pull-stream": "3.6.2"
+        "pull-stream": "3.6.3"
       }
     },
     "libp2p-tcp": {
@@ -7131,7 +7143,7 @@
         "once": "1.4.0",
         "peer-id": "0.10.6",
         "peer-info": "0.11.6",
-        "pull-stream": "3.6.2",
+        "pull-stream": "3.6.3",
         "simple-peer": "8.5.0",
         "socket.io": "2.0.4",
         "socket.io-client": "2.0.4",
@@ -7156,7 +7168,7 @@
         "once": "1.4.0",
         "peer-id": "0.10.6",
         "peer-info": "0.11.6",
-        "pull-stream": "3.6.2",
+        "pull-stream": "3.6.3",
         "socket.io-client": "2.0.4",
         "socket.io-pull-stream": "0.1.5",
         "uuid": "3.2.1"
@@ -7435,9 +7447,9 @@
       }
     },
     "ltgt": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.2.0.tgz",
-      "integrity": "sha1-tlul/LNJopkkyOMz98alVi8uSEI="
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.2.1.tgz",
+      "integrity": "sha1-81ypHEk/e3PaDgdJUwTxezH4fuU="
     },
     "mafmt": {
       "version": "4.0.0",
@@ -7513,7 +7525,7 @@
         "functional-red-black-tree": "1.0.1",
         "immediate": "3.2.3",
         "inherits": "2.0.3",
-        "ltgt": "2.2.0",
+        "ltgt": "2.2.1",
         "safe-buffer": "5.1.1"
       },
       "dependencies": {
@@ -7936,7 +7948,7 @@
         "once": "1.4.0",
         "pull-handshake": "1.1.4",
         "pull-length-prefixed": "1.3.0",
-        "pull-stream": "3.6.2",
+        "pull-stream": "3.6.3",
         "semver": "5.5.0",
         "varint": "5.0.0"
       }
@@ -8344,11 +8356,11 @@
       }
     },
     "orbit-db-pubsub": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/orbit-db-pubsub/-/orbit-db-pubsub-0.4.0.tgz",
-      "integrity": "sha512-RXgH2XazxG8H4i80JpqIonITvPxgifw3WvMDEY+f5UljJEhCC5UPbKywMZZuMHd/khh6BjXEQWI5yxBI8ZX+Jw==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/orbit-db-pubsub/-/orbit-db-pubsub-0.5.1.tgz",
+      "integrity": "sha512-JqnEjYwSxVa+QEpKWUp/C4NrKdiUlW/pBJq2hdWHxaiMKgy5/qzkuJwaQQPltuCbaKfejaEiPlHoT/DtOzqZ5Q==",
       "requires": {
-        "ipfs-pubsub-room": "1.2.0",
+        "ipfs-pubsub-peer-monitor": "0.0.2",
         "logplease": "1.2.14"
       }
     },
@@ -8967,7 +8979,7 @@
       "integrity": "sha1-Pa3ZttFWxUVyG9qNAAPdjqoGKT4=",
       "dev": true,
       "requires": {
-        "pull-stream": "3.6.2"
+        "pull-stream": "3.6.3"
       }
     },
     "pull-ndjson": {
@@ -8977,7 +8989,7 @@
       "dev": true,
       "requires": {
         "pull-split": "0.2.0",
-        "pull-stream": "3.6.2",
+        "pull-stream": "3.6.3",
         "pull-stringify": "1.2.2"
       }
     },
@@ -9013,7 +9025,8 @@
     "pull-pushable": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/pull-pushable/-/pull-pushable-2.2.0.tgz",
-      "integrity": "sha1-Xy867UethpGfAbEqLpnW8b13ZYE="
+      "integrity": "sha1-Xy867UethpGfAbEqLpnW8b13ZYE=",
+      "dev": true
     },
     "pull-reader": {
       "version": "1.2.9",
@@ -9028,7 +9041,7 @@
       "dev": true,
       "requires": {
         "pull-defer": "0.2.2",
-        "pull-stream": "3.6.2"
+        "pull-stream": "3.6.3"
       }
     },
     "pull-split": {
@@ -9041,9 +9054,10 @@
       }
     },
     "pull-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-3.6.2.tgz",
-      "integrity": "sha1-HqFMbxMXTmrE3vDCpOdlZ7fLDFw="
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-3.6.3.tgz",
+      "integrity": "sha1-gBCGTB2dmehTnVpIfKdYMTHEmbg=",
+      "dev": true
     },
     "pull-stream-to-stream": {
       "version": "1.3.4",
@@ -9086,7 +9100,7 @@
       "requires": {
         "looper": "4.0.0",
         "pull-cat": "1.1.11",
-        "pull-stream": "3.6.2"
+        "pull-stream": "3.6.3"
       },
       "dependencies": {
         "looper": {
@@ -9504,7 +9518,7 @@
       "integrity": "sha512-yYrjb9TX2k/J1Y5UNy3KYdZq10xhYcF8nMpAW6o3hy6Q8WSIEf9lJHG/ePnOBfziPM3fvQwfOwa13U/Fh8qTfA==",
       "dev": true,
       "requires": {
-        "ajv": "6.3.0",
+        "ajv": "6.4.0",
         "ajv-keywords": "3.1.0"
       }
     },
@@ -9936,7 +9950,7 @@
       "requires": {
         "data-queue": "0.0.3",
         "debug": "3.1.0",
-        "pull-stream": "3.6.2",
+        "pull-stream": "3.6.3",
         "uuid": "3.2.1"
       }
     },
@@ -10241,7 +10255,7 @@
       "dev": true,
       "requires": {
         "looper": "3.0.0",
-        "pull-stream": "3.6.2"
+        "pull-stream": "3.6.3"
       }
     },
     "streamifier": {
@@ -10786,15 +10800,16 @@
       "dev": true
     },
     "update-notifier": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.3.0.tgz",
-      "integrity": "sha1-TognpruRUUCrCTVZ1wFOPruDdFE=",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.4.0.tgz",
+      "integrity": "sha1-+bTHAPv9TsEsgRWHJYd31WPYyGY=",
       "dev": true,
       "requires": {
         "boxen": "1.3.0",
         "chalk": "2.3.2",
-        "configstore": "3.1.1",
+        "configstore": "3.1.2",
         "import-lazy": "2.1.0",
+        "is-ci": "1.1.0",
         "is-installed-globally": "0.1.0",
         "is-npm": "1.0.0",
         "latest-version": "3.1.0",
@@ -10831,6 +10846,15 @@
             "has-flag": "3.0.0"
           }
         }
+      }
+    },
+    "uri-js": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-3.0.2.tgz",
+      "integrity": "sha1-+QuFhQf4HepNz7s8TD2/orVX+qo=",
+      "dev": true,
+      "requires": {
+        "punycode": "2.1.0"
       }
     },
     "urix": {
@@ -11006,7 +11030,7 @@
       "requires": {
         "acorn": "5.5.3",
         "acorn-dynamic-import": "2.0.2",
-        "ajv": "6.3.0",
+        "ajv": "6.4.0",
         "ajv-keywords": "3.1.0",
         "async": "2.6.0",
         "enhanced-resolve": "3.4.1",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "orbit-db-feedstore": "~1.3.0",
     "orbit-db-keystore": "~0.1.0",
     "orbit-db-kvstore": "~1.3.0",
-    "orbit-db-pubsub": "~0.4.0"
+    "orbit-db-pubsub": "~0.5.1"
   },
   "devDependencies": {
     "babel-core": "^6.26.0",


### PR DESCRIPTION
This PR will update orbit-db-pubsub to the latest version which uses ipfs-pubsub-peer-monitor instead of ipfs-pubsub-room for exchanging heads upon connecting to peers.