### PR TITLE
Use latest document store

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8353,9 +8353,9 @@
       }
     },
     "orbit-db-docstore": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/orbit-db-docstore/-/orbit-db-docstore-1.4.0.tgz",
-      "integrity": "sha512-AHS/hYiM7r3Ki/Tl5NcjCEFTo1lL7Mlph0c/ulzIlvf6Ix8BGxIJOHUUqAI7m8IZUGCQNi3J69HUnK0AuqHOQw==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/orbit-db-docstore/-/orbit-db-docstore-1.4.1.tgz",
+      "integrity": "sha512-GHUPOdYcjPUKI8Ihfh7HNt1Rv4BdO8/40+j9p8oB2yuw19g3slyA8QFgAXeebbrXQ7bdjeTgUSPzIyG24dYBCA==",
       "requires": {
         "orbit-db-store": "~2.5.0",
         "p-map": "~1.1.1"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "multihashes": "^0.4.12",
     "orbit-db-cache": "~0.2.2",
     "orbit-db-counterstore": "~1.4.0",
-    "orbit-db-docstore": "~1.4.0",
+    "orbit-db-docstore": "~1.4.1",
     "orbit-db-eventstore": "~1.4.0",
     "orbit-db-feedstore": "~1.4.0",
     "orbit-db-keystore": "~0.1.0",

--- a/test/docstore.test.js
+++ b/test/docstore.test.js
@@ -135,6 +135,37 @@ Object.keys(testAPIs).forEach(API => {
         assert.deepEqual(value1, [doc2, doc3])
         assert.deepEqual(value2, [doc2])
       })
+
+      it('query returns full op', async () => {
+        const doc1 = { _id: 'hello world', doc: 'all the things', views: 17}
+        const doc2 = { _id: 'sup world', doc: 'some of the things', views: 10}
+
+        const expectedOperation = {
+          op: 'PUT', 
+          key: 'sup world', 
+          value: { 
+            _id: 'sup world', 
+            doc: 'some of the things', 
+            views: 10
+          },
+        }
+
+        await db.put(doc1)
+        await db.put(doc2)
+
+        const res = db.query(e => e.payload.value.views < 17, { fullOp: true })[0]
+        assert.notEqual(res, undefined)
+        assert.notEqual(res.hash, undefined)
+        assert.notEqual(res.id, undefined)
+        assert.deepEqual(res.payload, expectedOperation)
+        assert.notEqual(res.next, undefined)
+        assert.equal(res.next.length, 1)
+        assert.equal(res.v, 0)
+        assert.notEqual(res.clock, undefined)
+        assert.equal(res.clock.time, 2)
+        assert.notEqual(res.key, undefined)
+        assert.notEqual(res.sig, undefined)
+      })
     })
 
     describe('Specified index', function() {


### PR DESCRIPTION
This PR will pull in the latest document store which adds the feature to get the full operation data with `query()`.

- Updates package.json and the lockfile
- Adds a test to test that the document store returns the full op data