### PR TITLE
Add Linux-specific installation details in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,11 +127,24 @@ npm install --global babel-cli
 npm install --global webpack
 ```
 
+Some dependencies depend on native addon modules, so you'll also need to meet [node-gyp's](https://github.com/nodejs/node-gyp#installation) installation prerequisites. Therefore, Linux users may need to 
+```
+make clean && make
+```
+to redo the local package-lock.json with working native dependencies. 
+
 ### Browser example
 
+In macOS:
 ```
 npm run build
-npm run examples:browser
+npm run examples:browser-macos
+```
+
+In Linux:
+```
+npm run build
+npm run examples:browser-linux
 ```
 
 <p align="left">

--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
   "scripts": {
     "examples": "npm run examples:node",
     "examples:node": "node examples/eventlog.js",
-    "examples:browser": "open examples/browser/browser.html",
+    "examples:browser-macos": "open examples/browser/browser.html",
+    "examples:browser-linux": "xdg-open examples/browser/browser.html",
     "test": "TEST=all mocha",
     "build": "npm run build:es5 && npm run build:debug && npm run build:dist && npm run build:examples",
     "build:examples": "webpack --config conf/webpack.example.config.js --sort-modules-by size && mkdir -p examples/browser/lib && cp node_modules/ipfs/dist/index.js examples/browser/lib/ipfs.js",


### PR DESCRIPTION
Instructions for running examples only applied to MacOS. Rather than introducing
a new NPM dependency for running platform-specific commands, I thought it's
simpler to just have own scripts for each platform.