### PR TITLE
feat: update ipfs deps + make pubsub.unsubscribe async

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,11 @@
         "lodash": "^4.15.0"
       }
     },
+    "@sindresorhus/is": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz",
+      "integrity": "sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow=="
+    },
     "File": {
       "version": "0.10.2",
       "resolved": "https://registry.npmjs.org/File/-/File-0.10.2.tgz",
@@ -314,6 +319,7 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
       "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+      "dev": true,
       "requires": {
         "lodash": "^4.17.10"
       }
@@ -8155,7 +8161,8 @@
     "lodash": {
       "version": "4.17.10",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
+      "dev": true
     },
     "lodash.clone": {
       "version": "4.5.0",
@@ -9349,12 +9356,12 @@
       }
     },
     "orbit-db-pubsub": {
-      "version": "github:mistakia/orbit-db-pubsub#3d767dbb4631a3981a677c13f31a021a9465d4a4",
+      "version": "github:mistakia/orbit-db-pubsub#e40e30e7a71e980dbd35fc040316762d1c6283ca",
       "from": "github:mistakia/orbit-db-pubsub#fix/unsubscribe",
       "requires": {
-        "async": "^2.6.1",
         "ipfs-pubsub-peer-monitor": "~0.0.5",
-        "logplease": "~1.2.14"
+        "logplease": "~1.2.14",
+        "p-series": "^1.1.0"
       }
     },
     "orbit-db-store": {
@@ -9463,6 +9470,15 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-1.0.0.tgz",
       "integrity": "sha1-GMKw3ZNqRpClKfgjH1ig/bakffo="
+    },
+    "p-series": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/p-series/-/p-series-1.1.0.tgz",
+      "integrity": "sha512-356covArc9UCfj2twY/sxCJKGMzzO+pJJtucizsPC6aS1xKSTBc9PQrQhvFR3+7F+fa2KBKdJjdIcv6NEWDcIQ==",
+      "requires": {
+        "@sindresorhus/is": "^0.7.0",
+        "p-reduce": "^1.0.0"
+      }
     },
     "p-try": {
       "version": "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,30 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@nodeutils/defaults-deep": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@nodeutils/defaults-deep/-/defaults-deep-1.1.0.tgz",
+      "integrity": "sha1-uxEk3I184LxdodZorOWBSSWO8gs=",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.15.0"
+      }
+    },
+    "File": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/File/-/File-0.10.2.tgz",
+      "integrity": "sha1-6Jn3dtJz4iQ7qGEFuzsFbQ+5VgQ=",
+      "dev": true,
+      "requires": {
+        "mime": ">= 0.0.0"
+      }
+    },
+    "FileList": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/FileList/-/FileList-0.10.2.tgz",
+      "integrity": "sha1-YAOxqXFZNBZLZ8Q0rWqHQaHNFHo=",
+      "dev": true
+    },
     "abstract-leveldown": {
       "version": "0.12.4",
       "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-0.12.4.tgz",
@@ -290,7 +314,6 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
       "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
-      "dev": true,
       "requires": {
         "lodash": "^4.17.10"
       }
@@ -1420,12 +1443,6 @@
       "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
       "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg=="
     },
-    "buffer-equals": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/buffer-equals/-/buffer-equals-1.0.4.tgz",
-      "integrity": "sha1-A1O1T9B/2VZBcGca5vZrnPENJ/U=",
-      "dev": true
-    },
     "buffer-fill": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
@@ -1462,6 +1479,12 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
       "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=",
+      "dev": true
+    },
+    "bufferjs": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/bufferjs/-/bufferjs-3.0.1.tgz",
+      "integrity": "sha1-BpLoKcsQoQVQ5kc5CwNesGw46O8=",
       "dev": true
     },
     "buffers": {
@@ -1700,6 +1723,12 @@
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
       "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE="
     },
+    "chunky": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/chunky/-/chunky-0.0.0.tgz",
+      "integrity": "sha1-HnWAojwIOJfSrWYkWefv2EZfYIo=",
+      "dev": true
+    },
     "ci-info": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.3.tgz",
@@ -1726,6 +1755,12 @@
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
       }
+    },
+    "class-is": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/class-is/-/class-is-1.1.0.tgz",
+      "integrity": "sha512-rhjH9AG1fvabIDoGRVH587413LPjTZgmDF9fOFCbFJQV4yuocX1mHxxvXI4g3cGwbVY9wAYIoKlg1N79frJKQw==",
+      "dev": true
     },
     "class-utils": {
       "version": "0.3.6",
@@ -2189,18 +2224,18 @@
       }
     },
     "datastore-fs": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/datastore-fs/-/datastore-fs-0.4.2.tgz",
-      "integrity": "sha512-mJ511KiZP1zrkEnCvMqvrurW6YSf3QT4P3bdGVftPl+DeaGxC/gdwj8DE9cWsmyD6E1a50jU2Q8IqhaZGNEBbg==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/datastore-fs/-/datastore-fs-0.5.0.tgz",
+      "integrity": "sha512-l2WF+/TFzzCY3L0b4GYYa196X25PqR2jZnLvqXtz2WODkTXZTcZJ+s4+KAnUAc6TMxWejN8NkEnkcPL05lKSSA==",
       "dev": true,
       "requires": {
-        "async": "^2.6.0",
+        "async": "^2.6.1",
         "datastore-core": "~0.4.0",
         "glob": "^7.1.2",
         "graceful-fs": "^4.1.11",
         "interface-datastore": "^0.4.2",
-        "mkdirp": "^0.5.1",
-        "pull-stream": "^3.6.1",
+        "mkdirp": "~0.5.1",
+        "pull-stream": "^3.6.8",
         "write-file-atomic": "^2.3.0"
       },
       "dependencies": {
@@ -2397,6 +2432,12 @@
       "integrity": "sha1-ogM8CcyOFY03dI+951B4Mr1s4Sc=",
       "dev": true
     },
+    "dexie": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/dexie/-/dexie-1.5.1.tgz",
+      "integrity": "sha1-rDrVoOuvfm5Cdg21hxBBjUp1ZiQ=",
+      "dev": true
+    },
     "dicer": {
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/dicer/-/dicer-0.2.5.tgz",
@@ -2457,13 +2498,13 @@
       "dev": true
     },
     "dns-packet": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.3.1.tgz",
-      "integrity": "sha512-0UxfQkMhYAUaZI+xrNZOz/as5KgDU0M/fQ9b6SpkyLbk3GEswDi6PADJVaYJradtRVsRIlF1zLyOodbcTCDzUg==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-4.2.0.tgz",
+      "integrity": "sha512-bn1AKpfkFbm0MIioOMHZ5qJzl2uypdBwI4nYNsqvhjsegBhcKJUlCrMPWLx6JEezRjxZmxhtIz/FkBEur2l8Cw==",
       "dev": true,
       "requires": {
-        "ip": "^1.1.0",
-        "safe-buffer": "^5.0.1"
+        "ip": "^1.1.5",
+        "safe-buffer": "^5.1.1"
       }
     },
     "domain-browser": {
@@ -2556,6 +2597,51 @@
       "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
       "dev": true
     },
+    "encoding-down": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/encoding-down/-/encoding-down-5.0.3.tgz",
+      "integrity": "sha512-grBSxdQBY6xNkMJoqXWUUsqneXyxcBk966OWbSF6FHjLRv1FiExseSM0poga7aZDC0TziUMCzQDo8NnLJ5Rvlw==",
+      "dev": true,
+      "requires": {
+        "abstract-leveldown": "^5.0.0",
+        "inherits": "^2.0.3",
+        "level-codec": "^9.0.0",
+        "level-errors": "^2.0.0",
+        "xtend": "^4.0.1"
+      },
+      "dependencies": {
+        "abstract-leveldown": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-5.0.0.tgz",
+          "integrity": "sha512-5mU5P1gXtsMIXg65/rsYGsi93+MlogXZ9FA8JnwKurHQg64bfXwGYVdVdijNTVNOlAsuIiOwHdvFFD5JqCJQ7A==",
+          "dev": true,
+          "requires": {
+            "xtend": "~4.0.0"
+          }
+        },
+        "level-codec": {
+          "version": "9.0.0",
+          "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-9.0.0.tgz",
+          "integrity": "sha512-OIpVvjCcZNP5SdhcNupnsI1zo5Y9Vpm+k/F1gfG5kXrtctlrwanisakweJtE0uA0OpLukRfOQae+Fg0M5Debhg==",
+          "dev": true
+        },
+        "level-errors": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-2.0.0.tgz",
+          "integrity": "sha512-AmY4HCp9h3OiU19uG+3YWkdELgy05OTP/r23aNHaQKWv8DO787yZgsEuGVkoph40uwN+YdUKnANlrxSsoOaaxg==",
+          "dev": true,
+          "requires": {
+            "errno": "~0.1.1"
+          }
+        },
+        "xtend": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+          "dev": true
+        }
+      }
+    },
     "end-of-stream": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
@@ -2586,6 +2672,23 @@
           "requires": {
             "ms": "2.0.0"
           }
+        },
+        "ultron": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
+          "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og==",
+          "dev": true
+        },
+        "ws": {
+          "version": "3.3.3",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
+          "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
+          "dev": true,
+          "requires": {
+            "async-limiter": "~1.0.0",
+            "safe-buffer": "~5.1.0",
+            "ultron": "~1.1.0"
+          }
         }
       }
     },
@@ -2615,6 +2718,23 @@
           "dev": true,
           "requires": {
             "ms": "2.0.0"
+          }
+        },
+        "ultron": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
+          "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og==",
+          "dev": true
+        },
+        "ws": {
+          "version": "3.3.3",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
+          "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
+          "dev": true,
+          "requires": {
+            "async-limiter": "~1.0.0",
+            "safe-buffer": "~5.1.0",
+            "ultron": "~1.1.0"
           }
         }
       }
@@ -2651,6 +2771,17 @@
       "dev": true,
       "requires": {
         "prom-client": "^10.0.0"
+      },
+      "dependencies": {
+        "prom-client": {
+          "version": "10.2.3",
+          "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-10.2.3.tgz",
+          "integrity": "sha512-Xboq5+TdUwuQtSSDRZRNnb5NprINlgQN999VqUjZxnLKydUNLeIPx6Eiahg6oJua3XBg2TGnh5Cth1s4I6+r7g==",
+          "dev": true,
+          "requires": {
+            "tdigest": "^0.1.1"
+          }
+        }
       }
     },
     "errno": {
@@ -2672,9 +2803,9 @@
       }
     },
     "es5-ext": {
-      "version": "0.10.45",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.45.tgz",
-      "integrity": "sha512-FkfM6Vxxfmztilbxxz5UKSD4ICMf5tSpRFtDNtkAhOxZ0EKtX6qwmXNyH/sFyIbX2P/nU5AMiA9jilWsUGJzCQ==",
+      "version": "0.10.44",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.44.tgz",
+      "integrity": "sha512-TO4Vt9IhW3FzDKLDOpoA8VS9BCV4b9WTf6BqvMOgfoa8wX73F3Kh3y2J7yTstTaXlQ0k1vq4DH2vw6RSs42z+g==",
       "dev": true,
       "requires": {
         "es6-iterator": "~2.0.3",
@@ -2822,9 +2953,9 @@
       }
     },
     "ethereumjs-tx": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-1.3.5.tgz",
-      "integrity": "sha512-cPr0BxitCaffq0qQwZRHJgiNCM/3IIJqkYbweeUCyPwV77S+GlQHou2L3afKEFtfiAjfaa82T9LnSmY/pM8iYQ==",
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-1.3.6.tgz",
+      "integrity": "sha512-wzsEs0mCSLqdDjqSDg6AWh1hyL8H3R/pyZxehkcCXq5MJEFXWz+eJ2jSv+3yEaLy6tXrNP7dmqS3Kyb3zAONkg==",
       "dev": true,
       "requires": {
         "ethereum-common": "^0.0.18",
@@ -3066,11 +3197,60 @@
       "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
       "dev": true
     },
-    "file-type": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-7.7.1.tgz",
-      "integrity": "sha512-bTrKkzzZI6wH+NXhyD3SOXtb2zXTw2SbwI2RxUlRcXVsnN7jNL5hJzVQLYv7FOQhxFkK4XWdAflEaWFpaLLWpQ==",
+    "file-api": {
+      "version": "0.10.4",
+      "resolved": "https://registry.npmjs.org/file-api/-/file-api-0.10.4.tgz",
+      "integrity": "sha1-LxASJttyfMAXKg3WiPL2iD1SiD0=",
+      "dev": true,
+      "requires": {
+        "File": ">= 0.10.0",
+        "FileList": ">= 0.10.0",
+        "bufferjs": "> 0.2.0",
+        "file-error": ">= 0.10.0",
+        "filereader": ">= 0.10.3",
+        "formdata": ">= 0.10.0",
+        "mime": ">= 1.2.11",
+        "remedial": ">= 1.0.7"
+      }
+    },
+    "file-error": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/file-error/-/file-error-0.10.2.tgz",
+      "integrity": "sha1-ljtIuSc7PUuEtADuVxvHixc5cko=",
       "dev": true
+    },
+    "file-type": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-8.1.0.tgz",
+      "integrity": "sha512-qyQ0pzAy78gVoJsmYeNgl8uH8yKhr1lVhW7JbzJmnlRi0I4R2eEDEJZVKG8agpDnLpacwNbDhLNG/LMdxHD2YQ==",
+      "dev": true
+    },
+    "filereader": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/filereader/-/filereader-0.10.3.tgz",
+      "integrity": "sha1-x0fUos2PYeVBinwH/hJXpD8KzbE=",
+      "dev": true
+    },
+    "filereader-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/filereader-stream/-/filereader-stream-2.0.0.tgz",
+      "integrity": "sha1-sw1aW/bRTGONfrVeGTq7mG+ASKE=",
+      "dev": true,
+      "requires": {
+        "from2": "^2.1.0",
+        "typedarray-to-buffer": "^3.0.4"
+      },
+      "dependencies": {
+        "typedarray-to-buffer": {
+          "version": "3.1.5",
+          "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+          "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+          "dev": true,
+          "requires": {
+            "is-typedarray": "^1.0.0"
+          }
+        }
+      }
     },
     "filesize": {
       "version": "3.6.1",
@@ -3179,10 +3359,22 @@
         "readable-stream": "^2.0.4"
       }
     },
+    "fnv1a": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fnv1a/-/fnv1a-1.0.1.tgz",
+      "integrity": "sha1-kV4tbQI8Q9UiStn20qPEFW9XEvU=",
+      "dev": true
+    },
     "for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
       "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+      "dev": true
+    },
+    "foreachasync": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/foreachasync/-/foreachasync-3.0.0.tgz",
+      "integrity": "sha1-VQKYfchxS+M5IJfzLgBxyd7gfPY=",
       "dev": true
     },
     "forever-agent": {
@@ -3200,6 +3392,28 @@
         "asynckit": "^0.4.0",
         "combined-stream": "1.0.6",
         "mime-types": "^2.1.12"
+      }
+    },
+    "formdata": {
+      "version": "0.10.4",
+      "resolved": "https://registry.npmjs.org/formdata/-/formdata-0.10.4.tgz",
+      "integrity": "sha1-liH9wMw2H0oBEd5dJbNfanjcVaA=",
+      "dev": true,
+      "requires": {
+        "File": "^0.10.2",
+        "FileList": "^0.10.2",
+        "bufferjs": "^2.0.0",
+        "filereader": "^0.10.3",
+        "foreachasync": "^3.0.0",
+        "remedial": "^1.0.7"
+      },
+      "dependencies": {
+        "bufferjs": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/bufferjs/-/bufferjs-2.0.0.tgz",
+          "integrity": "sha1-aF5x7VwGAOPXA/+b0BK7MnCjnig=",
+          "dev": true
+        }
       }
     },
     "formidable": {
@@ -4425,21 +4639,13 @@
       "dev": true
     },
     "get-folder-size": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/get-folder-size/-/get-folder-size-1.0.1.tgz",
-      "integrity": "sha1-gC+kIIQ03nEgUYKxWrfxNSCI5YA=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-folder-size/-/get-folder-size-2.0.0.tgz",
+      "integrity": "sha512-5h4efQY/sHvf9ZuwOan1HgNaRyApKnJjZ1ZdTOPkpTjIHZNqeMTabBU/LLN6lU9jncBwxJKFcG9cuqiGhu47uQ==",
       "dev": true,
       "requires": {
-        "async": "^1.4.2",
-        "gar": "^1.0.2"
-      },
-      "dependencies": {
-        "async": {
-          "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-          "dev": true
-        }
+        "gar": "^1.0.2",
+        "tiny-each-async": "2.0.3"
       }
     },
     "get-stream": {
@@ -4892,7 +5098,6 @@
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/idb-readable-stream/-/idb-readable-stream-0.0.4.tgz",
       "integrity": "sha1-MoPaZkW/ayINxhumHfYr7l2uSs8=",
-      "dev": true,
       "requires": {
         "xtend": "^4.0.1"
       },
@@ -4900,8 +5105,7 @@
         "xtend": {
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
-          "dev": true
+          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
         }
       }
     },
@@ -5087,94 +5291,100 @@
       }
     },
     "ipfs": {
-      "version": "0.28.2",
-      "resolved": "https://registry.npmjs.org/ipfs/-/ipfs-0.28.2.tgz",
-      "integrity": "sha512-ryNxKhNQvU33M3tvRwk/pVG63ZLiS1R5a2zbrqAS75DSrO3N/sRd/iCr8THr4EPIdnYfGEEWluqig6n6rBzl4A==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/ipfs/-/ipfs-0.30.0.tgz",
+      "integrity": "sha512-31Rz0m+tSyn5QX5NOU6Aw41tX7MA10ao8YdnOiJ9MkzpT5EfZ0Vulc7FAc9dyVXOZK22qAkblp1zAIyaOnVmYw==",
       "dev": true,
       "requires": {
-        "async": "^2.6.0",
-        "big.js": "^5.0.3",
+        "@nodeutils/defaults-deep": "^1.1.0",
+        "async": "^2.6.1",
+        "big.js": "^5.1.2",
         "binary-querystring": "~0.1.2",
-        "bl": "^1.2.1",
-        "boom": "^7.1.1",
+        "bl": "^2.0.1",
+        "boom": "^7.2.0",
         "bs58": "^4.0.1",
         "byteman": "^1.3.5",
-        "cids": "~0.5.2",
+        "cids": "~0.5.3",
         "debug": "^3.1.0",
-        "file-type": "^7.6.0",
-        "filesize": "^3.6.0",
+        "file-type": "^8.0.0",
+        "filesize": "^3.6.1",
+        "fnv1a": "^1.0.1",
         "fsm-event": "^2.1.0",
-        "get-folder-size": "^1.0.1",
+        "get-folder-size": "^2.0.0",
         "glob": "^7.1.2",
         "hapi": "^16.6.2",
         "hapi-set-header": "^1.0.2",
         "hoek": "^5.0.3",
         "human-to-milliseconds": "^1.0.0",
-        "ipfs-api": "^18.1.2",
-        "ipfs-bitswap": "~0.19.0",
-        "ipfs-block": "~0.6.1",
-        "ipfs-block-service": "~0.13.0",
+        "interface-datastore": "~0.4.2",
+        "ipfs-api": "^22.2.1",
+        "ipfs-bitswap": "~0.20.2",
+        "ipfs-block": "~0.7.1",
+        "ipfs-block-service": "~0.14.0",
+        "ipfs-http-response": "~0.1.2",
+        "ipfs-mfs": "~0.0.14",
         "ipfs-multipart": "~0.1.0",
-        "ipfs-repo": "~0.18.7",
-        "ipfs-unixfs": "~0.1.14",
-        "ipfs-unixfs-engine": "~0.24.4",
-        "ipld": "^0.15.0",
-        "is-ipfs": "^0.3.2",
+        "ipfs-repo": "~0.22.1",
+        "ipfs-unixfs": "~0.1.15",
+        "ipfs-unixfs-engine": "~0.30.0",
+        "ipld": "~0.17.2",
+        "ipld-dag-cbor": "~0.12.1",
+        "ipld-dag-pb": "~0.14.5",
+        "is-ipfs": "~0.3.2",
+        "is-pull-stream": "~0.0.0",
         "is-stream": "^1.1.0",
-        "joi": "^13.1.2",
-        "joi-browser": "^13.0.1",
-        "joi-multiaddr": "^1.0.1",
-        "libp2p": "~0.18.0",
-        "libp2p-circuit": "~0.1.4",
-        "libp2p-floodsub": "~0.14.1",
-        "libp2p-kad-dht": "~0.8.0",
+        "joi": "^13.4.0",
+        "joi-browser": "^13.4.0",
+        "joi-multiaddr": "^2.0.0",
+        "libp2p": "~0.22.0",
+        "libp2p-bootstrap": "~0.9.3",
+        "libp2p-circuit": "~0.2.0",
+        "libp2p-floodsub": "~0.15.0",
+        "libp2p-kad-dht": "~0.10.0",
         "libp2p-keychain": "~0.3.1",
-        "libp2p-mdns": "~0.9.2",
-        "libp2p-multiplex": "~0.5.1",
-        "libp2p-railing": "~0.7.1",
-        "libp2p-secio": "~0.9.3",
-        "libp2p-tcp": "~0.11.6",
-        "libp2p-webrtc-star": "~0.13.4",
-        "libp2p-websocket-star": "~0.7.7",
-        "libp2p-websockets": "~0.10.5",
-        "lodash.flatmap": "^4.5.0",
-        "lodash.get": "^4.4.2",
-        "lodash.sortby": "^4.7.0",
-        "lodash.values": "^4.3.0",
-        "mafmt": "^4.0.0",
+        "libp2p-mdns": "~0.12.0",
+        "libp2p-mplex": "~0.8.0",
+        "libp2p-secio": "~0.10.0",
+        "libp2p-tcp": "~0.12.0",
+        "libp2p-webrtc-star": "~0.15.3",
+        "libp2p-websocket-star": "~0.8.1",
+        "libp2p-websockets": "~0.12.0",
+        "lodash": "^4.17.10",
+        "mafmt": "^6.0.0",
         "mime-types": "^2.1.18",
         "mkdirp": "~0.5.1",
-        "multiaddr": "^3.0.2",
+        "multiaddr": "^5.0.0",
+        "multibase": "~0.4.0",
         "multihashes": "~0.4.13",
         "once": "^1.4.0",
         "path-exists": "^3.0.0",
-        "peer-book": "~0.5.4",
-        "peer-id": "~0.10.6",
-        "peer-info": "~0.11.6",
+        "peer-book": "~0.8.0",
+        "peer-id": "~0.11.0",
+        "peer-info": "~0.14.1",
         "progress": "^2.0.0",
-        "prom-client": "^10.2.2",
-        "prometheus-gc-stats": "^0.5.0",
+        "prom-client": "^11.1.1",
+        "prometheus-gc-stats": "~0.5.1",
         "promisify-es6": "^1.0.3",
         "pull-abortable": "^4.1.1",
-        "pull-defer": "^0.2.2",
+        "pull-defer": "~0.2.2",
         "pull-file": "^1.1.0",
-        "pull-ndjson": "^0.1.1",
+        "pull-ndjson": "~0.1.1",
         "pull-paramap": "^1.2.2",
         "pull-pushable": "^2.2.0",
         "pull-sort": "^1.0.1",
-        "pull-stream": "^3.6.2",
+        "pull-stream": "^3.6.8",
         "pull-stream-to-stream": "^1.3.4",
         "pull-zip": "^2.0.1",
-        "read-pkg-up": "^3.0.0",
-        "readable-stream": "2.3.4",
-        "safe-buffer": "^5.1.1",
+        "read-pkg-up": "^4.0.0",
+        "readable-stream": "2.3.6",
         "stream-to-pull-stream": "^1.7.2",
-        "tar-stream": "^1.5.5",
+        "tar-stream": "^1.6.1",
         "temp": "~0.8.3",
         "through2": "^2.0.3",
-        "update-notifier": "^2.3.0",
-        "yargs": "^11.0.0",
-        "yargs-parser": "^9.0.2"
+        "update-notifier": "^2.5.0",
+        "yargs": "^12.0.1",
+        "yargs-parser": "^10.1.0",
+        "yargs-promise": "^1.1.0"
       },
       "dependencies": {
         "big.js": {
@@ -5182,6 +5392,16 @@
           "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.1.2.tgz",
           "integrity": "sha512-qG6ZOc1lY84Bn8p/z9xvJisj9F4PRyo0pOGqGNYc7gS3p1WciS/3XcLuNI3Z/yYZpMNFhHeX3YNENwgrQq0NTA==",
           "dev": true
+        },
+        "bl": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-2.0.1.tgz",
+          "integrity": "sha512-FrMgLukB9jujvJ92p5TA0hcKIHtInVXXhxD7qgAuV7k0cbPt9USZmOYnhDXH6IsnGeIUglX42TSBV7Gn4q5sbQ==",
+          "dev": true,
+          "requires": {
+            "readable-stream": "^2.3.5",
+            "safe-buffer": "^5.1.1"
+          }
         },
         "debug": {
           "version": "3.1.0",
@@ -5191,69 +5411,50 @@
           "requires": {
             "ms": "2.0.0"
           }
-        },
-        "readable-stream": {
-          "version": "2.3.4",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.4.tgz",
-          "integrity": "sha512-vuYxeWYM+fde14+rajzqgeohAI7YoJcHE7kXDAc4Nk0EbuKnJfqtY9YtRkLo/tqkuF7MsBQRhPnPeyjYITp3ZQ==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.0.3",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
         }
       }
     },
     "ipfs-api": {
-      "version": "18.2.1",
-      "resolved": "https://registry.npmjs.org/ipfs-api/-/ipfs-api-18.2.1.tgz",
-      "integrity": "sha512-ffT6tO4KkACztnA3wm2R1hanQLjyeYgTaaXLtoetMvdKTuI6JeOuwg7lv7HfLpIBRKfeYU98e2wzH7Vv7bhERw==",
+      "version": "22.2.3",
+      "resolved": "https://registry.npmjs.org/ipfs-api/-/ipfs-api-22.2.3.tgz",
+      "integrity": "sha512-RXoVh1t9qI+F0RkJlX0HNRps2z7UTKLTp07NSBLHvlDgFi5Kvo7Ieu8la1NTAj0WpuFbJExvYngBGSZuPTz6zw==",
       "dev": true,
       "requires": {
-        "async": "^2.6.0",
-        "big.js": "^5.0.3",
+        "async": "^2.6.1",
+        "big.js": "^5.1.2",
         "bs58": "^4.0.1",
         "cids": "~0.5.3",
         "concat-stream": "^1.6.2",
         "detect-node": "^2.0.3",
         "flatmap": "0.0.3",
         "glob": "^7.1.2",
-        "ipfs-block": "~0.6.1",
-        "ipfs-unixfs": "~0.1.14",
-        "ipld-dag-pb": "~0.13.1",
-        "is-ipfs": "^0.3.2",
+        "ipfs-block": "~0.7.1",
+        "ipfs-unixfs": "~0.1.15",
+        "ipld-dag-cbor": "~0.12.1",
+        "ipld-dag-pb": "~0.14.5",
+        "is-ipfs": "~0.3.2",
+        "is-pull-stream": "0.0.0",
         "is-stream": "^1.1.0",
-        "lru-cache": "^4.1.2",
-        "multiaddr": "^3.0.2",
+        "libp2p-crypto": "~0.13.0",
+        "lru-cache": "^4.1.3",
+        "multiaddr": "^5.0.0",
+        "multibase": "~0.4.0",
         "multihashes": "~0.4.13",
         "ndjson": "^1.5.0",
         "once": "^1.4.0",
-        "peer-id": "~0.10.6",
-        "peer-info": "~0.11.6",
+        "peer-id": "~0.11.0",
+        "peer-info": "~0.14.1",
         "promisify-es6": "^1.0.3",
-        "pull-defer": "^0.2.2",
+        "pull-defer": "~0.2.2",
         "pull-pushable": "^2.2.0",
+        "pull-stream-to-stream": "^1.3.4",
         "pump": "^3.0.0",
-        "qs": "^6.5.1",
-        "readable-stream": "^2.3.5",
-        "stream-http": "^2.8.1",
+        "qs": "^6.5.2",
+        "readable-stream": "^2.3.6",
+        "stream-http": "^2.8.3",
         "stream-to-pull-stream": "^1.7.2",
-        "streamifier": "^0.1.1",
-        "tar-stream": "^1.5.5"
+        "streamifier": "~0.1.1",
+        "tar-stream": "^1.6.1"
       },
       "dependencies": {
         "big.js": {
@@ -5271,20 +5472,39 @@
             "end-of-stream": "^1.1.0",
             "once": "^1.3.1"
           }
+        },
+        "stream-http": {
+          "version": "2.8.3",
+          "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.3.tgz",
+          "integrity": "sha512-+TSkfINHDo4J+ZobQLWiMouQYB+UVYFttRA94FpEzzJ7ZdqcL4uUUQ7WkdkI4DSozGmgBUE/a47L+38PenXhUw==",
+          "dev": true,
+          "requires": {
+            "builtin-status-codes": "^3.0.0",
+            "inherits": "^2.0.1",
+            "readable-stream": "^2.3.6",
+            "to-arraybuffer": "^1.0.0",
+            "xtend": "^4.0.0"
+          }
+        },
+        "xtend": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+          "dev": true
         }
       }
     },
     "ipfs-bitswap": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/ipfs-bitswap/-/ipfs-bitswap-0.19.0.tgz",
-      "integrity": "sha512-TF+wi6tYaWusJatJROlKOP4XftIf4cW8YVu6+5iIZ1oezon0I5eKRwh4iRd1HtOqyRckXrGgy8mg6rvWyGpaiA==",
+      "version": "0.20.3",
+      "resolved": "https://registry.npmjs.org/ipfs-bitswap/-/ipfs-bitswap-0.20.3.tgz",
+      "integrity": "sha512-qXg/QhevKBU/tKdWgW6yhcSKQDQx+4Mvv9HEeoVjkqZ9Pagmojk6yGk8X4J9H2G2PagvHXkWsqwqyKho7RcPWA==",
       "dev": true,
       "requires": {
-        "async": "^2.6.0",
-        "big.js": "^5.0.3",
-        "cids": "~0.5.2",
+        "async": "^2.6.1",
+        "big.js": "^5.1.2",
+        "cids": "~0.5.3",
         "debug": "^3.1.0",
-        "ipfs-block": "~0.6.1",
+        "ipfs-block": "~0.7.1",
         "lodash.debounce": "^4.0.8",
         "lodash.find": "^4.6.0",
         "lodash.groupby": "^4.6.0",
@@ -5295,15 +5515,14 @@
         "lodash.uniqwith": "^4.5.0",
         "lodash.values": "^4.3.0",
         "moving-average": "^1.0.0",
-        "multicodec": "~0.2.6",
-        "multihashing-async": "~0.4.7",
+        "multicodec": "~0.2.7",
+        "multihashing-async": "~0.5.1",
         "protons": "^1.0.1",
         "pull-defer": "~0.2.2",
         "pull-length-prefixed": "^1.3.0",
-        "pull-pushable": "^2.1.2",
-        "pull-stream": "^3.6.1",
-        "safe-buffer": "^5.1.1",
-        "varint-decoder": "^0.1.1"
+        "pull-pushable": "^2.2.0",
+        "pull-stream": "^3.6.8",
+        "varint-decoder": "~0.1.1"
       },
       "dependencies": {
         "big.js": {
@@ -5324,19 +5543,49 @@
       }
     },
     "ipfs-block": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/ipfs-block/-/ipfs-block-0.6.1.tgz",
-      "integrity": "sha512-28dgGsb2YsYnFs+To4cVBX8e/lTCb8eWDzGhN5csj3a/sHMOYrHeK8+Ez0IV67CI3lqKGuG/ZD01Cmd6JUvKrQ==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/ipfs-block/-/ipfs-block-0.7.1.tgz",
+      "integrity": "sha512-ABZS9J/+OaDwc10zu6pIVdxWnOD/rkPEravk7FRVuRep7/zKSjffNhO/WuHN7Ex+MOBMz7mty0e+i6xjGnRsRQ==",
       "dev": true,
       "requires": {
-        "cids": "^0.5.2"
+        "cids": "^0.5.3",
+        "class-is": "^1.1.0"
       }
     },
     "ipfs-block-service": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/ipfs-block-service/-/ipfs-block-service-0.13.0.tgz",
-      "integrity": "sha512-fKKEF47oOSTV4S0X12FPqtfxBRL1/BZF+AzIzpfuTXer7ikStn02quUs2mz0Hfn5I0BjCuDGbJEnzca4m6EpQg==",
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/ipfs-block-service/-/ipfs-block-service-0.14.0.tgz",
+      "integrity": "sha512-qu5VdBSAh/44wtqVgyoyWebjIY6mLbiEZObwYZHEZ5VFuU4oOlfZ+s2oz2I5lTw1eeL7SGccQeshQ0OePxIPnw==",
       "dev": true
+    },
+    "ipfs-http-response": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ipfs-http-response/-/ipfs-http-response-0.1.2.tgz",
+      "integrity": "sha512-mJRFX3mlcv4yAxh0qMnlBuOyoB/3DiMj54sv12upubQckN0nPGJREldar8nHjVr4biuQKwyMPyxK5O1bK42UDQ==",
+      "dev": true,
+      "requires": {
+        "async": "^2.6.0",
+        "cids": "^0.5.3",
+        "debug": "^3.1.0",
+        "file-type": "^8.0.0",
+        "filesize": "^3.6.1",
+        "ipfs-unixfs": "^0.1.14",
+        "mime-types": "^2.1.18",
+        "multihashes": "^0.4.13",
+        "promisify-es6": "^1.0.3",
+        "readable-stream-node-to-web": "^1.0.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
     },
     "ipfs-log": {
       "version": "4.1.0",
@@ -5345,6 +5594,50 @@
       "requires": {
         "p-map": "^1.1.1",
         "p-whilst": "^1.0.0"
+      }
+    },
+    "ipfs-mfs": {
+      "version": "0.0.16",
+      "resolved": "https://registry.npmjs.org/ipfs-mfs/-/ipfs-mfs-0.0.16.tgz",
+      "integrity": "sha512-UR5zy1jVJvZas1bAXrHp7ujpaU5CO/DqMc49zOLeSpiO0mB8ZZ3eK3fBjKDpLrEWCd8pG+yDL60w3AinVOlKTA==",
+      "dev": true,
+      "requires": {
+        "async": "^2.6.1",
+        "blob": "~0.0.4",
+        "bs58": "^4.0.1",
+        "cids": "~0.5.3",
+        "debug": "^3.1.0",
+        "detect-node": "^2.0.3",
+        "file-api": "~0.10.4",
+        "filereader-stream": "^2.0.0",
+        "interface-datastore": "~0.4.2",
+        "ipfs-unixfs": "~0.1.15",
+        "ipfs-unixfs-engine": "~0.30.0",
+        "is-pull-stream": "~0.0.0",
+        "is-stream": "^1.1.0",
+        "joi": "^13.4.0",
+        "joi-browser": "^13.4.0",
+        "mortice": "^1.2.0",
+        "once": "^1.4.0",
+        "promisify-es6": "^1.0.3",
+        "pull-cat": "^1.1.11",
+        "pull-paramap": "^1.2.2",
+        "pull-pushable": "^2.2.0",
+        "pull-stream": "^3.6.7",
+        "pull-stream-to-stream": "^1.3.4",
+        "pull-traverse": "^1.0.3",
+        "stream-to-pull-stream": "^1.7.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "ipfs-multipart": {
@@ -5374,45 +5667,73 @@
       }
     },
     "ipfs-repo": {
-      "version": "0.18.7",
-      "resolved": "https://registry.npmjs.org/ipfs-repo/-/ipfs-repo-0.18.7.tgz",
-      "integrity": "sha512-a1gXPX2UA/8rE63/E5X7+QB7jvmNYD+mVHSX0ypb7ZIsMoc0ewiq5Bwc2NXQAN7PCNWksxp1tDGWzq6bAPm9vg==",
+      "version": "0.22.1",
+      "resolved": "https://registry.npmjs.org/ipfs-repo/-/ipfs-repo-0.22.1.tgz",
+      "integrity": "sha512-57RAHqbMMcVLEkbzx6PlMs7LnwsfMJrzjjNCNAsQuN2wcT8Abm09UIjo2P36x0leYMNIG2SWiyr1H5OLSKn74Q==",
       "dev": true,
       "requires": {
         "async": "^2.6.0",
         "base32.js": "~0.1.0",
         "big.js": "^5.0.3",
-        "cids": "~0.5.2",
+        "cids": "~0.5.3",
         "datastore-core": "~0.4.0",
-        "datastore-fs": "~0.4.2",
-        "datastore-level": "~0.7.0",
+        "datastore-fs": "~0.5.0",
+        "datastore-level": "~0.8.0",
         "debug": "^3.1.0",
         "interface-datastore": "~0.4.2",
-        "ipfs-block": "~0.6.1",
-        "level-js": "github:timkuijsten/level.js#18e03adab34c49523be7d3d58fafb0c632f61303",
-        "leveldown": "^1.7.2",
-        "lock-me": "^1.0.3",
+        "ipfs-block": "~0.7.1",
+        "lock-me": "^1.0.4",
         "lodash.get": "^4.4.2",
         "lodash.has": "^4.5.2",
         "lodash.set": "^4.3.2",
-        "multiaddr": "^3.0.1",
-        "pull-stream": "^3.6.1"
+        "multiaddr": "^4.0.0",
+        "pull-stream": "^3.6.7"
       },
       "dependencies": {
-        "abstract-leveldown": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.4.1.tgz",
-          "integrity": "sha1-s7/tuITraToSd18MVenwpCDM7mQ=",
-          "dev": true,
-          "requires": {
-            "xtend": "~4.0.0"
-          }
-        },
         "big.js": {
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.1.2.tgz",
           "integrity": "sha512-qG6ZOc1lY84Bn8p/z9xvJisj9F4PRyo0pOGqGNYc7gS3p1WciS/3XcLuNI3Z/yYZpMNFhHeX3YNENwgrQq0NTA==",
           "dev": true
+        },
+        "datastore-level": {
+          "version": "0.8.0",
+          "resolved": "https://registry.npmjs.org/datastore-level/-/datastore-level-0.8.0.tgz",
+          "integrity": "sha512-RSklSUhf4CBNXm8akR+Q7LvDE4J6NA8XfZ3h5pGPempdXcExFui5CoyHJscOlu0culvZzuJLU4k5PxcLPGzuMw==",
+          "dev": true,
+          "requires": {
+            "datastore-core": "~0.4.0",
+            "encoding-down": "^5.0.2",
+            "interface-datastore": "~0.4.1",
+            "level-js": "github:timkuijsten/level.js#18e03adab34c49523be7d3d58fafb0c632f61303",
+            "leveldown": "^3.0.2",
+            "levelup": "^2.0.2",
+            "pull-stream": "^3.6.1"
+          },
+          "dependencies": {
+            "level-js": {
+              "version": "github:timkuijsten/level.js#18e03adab34c49523be7d3d58fafb0c632f61303",
+              "from": "github:timkuijsten/level.js#idbunwrapper",
+              "dev": true,
+              "requires": {
+                "abstract-leveldown": "~2.4.1",
+                "idb-readable-stream": "0.0.4",
+                "ltgt": "^2.1.2",
+                "xtend": "^4.0.1"
+              },
+              "dependencies": {
+                "abstract-leveldown": {
+                  "version": "2.4.1",
+                  "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.4.1.tgz",
+                  "integrity": "sha1-s7/tuITraToSd18MVenwpCDM7mQ=",
+                  "dev": true,
+                  "requires": {
+                    "xtend": "~4.0.0"
+                  }
+                }
+              }
+            }
+          }
         },
         "debug": {
           "version": "3.1.0",
@@ -5423,22 +5744,140 @@
             "ms": "2.0.0"
           }
         },
+        "deferred-leveldown": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-3.0.0.tgz",
+          "integrity": "sha512-ajbXqRPMXRlcdyt0TuWqknOJkp1JgQjGB7xOl2V+ebol7/U11E9h3/nCZAtN1M7djmAJEIhypCUc1tIWxdQAuQ==",
+          "dev": true,
+          "requires": {
+            "abstract-leveldown": "~4.0.0"
+          },
+          "dependencies": {
+            "abstract-leveldown": {
+              "version": "4.0.3",
+              "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-4.0.3.tgz",
+              "integrity": "sha512-qsIHFQy0u17JqSY+3ZUT+ykqxYY17yOfvAsLkFkw8kSQqi05d1jyj0bCuSX6sjYlXuY9cKpgUt5EudQdP4aXyA==",
+              "dev": true,
+              "requires": {
+                "xtend": "~4.0.0"
+              }
+            }
+          }
+        },
+        "level-errors": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-1.1.2.tgz",
+          "integrity": "sha512-Sw/IJwWbPKF5Ai4Wz60B52yj0zYeqzObLh8k1Tk88jVmD51cJSKWSYpRyhVIvFzZdvsPqlH5wfhp/yxdsaQH4w==",
+          "dev": true,
+          "requires": {
+            "errno": "~0.1.1"
+          }
+        },
+        "level-iterator-stream": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-2.0.0.tgz",
+          "integrity": "sha512-TWOYw8HR5mhj6xwoVLo0yu26RPL6v28KgvhK1kY1CJf9LyL+rJXjx99zhORTYhN9ysOBIH+iaxAiqRteA+C1/g==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.1",
+            "readable-stream": "^2.0.5",
+            "xtend": "^4.0.0"
+          }
+        },
         "level-js": {
           "version": "github:timkuijsten/level.js#18e03adab34c49523be7d3d58fafb0c632f61303",
           "from": "github:timkuijsten/level.js#idbunwrapper",
-          "dev": true,
           "requires": {
-            "abstract-leveldown": "~2.4.1",
             "idb-readable-stream": "0.0.4",
             "ltgt": "^2.1.2",
             "xtend": "^4.0.1"
           }
         },
+        "leveldown": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/leveldown/-/leveldown-3.0.2.tgz",
+          "integrity": "sha512-+ANRScj1npQQzv6e4DYAKRjVQZZ+ahMoubKrNP68nIq+l9bYgb+WiXF+14oTcQTg2f7qE9WHGW7rBG9nGSsA+A==",
+          "dev": true,
+          "requires": {
+            "abstract-leveldown": "~4.0.0",
+            "bindings": "~1.3.0",
+            "fast-future": "~1.0.2",
+            "nan": "~2.10.0",
+            "prebuild-install": "^4.0.0"
+          },
+          "dependencies": {
+            "abstract-leveldown": {
+              "version": "4.0.3",
+              "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-4.0.3.tgz",
+              "integrity": "sha512-qsIHFQy0u17JqSY+3ZUT+ykqxYY17yOfvAsLkFkw8kSQqi05d1jyj0bCuSX6sjYlXuY9cKpgUt5EudQdP4aXyA==",
+              "dev": true,
+              "requires": {
+                "xtend": "~4.0.0"
+              }
+            }
+          }
+        },
+        "levelup": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/levelup/-/levelup-2.0.2.tgz",
+          "integrity": "sha512-us+nTLUyd/eLnclYYddOCdAVw1hnymGx/9p4Jr5ThohStsjLqMVmbYiz6/SYFZEPXNF+AKQSvh6fA2e2KZpC8w==",
+          "dev": true,
+          "requires": {
+            "deferred-leveldown": "~3.0.0",
+            "level-errors": "~1.1.0",
+            "level-iterator-stream": "~2.0.0",
+            "xtend": "~4.0.0"
+          }
+        },
+        "multiaddr": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-4.0.0.tgz",
+          "integrity": "sha512-zUatrOCfBd/tJNOSoJ10d2EI2FDXB9PyPZhqUMdXE9mOyR3C+HLuOjga2Ga/eChwvEHIpTYRMoIKF2Nv7af2qQ==",
+          "dev": true,
+          "requires": {
+            "bs58": "^4.0.1",
+            "class-is": "^1.1.0",
+            "ip": "^1.1.5",
+            "ip-address": "^5.8.9",
+            "lodash.filter": "^4.6.0",
+            "lodash.map": "^4.6.0",
+            "varint": "^5.0.0",
+            "xtend": "^4.0.1"
+          }
+        },
+        "nan": {
+          "version": "2.10.0",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
+          "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
+          "dev": true
+        },
+        "prebuild-install": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-4.0.0.tgz",
+          "integrity": "sha512-7tayxeYboJX0RbVzdnKyGl2vhQRWr6qfClEXDhOkXjuaOKCw2q8aiuFhONRYVsG/czia7KhpykIlI2S2VaPunA==",
+          "dev": true,
+          "requires": {
+            "detect-libc": "^1.0.3",
+            "expand-template": "^1.0.2",
+            "github-from-package": "0.0.0",
+            "minimist": "^1.2.0",
+            "mkdirp": "^0.5.1",
+            "node-abi": "^2.2.0",
+            "noop-logger": "^0.1.1",
+            "npmlog": "^4.0.1",
+            "os-homedir": "^1.0.1",
+            "pump": "^2.0.1",
+            "rc": "^1.1.6",
+            "simple-get": "^2.7.0",
+            "tar-fs": "^1.13.0",
+            "tunnel-agent": "^0.6.0",
+            "which-pm-runs": "^1.0.0"
+          }
+        },
         "xtend": {
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
-          "dev": true
+          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
         }
       }
     },
@@ -5452,22 +5891,22 @@
       }
     },
     "ipfs-unixfs-engine": {
-      "version": "0.24.4",
-      "resolved": "https://registry.npmjs.org/ipfs-unixfs-engine/-/ipfs-unixfs-engine-0.24.4.tgz",
-      "integrity": "sha512-dioocJXylmdWRMUR/9WqRn8EYOj0VGrSYFTTdy2Z2WJdOGhnb+C+ubkGTyewmkAFDWoxaqCcwwPRbos3PjqIUQ==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/ipfs-unixfs-engine/-/ipfs-unixfs-engine-0.30.0.tgz",
+      "integrity": "sha512-IOrr9DfX8Sr0KqekTuBxKp+Y2+OLCKvsXM0+rlIOEFfZsdTQZTrHyJATVgCBDkJmrfvrHhKRYhO4BuGwYdHNfA==",
       "dev": true,
       "requires": {
-        "async": "^2.6.0",
+        "async": "^2.6.1",
         "bs58": "^4.0.1",
-        "cids": "~0.5.2",
-        "deep-extend": "~0.5.0",
-        "ipfs-unixfs": "~0.1.14",
-        "ipld": "^0.15.0",
-        "ipld-dag-pb": "~0.13.1",
-        "left-pad": "^1.2.0",
-        "lodash": "^4.17.5",
+        "cids": "~0.5.3",
+        "deep-extend": "~0.6.0",
+        "ipfs-unixfs": "~0.1.15",
+        "ipld": "~0.17.2",
+        "ipld-dag-pb": "~0.14.4",
+        "left-pad": "^1.3.0",
+        "lodash": "^4.17.10",
         "multihashes": "~0.4.13",
-        "multihashing-async": "~0.4.8",
+        "multihashing-async": "~0.5.1",
         "pull-batch": "^1.0.0",
         "pull-block": "^1.4.0",
         "pull-cat": "^1.1.11",
@@ -5475,49 +5914,41 @@
         "pull-paramap": "^1.2.2",
         "pull-pause": "0.0.2",
         "pull-pushable": "^2.2.0",
-        "pull-stream": "^3.6.2",
+        "pull-stream": "^3.6.8",
+        "pull-through": "^1.0.18",
         "pull-traverse": "^1.0.3",
         "pull-write": "^1.1.4",
         "sparse-array": "^1.3.1"
-      },
-      "dependencies": {
-        "deep-extend": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.5.1.tgz",
-          "integrity": "sha512-N8vBdOa+DF7zkRrDCsaOXoCs/E2fJfx9B9MrKnnSiHNh4ws7eSys6YQE4KvT1cecKmOASYQBhbKjeuDD9lT81w==",
-          "dev": true
-        }
       }
     },
     "ipfsd-ctl": {
-      "version": "0.30.4",
-      "resolved": "https://registry.npmjs.org/ipfsd-ctl/-/ipfsd-ctl-0.30.4.tgz",
-      "integrity": "sha512-GZ8uzZ7AZ/DhgVQZ8f1j1sTuzOPMBAszDPd3p4ucxRd9kdlatxlFTaRyLlQB9/A+gx90SUQF8nKTqr5ZDWJ0yg==",
+      "version": "0.37.5",
+      "resolved": "https://registry.npmjs.org/ipfsd-ctl/-/ipfsd-ctl-0.37.5.tgz",
+      "integrity": "sha512-MkaK8QOmFVUAZsRCKyNzR7uFdvkJncKvu7lv2AR0cWLoe0y97hObtrrtZewYn1fUJe7IbRqbNogCIOTg9tM0UQ==",
       "dev": true,
       "requires": {
         "async": "^2.6.0",
         "boom": "^7.2.0",
         "debug": "^3.1.0",
         "detect-node": "^2.0.3",
+        "dexie": "^1.5.1",
         "hapi": "^16.6.2",
-        "hat": "0.0.3",
-        "ipfs-api": "^18.1.2",
-        "ipfs-repo": "^0.18.7",
+        "hat": "~0.0.3",
+        "ipfs-api": "^22.0.0",
         "joi": "^13.1.2",
         "lodash.clone": "^4.5.0",
         "lodash.defaults": "^4.2.0",
         "lodash.defaultsdeep": "^4.6.0",
-        "multiaddr": "^3.0.2",
+        "multiaddr": "^5.0.0",
         "once": "^1.4.0",
-        "readable-stream": "^2.3.5",
+        "readable-stream": "^2.3.6",
         "rimraf": "^2.6.2",
         "safe-json-parse": "^4.0.0",
         "safe-json-stringify": "^1.1.0",
-        "shutdown": "^0.3.0",
-        "stream-http": "^2.8.0",
+        "shutdown": "~0.3.0",
+        "stream-http": "^2.8.1",
         "subcomandante": "^1.0.5",
-        "superagent": "^3.8.2",
-        "truthy": "0.0.1"
+        "superagent": "^3.8.2"
       },
       "dependencies": {
         "debug": {
@@ -5532,20 +5963,20 @@
       }
     },
     "ipld": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/ipld/-/ipld-0.15.0.tgz",
-      "integrity": "sha512-/7aeDrd/SRBerJNAmGzWA2Iu61IQrkIJ4tiU0Sf/ZZeawuIIriH5KhQyFnPiTZk8a5tcEnCoqhzh6N++zpFccQ==",
+      "version": "0.17.2",
+      "resolved": "https://registry.npmjs.org/ipld/-/ipld-0.17.2.tgz",
+      "integrity": "sha512-IRW7wbn5dM10I/xEM1AhHwo6pjzbTgdY0lI3DtbkpfV4jS+awnyx8mWMY/M0ND1GjSwfaH9l+odVIHRPZoxo0Q==",
       "dev": true,
       "requires": {
-        "async": "^2.6.0",
-        "cids": "~0.5.2",
+        "async": "^2.6.1",
+        "cids": "~0.5.3",
         "interface-datastore": "~0.4.2",
-        "ipfs-block": "~0.6.1",
-        "ipfs-block-service": "~0.13.0",
-        "ipfs-repo": "~0.18.5",
+        "ipfs-block": "~0.7.1",
+        "ipfs-block-service": "~0.14.0",
+        "ipfs-repo": "~0.22.0",
         "ipld-bitcoin": "~0.1.5",
         "ipld-dag-cbor": "~0.12.0",
-        "ipld-dag-pb": "~0.13.0",
+        "ipld-dag-pb": "~0.14.4",
         "ipld-ethereum": "^2.0.0",
         "ipld-git": "~0.2.0",
         "ipld-raw": "^2.0.0",
@@ -5553,31 +5984,30 @@
         "is-ipfs": "~0.3.2",
         "lodash.flatten": "^4.4.0",
         "lodash.includes": "^4.3.0",
-        "memdown": "^1.4.1",
-        "multihashes": "~0.4.12",
+        "memdown": "^3.0.0",
+        "multihashes": "~0.4.13",
         "pull-defer": "^0.2.2",
         "pull-sort": "^1.0.1",
-        "pull-stream": "^3.6.1",
+        "pull-stream": "^3.6.8",
         "pull-traverse": "^1.0.3"
       }
     },
     "ipld-bitcoin": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/ipld-bitcoin/-/ipld-bitcoin-0.1.5.tgz",
-      "integrity": "sha512-sXgjbp++QTs1onkeBY/W1/LTvDdFErZoPgPlIKAOR9fiLXaRHSUKHTBulaL/IDnNXhD5jaFPveOudFkNNJCbDw==",
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/ipld-bitcoin/-/ipld-bitcoin-0.1.6.tgz",
+      "integrity": "sha512-WqF3u8nEsk94dfpTZUHXHlnscWBSTs8i02VpJmWIjugcqYZeZzjgeMS5Q2dNTDNzuKshmvjQJa3ubpSkWo3XwA==",
       "dev": true,
       "requires": {
         "bitcoinjs-lib": "^3.3.2",
         "cids": "~0.5.2",
-        "dirty-chai": "^2.0.1",
-        "hash.js": "^1.1.3",
-        "multihashes": "~0.4.12"
+        "multihashes": "~0.4.12",
+        "multihashing-async": "~0.5.1"
       }
     },
     "ipld-dag-cbor": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/ipld-dag-cbor/-/ipld-dag-cbor-0.12.0.tgz",
-      "integrity": "sha512-zitoqSGNP/73r5LU4ZuYE5E+zJar84k+AEGdFl3Y+H3opBn8KTMcR3bm1CoTaJYBfpn1fJpB0jb2wTEQDRESpQ==",
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/ipld-dag-cbor/-/ipld-dag-cbor-0.12.1.tgz",
+      "integrity": "sha512-m0BR/zR9sKIuY/PydppkpwO0S9w7+ob0as7RN3jQmMIpW9m8HW7hLznvtp1xpYZknH7efUhIaMHgaQP43E5IWQ==",
       "dev": true,
       "requires": {
         "async": "^2.6.0",
@@ -5586,8 +6016,8 @@
         "cids": "~0.5.2",
         "is-circular": "^1.0.1",
         "multihashes": "~0.4.12",
-        "multihashing-async": "~0.4.7",
-        "traverse": "^0.6.6"
+        "multihashing-async": "~0.5.1",
+        "traverse": "~0.6.6"
       },
       "dependencies": {
         "traverse": {
@@ -5599,23 +6029,23 @@
       }
     },
     "ipld-dag-pb": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/ipld-dag-pb/-/ipld-dag-pb-0.13.1.tgz",
-      "integrity": "sha512-HxybRQvpY8IQ9T0bImlT5v4LBR3jJAgEnFRA/ZU2UNIiBuRkbirI9+VSX03+WkiYooiFMoZz6Qp/xYMdoogNWg==",
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/ipld-dag-pb/-/ipld-dag-pb-0.14.5.tgz",
+      "integrity": "sha512-HHKqyjP1m9PxbT1+EWrbq/dH6uIY90mvwQ6G79JWKsdCsyOvRbyCdmZmXbbuTN9JBFcoMG2684qix+HtiEz0fQ==",
       "dev": true,
       "requires": {
-        "async": "^2.6.0",
+        "async": "^2.6.1",
         "bs58": "^4.0.1",
-        "buffer-loader": "0.0.1",
-        "cids": "~0.5.2",
-        "ipfs-block": "~0.6.1",
+        "buffer-loader": "~0.0.1",
+        "cids": "~0.5.3",
+        "class-is": "^1.1.0",
         "is-ipfs": "~0.3.2",
-        "multihashes": "~0.4.12",
-        "multihashing-async": "~0.4.7",
+        "multihashes": "~0.4.13",
+        "multihashing-async": "~0.5.1",
         "protons": "^1.0.1",
-        "pull-stream": "^3.6.1",
+        "pull-stream": "^3.6.8",
         "pull-traverse": "^1.0.3",
-        "stable": "^0.1.6"
+        "stable": "~0.1.8"
       }
     },
     "ipld-ethereum": {
@@ -5635,19 +6065,44 @@
         "multihashes": "~0.4.12",
         "multihashing-async": "~0.4.7",
         "rlp": "^2.0.0"
+      },
+      "dependencies": {
+        "ipfs-block": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/ipfs-block/-/ipfs-block-0.6.1.tgz",
+          "integrity": "sha512-28dgGsb2YsYnFs+To4cVBX8e/lTCb8eWDzGhN5csj3a/sHMOYrHeK8+Ez0IV67CI3lqKGuG/ZD01Cmd6JUvKrQ==",
+          "dev": true,
+          "requires": {
+            "cids": "^0.5.2"
+          }
+        },
+        "multihashing-async": {
+          "version": "0.4.8",
+          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.4.8.tgz",
+          "integrity": "sha512-LCc4lfxmTJOHKIjZjFNgvmfB6nXS/ErLInT9uwU8udFrRm2PH+aTPk3mfCREKmCiSHOlCWiv2O8rlnBx+OjlMw==",
+          "dev": true,
+          "requires": {
+            "async": "^2.6.0",
+            "blakejs": "^1.1.0",
+            "js-sha3": "^0.7.0",
+            "multihashes": "~0.4.13",
+            "murmurhash3js": "^3.0.1",
+            "nodeify": "^1.0.1"
+          }
+        }
       }
     },
     "ipld-git": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/ipld-git/-/ipld-git-0.2.0.tgz",
-      "integrity": "sha512-4hMxkRCIme5qlqxgtQ9ZKsU+LmbNu55Yqi9MTNPly6tOPuBdNcB/5Cvw9OBG8KPHaGpZkHYmZ1K/LTHD0M7FCg==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/ipld-git/-/ipld-git-0.2.1.tgz",
+      "integrity": "sha512-DjCgL6n8vFRyjoyjt6BVMHWy9S9XaOHD+IDvnoeZU0oMRd68B3Y/heTI0HStMxrOhR8VNhjH5W+EpJ3823BAYQ==",
       "dev": true,
       "requires": {
         "async": "^2.6.0",
         "cids": "~0.5.2",
         "multicodec": "~0.2.5",
         "multihashes": "~0.4.12",
-        "multihashing-async": "~0.4.7",
+        "multihashing-async": "~0.5.1",
         "smart-buffer": "^4.0.0",
         "traverse": "~0.6.6"
       },
@@ -5661,25 +6116,26 @@
       }
     },
     "ipld-raw": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ipld-raw/-/ipld-raw-2.0.0.tgz",
-      "integrity": "sha512-iuzlzyqIMnRjpsgyVcorkXIXRZjlYjdlmZFpYW5K1s2ce5qnl4DHy4o7ASsgIpr3Eevp4BuwMXnJBpK6i8u8qg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ipld-raw/-/ipld-raw-2.0.1.tgz",
+      "integrity": "sha512-wtP1I61YQoAPnRZqVeflrxjTi41+38ck2puEz9mnMlc0ChYRGc4ZSKcWDTk66EQuqEzDAdV71nOMKb3JzDfbsg==",
       "dev": true,
       "requires": {
-        "cids": "~0.5.2"
+        "cids": "~0.5.2",
+        "multihashing-async": "~0.5.1"
       }
     },
     "ipld-zcash": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/ipld-zcash/-/ipld-zcash-0.1.3.tgz",
-      "integrity": "sha512-SLMihJHMTjU008iSAUEVILKgpcRbhEhu/VZQ4Arcj3WnB18AdDZAwC7hg6E8BeJDG7oJq5vtfJ68YxRX9NSHgg==",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/ipld-zcash/-/ipld-zcash-0.1.4.tgz",
+      "integrity": "sha512-KjwuRH0VHPY+SPjTD1lYL3XzMfQyIeCRH+Jkq1z5kSmX0IjNe4riVzUPGySD+R1ITewSDGvnCoTeyNwK/dIrEg==",
       "dev": true,
       "requires": {
         "cids": "~0.5.2",
         "dirty-chai": "^2.0.1",
-        "hash.js": "^1.1.3",
         "multihashes": "~0.4.12",
-        "zcash-bitcore-lib": "^0.13.20-rc3"
+        "multihashing-async": "~0.5.1",
+        "zcash-bitcore-lib": "~0.13.20-rc3"
       }
     },
     "iron": {
@@ -5759,9 +6215,9 @@
       }
     },
     "is-circular": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-circular/-/is-circular-1.0.1.tgz",
-      "integrity": "sha1-ZbBHaoWI5Ua4CHwdZtTAjYKjFnk=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-circular/-/is-circular-1.0.2.tgz",
+      "integrity": "sha512-YttjnrswnUYRVJvxCvu8z+PGMUSzC2JttP0OEXezlAEdp3EXzhf7IZ3j0gRAybJBQupedIZFhY61Tga6E0qASA==",
       "dev": true
     },
     "is-data-descriptor": {
@@ -5931,6 +6387,12 @@
       "integrity": "sha1-MVc3YcBX4zwukaq56W2gjO++duU=",
       "dev": true
     },
+    "is-pull-stream": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/is-pull-stream/-/is-pull-stream-0.0.0.tgz",
+      "integrity": "sha1-o7w9HG0wVRUcRr3m85nv7SFEDKk=",
+      "dev": true
+    },
     "is-redirect": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
@@ -6051,13 +6513,37 @@
       "dev": true
     },
     "joi-multiaddr": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/joi-multiaddr/-/joi-multiaddr-1.0.1.tgz",
-      "integrity": "sha512-Ye5bCPQZ3Jl8zSaiBwKjBiZf3dM9PIrvWizrOecwRlbWpGWt0kPK5PunOMm/nAdVIOwQIR1Z2/sGMe3u+vrCGA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/joi-multiaddr/-/joi-multiaddr-2.0.0.tgz",
+      "integrity": "sha512-7dJLwgplwRnIQAlC+zTuX3jkk3uXVa/RKm7GDfNO3NqmjiYgwAet8yprIdilki1WhdkJJMLuTNDf49uFNru68A==",
       "dev": true,
       "requires": {
-        "mafmt": "^4.0.0",
-        "multiaddr": "^3.0.2"
+        "mafmt": "^6.0.0",
+        "multiaddr": "^4.0.0"
+      },
+      "dependencies": {
+        "multiaddr": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-4.0.0.tgz",
+          "integrity": "sha512-zUatrOCfBd/tJNOSoJ10d2EI2FDXB9PyPZhqUMdXE9mOyR3C+HLuOjga2Ga/eChwvEHIpTYRMoIKF2Nv7af2qQ==",
+          "dev": true,
+          "requires": {
+            "bs58": "^4.0.1",
+            "class-is": "^1.1.0",
+            "ip": "^1.1.5",
+            "ip-address": "^5.8.9",
+            "lodash.filter": "^4.6.0",
+            "lodash.map": "^4.6.0",
+            "varint": "^5.0.0",
+            "xtend": "^4.0.1"
+          }
+        },
+        "xtend": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+          "dev": true
+        }
       }
     },
     "js-sha3": {
@@ -6143,12 +6629,11 @@
       }
     },
     "k-bucket": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/k-bucket/-/k-bucket-3.3.1.tgz",
-      "integrity": "sha512-kgwWqYT79rAahn4maIVTP8dIe+m1KulufWW+f1bB9DlZrRFiGpZ4iJOg2HUp4xJYBWONP3+rOPIWF/RXABU6mw==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/k-bucket/-/k-bucket-4.0.1.tgz",
+      "integrity": "sha512-YvDpmY3waI999h1zZoW1rJ04fZrgZ+5PAlVmvwDHT6YO/Q1AOhdel07xsKy9eAvJjQ9xZV1wz3rXKqEfaWvlcQ==",
       "dev": true,
       "requires": {
-        "buffer-equals": "^1.0.3",
         "inherits": "^2.0.1",
         "randombytes": "^2.0.3"
       }
@@ -6178,6 +6663,16 @@
       "dev": true,
       "requires": {
         "is-buffer": "^1.1.5"
+      }
+    },
+    "latency-monitor": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/latency-monitor/-/latency-monitor-0.2.1.tgz",
+      "integrity": "sha1-QEPV8j3obiv872ztSjtbki4d1+0=",
+      "dev": true,
+      "requires": {
+        "debug": "^2.6.0",
+        "lodash": "^4.17.4"
       }
     },
     "latest-version": {
@@ -6386,26 +6881,163 @@
       }
     },
     "libp2p": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/libp2p/-/libp2p-0.18.0.tgz",
-      "integrity": "sha512-gC5TNB3atM5Tc14CFu14IEAqm/v9ZJA3XuCX+kbZfcTZiNbMiIFTZrQY4UY/0mx7ZEpDTJn/fGwI8OIc0EYJRQ==",
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/libp2p/-/libp2p-0.22.0.tgz",
+      "integrity": "sha512-7CcituMkZc4OcsXs1yjBnLDCjXl3OlDB6A6NgjRLOWplb2VnyR1RSU4kpUmslcE7BvKKNqSeDd/QzBwcPp7prg==",
       "dev": true,
       "requires": {
-        "async": "^2.6.0",
-        "libp2p-floodsub": "^0.14.1",
-        "libp2p-ping": "~0.6.1",
-        "libp2p-switch": "~0.36.1",
-        "mafmt": "^4.0.0",
-        "multiaddr": "^3.0.2",
-        "peer-book": "~0.5.4",
-        "peer-id": "~0.10.6",
-        "peer-info": "~0.11.6"
+        "async": "^2.6.1",
+        "joi": "^13.4.0",
+        "joi-browser": "^13.4.0",
+        "libp2p-connection-manager": "~0.0.2",
+        "libp2p-floodsub": "~0.15.0",
+        "libp2p-ping": "~0.8.0",
+        "libp2p-switch": "~0.40.4",
+        "libp2p-websockets": "~0.12.0",
+        "mafmt": "^6.0.0",
+        "multiaddr": "^5.0.0",
+        "peer-book": "~0.8.0",
+        "peer-id": "~0.10.7",
+        "peer-info": "~0.14.1"
+      },
+      "dependencies": {
+        "libp2p-crypto": {
+          "version": "0.12.1",
+          "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.12.1.tgz",
+          "integrity": "sha512-1/z8rxZ0DcQNreZhEsl7PnLr7DWOioSvYbKBLGkRwNRiNh1JJLgh0PdTySBb44wkrOGT+TxcGRd7iq3/X6Wxwg==",
+          "dev": true,
+          "requires": {
+            "asn1.js": "^5.0.0",
+            "async": "^2.6.0",
+            "browserify-aes": "^1.1.1",
+            "bs58": "^4.0.1",
+            "keypair": "^1.0.1",
+            "libp2p-crypto-secp256k1": "~0.2.2",
+            "multihashing-async": "~0.4.7",
+            "node-forge": "^0.7.1",
+            "pem-jwk": "^1.5.1",
+            "protons": "^1.0.1",
+            "rsa-pem-to-jwk": "^1.1.3",
+            "tweetnacl": "^1.0.0",
+            "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
+          }
+        },
+        "multihashing-async": {
+          "version": "0.4.8",
+          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.4.8.tgz",
+          "integrity": "sha512-LCc4lfxmTJOHKIjZjFNgvmfB6nXS/ErLInT9uwU8udFrRm2PH+aTPk3mfCREKmCiSHOlCWiv2O8rlnBx+OjlMw==",
+          "dev": true,
+          "requires": {
+            "async": "^2.6.0",
+            "blakejs": "^1.1.0",
+            "js-sha3": "^0.7.0",
+            "multihashes": "~0.4.13",
+            "murmurhash3js": "^3.0.1",
+            "nodeify": "^1.0.1"
+          }
+        },
+        "peer-id": {
+          "version": "0.10.7",
+          "resolved": "https://registry.npmjs.org/peer-id/-/peer-id-0.10.7.tgz",
+          "integrity": "sha512-VEpMFcL9q0NQijmR0jsj38OGbY4yzaWMEareVkDahopmlNT+Cpsot8btPgsgBBApP9NiZj2Enwvh8rZN30ocQw==",
+          "dev": true,
+          "requires": {
+            "async": "^2.6.0",
+            "libp2p-crypto": "~0.12.1",
+            "lodash": "^4.17.5",
+            "multihashes": "~0.4.13"
+          }
+        },
+        "tweetnacl": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.0.tgz",
+          "integrity": "sha1-cT2LgY2kIGh0C/aDhtBHnmb8ins=",
+          "dev": true
+        }
+      }
+    },
+    "libp2p-bootstrap": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/libp2p-bootstrap/-/libp2p-bootstrap-0.9.3.tgz",
+      "integrity": "sha512-rEVvZZCKmoJlfgSMk7JkuvsdKGpLkoPK3U47xtT+pNJC+p/LZcjSmGwxNwwJvgg3jTuy2sl23W6JRZ26AXv7Og==",
+      "dev": true,
+      "requires": {
+        "async": "^2.6.1",
+        "debug": "^3.1.0",
+        "mafmt": "^6.0.0",
+        "multiaddr": "^5.0.0",
+        "peer-id": "~0.10.7",
+        "peer-info": "~0.14.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "libp2p-crypto": {
+          "version": "0.12.1",
+          "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.12.1.tgz",
+          "integrity": "sha512-1/z8rxZ0DcQNreZhEsl7PnLr7DWOioSvYbKBLGkRwNRiNh1JJLgh0PdTySBb44wkrOGT+TxcGRd7iq3/X6Wxwg==",
+          "dev": true,
+          "requires": {
+            "asn1.js": "^5.0.0",
+            "async": "^2.6.0",
+            "browserify-aes": "^1.1.1",
+            "bs58": "^4.0.1",
+            "keypair": "^1.0.1",
+            "libp2p-crypto-secp256k1": "~0.2.2",
+            "multihashing-async": "~0.4.7",
+            "node-forge": "^0.7.1",
+            "pem-jwk": "^1.5.1",
+            "protons": "^1.0.1",
+            "rsa-pem-to-jwk": "^1.1.3",
+            "tweetnacl": "^1.0.0",
+            "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
+          }
+        },
+        "multihashing-async": {
+          "version": "0.4.8",
+          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.4.8.tgz",
+          "integrity": "sha512-LCc4lfxmTJOHKIjZjFNgvmfB6nXS/ErLInT9uwU8udFrRm2PH+aTPk3mfCREKmCiSHOlCWiv2O8rlnBx+OjlMw==",
+          "dev": true,
+          "requires": {
+            "async": "^2.6.0",
+            "blakejs": "^1.1.0",
+            "js-sha3": "^0.7.0",
+            "multihashes": "~0.4.13",
+            "murmurhash3js": "^3.0.1",
+            "nodeify": "^1.0.1"
+          }
+        },
+        "peer-id": {
+          "version": "0.10.7",
+          "resolved": "https://registry.npmjs.org/peer-id/-/peer-id-0.10.7.tgz",
+          "integrity": "sha512-VEpMFcL9q0NQijmR0jsj38OGbY4yzaWMEareVkDahopmlNT+Cpsot8btPgsgBBApP9NiZj2Enwvh8rZN30ocQw==",
+          "dev": true,
+          "requires": {
+            "async": "^2.6.0",
+            "libp2p-crypto": "~0.12.1",
+            "lodash": "^4.17.5",
+            "multihashes": "~0.4.13"
+          }
+        },
+        "tweetnacl": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.0.tgz",
+          "integrity": "sha1-cT2LgY2kIGh0C/aDhtBHnmb8ins=",
+          "dev": true
+        }
       }
     },
     "libp2p-circuit": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/libp2p-circuit/-/libp2p-circuit-0.1.5.tgz",
-      "integrity": "sha512-0aUhyceJjpmB+lo0InYuzLP5NPWjkdga8LoZ0Gw1Qm+ghPOXk/plPBUH4urLT84H10aPb/OETyG9i1+uQQPxFA==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/libp2p-circuit/-/libp2p-circuit-0.2.0.tgz",
+      "integrity": "sha512-K3k+ojqO8b1VM1C2Nb+ba+8z7lDD1pn6stieIB3pOEB35M9pVbXfVg8nKoSnjw3NAXCSsSCbD1swYMwq8g/fAA==",
       "dev": true,
       "requires": {
         "assert": "^1.4.1",
@@ -6413,17 +7045,113 @@
         "debug": "^3.1.0",
         "interface-connection": "^0.3.2",
         "lodash": "^4.17.5",
-        "mafmt": "^4.0.0",
-        "multiaddr": "^3.0.2",
+        "mafmt": "^6.0.0",
+        "multiaddr": "^4.0.0",
         "multistream-select": "^0.14.1",
-        "peer-id": "^0.10.6",
-        "peer-info": "^0.11.6",
+        "peer-id": "^0.10.7",
+        "peer-info": "^0.14.0",
         "protons": "^1.0.1",
         "pull-abortable": "^4.1.1",
         "pull-handshake": "^1.1.4",
-        "pull-stream": "^3.6.2",
+        "pull-stream": "^3.6.7",
         "safe-buffer": "^5.1.1",
         "setimmediate": "^1.0.5"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "libp2p-crypto": {
+          "version": "0.12.1",
+          "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.12.1.tgz",
+          "integrity": "sha512-1/z8rxZ0DcQNreZhEsl7PnLr7DWOioSvYbKBLGkRwNRiNh1JJLgh0PdTySBb44wkrOGT+TxcGRd7iq3/X6Wxwg==",
+          "dev": true,
+          "requires": {
+            "asn1.js": "^5.0.0",
+            "async": "^2.6.0",
+            "browserify-aes": "^1.1.1",
+            "bs58": "^4.0.1",
+            "keypair": "^1.0.1",
+            "libp2p-crypto-secp256k1": "~0.2.2",
+            "multihashing-async": "~0.4.7",
+            "node-forge": "^0.7.1",
+            "pem-jwk": "^1.5.1",
+            "protons": "^1.0.1",
+            "rsa-pem-to-jwk": "^1.1.3",
+            "tweetnacl": "^1.0.0",
+            "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
+          }
+        },
+        "multiaddr": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-4.0.0.tgz",
+          "integrity": "sha512-zUatrOCfBd/tJNOSoJ10d2EI2FDXB9PyPZhqUMdXE9mOyR3C+HLuOjga2Ga/eChwvEHIpTYRMoIKF2Nv7af2qQ==",
+          "dev": true,
+          "requires": {
+            "bs58": "^4.0.1",
+            "class-is": "^1.1.0",
+            "ip": "^1.1.5",
+            "ip-address": "^5.8.9",
+            "lodash.filter": "^4.6.0",
+            "lodash.map": "^4.6.0",
+            "varint": "^5.0.0",
+            "xtend": "^4.0.1"
+          }
+        },
+        "multihashing-async": {
+          "version": "0.4.8",
+          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.4.8.tgz",
+          "integrity": "sha512-LCc4lfxmTJOHKIjZjFNgvmfB6nXS/ErLInT9uwU8udFrRm2PH+aTPk3mfCREKmCiSHOlCWiv2O8rlnBx+OjlMw==",
+          "dev": true,
+          "requires": {
+            "async": "^2.6.0",
+            "blakejs": "^1.1.0",
+            "js-sha3": "^0.7.0",
+            "multihashes": "~0.4.13",
+            "murmurhash3js": "^3.0.1",
+            "nodeify": "^1.0.1"
+          }
+        },
+        "peer-id": {
+          "version": "0.10.7",
+          "resolved": "https://registry.npmjs.org/peer-id/-/peer-id-0.10.7.tgz",
+          "integrity": "sha512-VEpMFcL9q0NQijmR0jsj38OGbY4yzaWMEareVkDahopmlNT+Cpsot8btPgsgBBApP9NiZj2Enwvh8rZN30ocQw==",
+          "dev": true,
+          "requires": {
+            "async": "^2.6.0",
+            "libp2p-crypto": "~0.12.1",
+            "lodash": "^4.17.5",
+            "multihashes": "~0.4.13"
+          }
+        },
+        "tweetnacl": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.0.tgz",
+          "integrity": "sha1-cT2LgY2kIGh0C/aDhtBHnmb8ins=",
+          "dev": true
+        },
+        "xtend": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+          "dev": true
+        }
+      }
+    },
+    "libp2p-connection-manager": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/libp2p-connection-manager/-/libp2p-connection-manager-0.0.2.tgz",
+      "integrity": "sha512-G/OzMfxQe0lHx7ujibPqpFLCeMN9I5vNH0+Rs9zat6+uIT51Saupx95lyoyh5J8nh93ui2cNH7PQnwJMZVKa1A==",
+      "dev": true,
+      "requires": {
+        "debug": "^3.1.0",
+        "latency-monitor": "^0.2.1"
       },
       "dependencies": {
         "debug": {
@@ -6438,19 +7166,19 @@
       }
     },
     "libp2p-crypto": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.12.1.tgz",
-      "integrity": "sha512-1/z8rxZ0DcQNreZhEsl7PnLr7DWOioSvYbKBLGkRwNRiNh1JJLgh0PdTySBb44wkrOGT+TxcGRd7iq3/X6Wxwg==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.13.0.tgz",
+      "integrity": "sha512-i3r1TBec/xYmC5bcpPiIs3OyUAU3iy53OdRdxqawKoWTQPjYB+TyQ4w+otT66Y0sMcw70O0wH3GFAfPmQgFn+g==",
       "dev": true,
       "requires": {
         "asn1.js": "^5.0.0",
         "async": "^2.6.0",
-        "browserify-aes": "^1.1.1",
+        "browserify-aes": "^1.2.0",
         "bs58": "^4.0.1",
         "keypair": "^1.0.1",
         "libp2p-crypto-secp256k1": "~0.2.2",
-        "multihashing-async": "~0.4.7",
-        "node-forge": "^0.7.1",
+        "multihashing-async": "~0.4.8",
+        "node-forge": "^0.7.5",
         "pem-jwk": "^1.5.1",
         "protons": "^1.0.1",
         "rsa-pem-to-jwk": "^1.1.3",
@@ -6458,6 +7186,20 @@
         "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
       },
       "dependencies": {
+        "multihashing-async": {
+          "version": "0.4.8",
+          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.4.8.tgz",
+          "integrity": "sha512-LCc4lfxmTJOHKIjZjFNgvmfB6nXS/ErLInT9uwU8udFrRm2PH+aTPk3mfCREKmCiSHOlCWiv2O8rlnBx+OjlMw==",
+          "dev": true,
+          "requires": {
+            "async": "^2.6.0",
+            "blakejs": "^1.1.0",
+            "js-sha3": "^0.7.0",
+            "multihashes": "~0.4.13",
+            "murmurhash3js": "^3.0.1",
+            "nodeify": "^1.0.1"
+          }
+        },
         "tweetnacl": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.0.tgz",
@@ -6477,22 +7219,38 @@
         "nodeify": "^1.0.1",
         "safe-buffer": "^5.1.1",
         "secp256k1": "^3.3.0"
+      },
+      "dependencies": {
+        "multihashing-async": {
+          "version": "0.4.8",
+          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.4.8.tgz",
+          "integrity": "sha512-LCc4lfxmTJOHKIjZjFNgvmfB6nXS/ErLInT9uwU8udFrRm2PH+aTPk3mfCREKmCiSHOlCWiv2O8rlnBx+OjlMw==",
+          "dev": true,
+          "requires": {
+            "async": "^2.6.0",
+            "blakejs": "^1.1.0",
+            "js-sha3": "^0.7.0",
+            "multihashes": "~0.4.13",
+            "murmurhash3js": "^3.0.1",
+            "nodeify": "^1.0.1"
+          }
+        }
       }
     },
     "libp2p-floodsub": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/libp2p-floodsub/-/libp2p-floodsub-0.14.1.tgz",
-      "integrity": "sha512-MxdKgD/1dWlQjT4WVlirAHq0QAczGjC/P0SLpoYRna/RZqEmkOuiJfUEwqWWZXENVBuyQep8Ry3yLKt67xJfVg==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/libp2p-floodsub/-/libp2p-floodsub-0.15.0.tgz",
+      "integrity": "sha512-sDVNxE6GKOZ7+qWE06jQuJ/CrYgPfOqkRD4qWPFe02AtghswyocWJkDiceKHx++mW2h2KYl7ae68XK0DLEEOiw==",
       "dev": true,
       "requires": {
         "async": "^2.6.0",
         "bs58": "^4.0.1",
         "debug": "^3.1.0",
-        "length-prefixed-stream": "^1.5.1",
-        "libp2p-crypto": "~0.12.1",
+        "length-prefixed-stream": "^1.5.2",
+        "libp2p-crypto": "~0.13.0",
         "lodash.values": "^4.3.0",
         "protons": "^1.0.1",
-        "pull-pushable": "^2.1.2",
+        "pull-pushable": "^2.2.0",
         "time-cache": "~0.3.0"
       },
       "dependencies": {
@@ -6508,43 +7266,97 @@
       }
     },
     "libp2p-identify": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/libp2p-identify/-/libp2p-identify-0.6.3.tgz",
-      "integrity": "sha512-tCkobHxmK636lCF3PwIA/G8Ty7KGFVT/WW7zaNUUypMKJKT9gZg9U1d+BVTM2xA4TUYSnt8TTY6WgKeUfDffHg==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/libp2p-identify/-/libp2p-identify-0.7.1.tgz",
+      "integrity": "sha512-uQh04s5s2v6JbhdzeKdQqaOGmEMlZv60djMR74MPkerNPFLcJEHHyVXcD35CgMVaZezqai2Y8L2zvPuuOnUZtA==",
       "dev": true,
       "requires": {
-        "multiaddr": "^3.0.2",
-        "peer-id": "~0.10.5",
-        "peer-info": "~0.11.6",
+        "multiaddr": "^5.0.0",
+        "peer-id": "~0.10.7",
+        "peer-info": "~0.14.1",
         "protons": "^1.0.1",
         "pull-length-prefixed": "^1.3.0",
-        "pull-stream": "^3.6.1"
+        "pull-stream": "^3.6.7"
+      },
+      "dependencies": {
+        "libp2p-crypto": {
+          "version": "0.12.1",
+          "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.12.1.tgz",
+          "integrity": "sha512-1/z8rxZ0DcQNreZhEsl7PnLr7DWOioSvYbKBLGkRwNRiNh1JJLgh0PdTySBb44wkrOGT+TxcGRd7iq3/X6Wxwg==",
+          "dev": true,
+          "requires": {
+            "asn1.js": "^5.0.0",
+            "async": "^2.6.0",
+            "browserify-aes": "^1.1.1",
+            "bs58": "^4.0.1",
+            "keypair": "^1.0.1",
+            "libp2p-crypto-secp256k1": "~0.2.2",
+            "multihashing-async": "~0.4.7",
+            "node-forge": "^0.7.1",
+            "pem-jwk": "^1.5.1",
+            "protons": "^1.0.1",
+            "rsa-pem-to-jwk": "^1.1.3",
+            "tweetnacl": "^1.0.0",
+            "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
+          }
+        },
+        "multihashing-async": {
+          "version": "0.4.8",
+          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.4.8.tgz",
+          "integrity": "sha512-LCc4lfxmTJOHKIjZjFNgvmfB6nXS/ErLInT9uwU8udFrRm2PH+aTPk3mfCREKmCiSHOlCWiv2O8rlnBx+OjlMw==",
+          "dev": true,
+          "requires": {
+            "async": "^2.6.0",
+            "blakejs": "^1.1.0",
+            "js-sha3": "^0.7.0",
+            "multihashes": "~0.4.13",
+            "murmurhash3js": "^3.0.1",
+            "nodeify": "^1.0.1"
+          }
+        },
+        "peer-id": {
+          "version": "0.10.7",
+          "resolved": "https://registry.npmjs.org/peer-id/-/peer-id-0.10.7.tgz",
+          "integrity": "sha512-VEpMFcL9q0NQijmR0jsj38OGbY4yzaWMEareVkDahopmlNT+Cpsot8btPgsgBBApP9NiZj2Enwvh8rZN30ocQw==",
+          "dev": true,
+          "requires": {
+            "async": "^2.6.0",
+            "libp2p-crypto": "~0.12.1",
+            "lodash": "^4.17.5",
+            "multihashes": "~0.4.13"
+          }
+        },
+        "tweetnacl": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.0.tgz",
+          "integrity": "sha1-cT2LgY2kIGh0C/aDhtBHnmb8ins=",
+          "dev": true
+        }
       }
     },
     "libp2p-kad-dht": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/libp2p-kad-dht/-/libp2p-kad-dht-0.8.0.tgz",
-      "integrity": "sha512-eVpOFz2nvAG/zcusWSU2uBQFyD+jbmDIXOtdAlYDJiwKvXkfZ3wWmzmePEaM+vzr/zI2srtWH0WeMMJkR7HgkQ==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/libp2p-kad-dht/-/libp2p-kad-dht-0.10.0.tgz",
+      "integrity": "sha512-JbudRVI6iTFcQ+YtO+BByslR5uASKi5gEWadhDwZNuVlpSlNx177QiOb4uxxLVdo/JR13ulppMdUHFgVFXZiLA==",
       "dev": true,
       "requires": {
         "async": "^2.6.0",
         "base32.js": "^0.1.0",
-        "cids": "~0.5.2",
+        "cids": "~0.5.3",
         "debug": "^3.1.0",
         "hashlru": "^2.2.1",
         "heap": "^0.2.6",
         "interface-datastore": "~0.4.2",
-        "k-bucket": "^3.3.1",
-        "libp2p-crypto": "~0.12.0",
+        "k-bucket": "^4.0.0",
+        "libp2p-crypto": "~0.13.0",
         "libp2p-record": "~0.5.1",
-        "multihashing-async": "~0.4.7",
-        "peer-id": "~0.10.5",
-        "peer-info": "~0.11.6",
-        "priorityqueue": "^0.2.0",
+        "multihashing-async": "~0.4.8",
+        "peer-id": "~0.10.7",
+        "peer-info": "~0.14.0",
+        "priorityqueue": "^0.2.1",
         "protons": "^1.0.1",
         "pull-length-prefixed": "^1.3.0",
-        "pull-stream": "^3.6.1",
-        "safe-buffer": "^5.1.1",
+        "pull-stream": "^3.6.7",
         "varint": "^5.0.0",
         "xor-distance": "^1.0.0"
       },
@@ -6557,6 +7369,61 @@
           "requires": {
             "ms": "2.0.0"
           }
+        },
+        "multihashing-async": {
+          "version": "0.4.8",
+          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.4.8.tgz",
+          "integrity": "sha512-LCc4lfxmTJOHKIjZjFNgvmfB6nXS/ErLInT9uwU8udFrRm2PH+aTPk3mfCREKmCiSHOlCWiv2O8rlnBx+OjlMw==",
+          "dev": true,
+          "requires": {
+            "async": "^2.6.0",
+            "blakejs": "^1.1.0",
+            "js-sha3": "^0.7.0",
+            "multihashes": "~0.4.13",
+            "murmurhash3js": "^3.0.1",
+            "nodeify": "^1.0.1"
+          }
+        },
+        "peer-id": {
+          "version": "0.10.7",
+          "resolved": "https://registry.npmjs.org/peer-id/-/peer-id-0.10.7.tgz",
+          "integrity": "sha512-VEpMFcL9q0NQijmR0jsj38OGbY4yzaWMEareVkDahopmlNT+Cpsot8btPgsgBBApP9NiZj2Enwvh8rZN30ocQw==",
+          "dev": true,
+          "requires": {
+            "async": "^2.6.0",
+            "libp2p-crypto": "~0.12.1",
+            "lodash": "^4.17.5",
+            "multihashes": "~0.4.13"
+          },
+          "dependencies": {
+            "libp2p-crypto": {
+              "version": "0.12.1",
+              "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.12.1.tgz",
+              "integrity": "sha512-1/z8rxZ0DcQNreZhEsl7PnLr7DWOioSvYbKBLGkRwNRiNh1JJLgh0PdTySBb44wkrOGT+TxcGRd7iq3/X6Wxwg==",
+              "dev": true,
+              "requires": {
+                "asn1.js": "^5.0.0",
+                "async": "^2.6.0",
+                "browserify-aes": "^1.1.1",
+                "bs58": "^4.0.1",
+                "keypair": "^1.0.1",
+                "libp2p-crypto-secp256k1": "~0.2.2",
+                "multihashing-async": "~0.4.7",
+                "node-forge": "^0.7.1",
+                "pem-jwk": "^1.5.1",
+                "protons": "^1.0.1",
+                "rsa-pem-to-jwk": "^1.1.3",
+                "tweetnacl": "^1.0.0",
+                "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
+              }
+            }
+          }
+        },
+        "tweetnacl": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.0.tgz",
+          "integrity": "sha1-cT2LgY2kIGh0C/aDhtBHnmb8ins=",
+          "dev": true
         }
       }
     },
@@ -6572,59 +7439,139 @@
         "libp2p-crypto": "~0.12.0",
         "pull-stream": "^3.6.1",
         "sanitize-filename": "^1.6.1"
+      },
+      "dependencies": {
+        "libp2p-crypto": {
+          "version": "0.12.1",
+          "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.12.1.tgz",
+          "integrity": "sha512-1/z8rxZ0DcQNreZhEsl7PnLr7DWOioSvYbKBLGkRwNRiNh1JJLgh0PdTySBb44wkrOGT+TxcGRd7iq3/X6Wxwg==",
+          "dev": true,
+          "requires": {
+            "asn1.js": "^5.0.0",
+            "async": "^2.6.0",
+            "browserify-aes": "^1.1.1",
+            "bs58": "^4.0.1",
+            "keypair": "^1.0.1",
+            "libp2p-crypto-secp256k1": "~0.2.2",
+            "multihashing-async": "~0.4.7",
+            "node-forge": "^0.7.1",
+            "pem-jwk": "^1.5.1",
+            "protons": "^1.0.1",
+            "rsa-pem-to-jwk": "^1.1.3",
+            "tweetnacl": "^1.0.0",
+            "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
+          }
+        },
+        "multihashing-async": {
+          "version": "0.4.8",
+          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.4.8.tgz",
+          "integrity": "sha512-LCc4lfxmTJOHKIjZjFNgvmfB6nXS/ErLInT9uwU8udFrRm2PH+aTPk3mfCREKmCiSHOlCWiv2O8rlnBx+OjlMw==",
+          "dev": true,
+          "requires": {
+            "async": "^2.6.0",
+            "blakejs": "^1.1.0",
+            "js-sha3": "^0.7.0",
+            "multihashes": "~0.4.13",
+            "murmurhash3js": "^3.0.1",
+            "nodeify": "^1.0.1"
+          }
+        },
+        "tweetnacl": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.0.tgz",
+          "integrity": "sha1-cT2LgY2kIGh0C/aDhtBHnmb8ins=",
+          "dev": true
+        }
       }
     },
     "libp2p-mdns": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/libp2p-mdns/-/libp2p-mdns-0.9.2.tgz",
-      "integrity": "sha512-g77yK3znf4bZl6466EOs1MGP9Pqv4gEcsCnuDaSiWtZ4bZOApkGS/gWQBY3vaCbP1faJ5m7b83uBlEeHiT61cA==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/libp2p-mdns/-/libp2p-mdns-0.12.0.tgz",
+      "integrity": "sha512-2K1IT8ZwnzS00Ws6MiLW89W2KAG+8NsrMez2laVZJtD9RpWBgc9+KGQ7KU1nYRyYXD/NGXNEiQ6HTkhSQvYbiQ==",
       "dev": true,
       "requires": {
-        "libp2p-tcp": "~0.11.2",
-        "multiaddr": "^3.0.2",
-        "multicast-dns": "^6.2.3",
-        "peer-id": "~0.10.5",
-        "peer-info": "~0.11.6"
+        "libp2p-tcp": "~0.12.0",
+        "multiaddr": "^5.0.0",
+        "multicast-dns": "^7.0.0",
+        "peer-id": "~0.10.7",
+        "peer-info": "~0.14.1"
+      },
+      "dependencies": {
+        "libp2p-crypto": {
+          "version": "0.12.1",
+          "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.12.1.tgz",
+          "integrity": "sha512-1/z8rxZ0DcQNreZhEsl7PnLr7DWOioSvYbKBLGkRwNRiNh1JJLgh0PdTySBb44wkrOGT+TxcGRd7iq3/X6Wxwg==",
+          "dev": true,
+          "requires": {
+            "asn1.js": "^5.0.0",
+            "async": "^2.6.0",
+            "browserify-aes": "^1.1.1",
+            "bs58": "^4.0.1",
+            "keypair": "^1.0.1",
+            "libp2p-crypto-secp256k1": "~0.2.2",
+            "multihashing-async": "~0.4.7",
+            "node-forge": "^0.7.1",
+            "pem-jwk": "^1.5.1",
+            "protons": "^1.0.1",
+            "rsa-pem-to-jwk": "^1.1.3",
+            "tweetnacl": "^1.0.0",
+            "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
+          }
+        },
+        "multihashing-async": {
+          "version": "0.4.8",
+          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.4.8.tgz",
+          "integrity": "sha512-LCc4lfxmTJOHKIjZjFNgvmfB6nXS/ErLInT9uwU8udFrRm2PH+aTPk3mfCREKmCiSHOlCWiv2O8rlnBx+OjlMw==",
+          "dev": true,
+          "requires": {
+            "async": "^2.6.0",
+            "blakejs": "^1.1.0",
+            "js-sha3": "^0.7.0",
+            "multihashes": "~0.4.13",
+            "murmurhash3js": "^3.0.1",
+            "nodeify": "^1.0.1"
+          }
+        },
+        "peer-id": {
+          "version": "0.10.7",
+          "resolved": "https://registry.npmjs.org/peer-id/-/peer-id-0.10.7.tgz",
+          "integrity": "sha512-VEpMFcL9q0NQijmR0jsj38OGbY4yzaWMEareVkDahopmlNT+Cpsot8btPgsgBBApP9NiZj2Enwvh8rZN30ocQw==",
+          "dev": true,
+          "requires": {
+            "async": "^2.6.0",
+            "libp2p-crypto": "~0.12.1",
+            "lodash": "^4.17.5",
+            "multihashes": "~0.4.13"
+          }
+        },
+        "tweetnacl": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.0.tgz",
+          "integrity": "sha1-cT2LgY2kIGh0C/aDhtBHnmb8ins=",
+          "dev": true
+        }
       }
     },
-    "libp2p-multiplex": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/libp2p-multiplex/-/libp2p-multiplex-0.5.1.tgz",
-      "integrity": "sha512-XZagf1B31Vkbd+iAai8cOfRkcZWba+MtSRf/xQJ7uOz7O4heLMNC4orcDqT0n+Hkkn3zfqllH75Kp1xJ+Vog2w==",
+    "libp2p-mplex": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/libp2p-mplex/-/libp2p-mplex-0.8.0.tgz",
+      "integrity": "sha512-bjpHYqyxYNsnyKRgeATVU8u1wnP1vV/rEL+TOuVCv9WBnUPBifL9e+ggbEQtIQfZDsiDl3l43i8MJDuRKOag7A==",
       "dev": true,
       "requires": {
-        "async": "^2.6.0",
-        "multiplex": "github:dignifiedquire/multiplex#b5d5edd30454e2c978ee8c52df86f5f4840d2eab",
+        "async": "^2.6.1",
+        "chunky": "0.0.0",
+        "concat-stream": "^1.6.2",
+        "debug": "^3.1.0",
+        "duplexify": "^3.6.0",
+        "interface-connection": "~0.3.2",
         "pull-catch": "^1.0.0",
-        "pull-stream": "^3.6.1",
+        "pull-stream": "^3.6.8",
         "pull-stream-to-stream": "^1.3.4",
-        "pump": "^2.0.0",
-        "stream-to-pull-stream": "^1.7.2"
-      }
-    },
-    "libp2p-ping": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/libp2p-ping/-/libp2p-ping-0.6.1.tgz",
-      "integrity": "sha512-1u+77pedHwEqGp4LELBsYtjXrZSmXMGoPpfNAXLq0jyai4F54rvDAMin78VQlYbvNB2oz10KrOD34IlV3Cna1w==",
-      "dev": true,
-      "requires": {
-        "libp2p-crypto": "~0.12.1",
-        "pull-handshake": "^1.1.4",
-        "pull-stream": "^3.6.1"
-      }
-    },
-    "libp2p-railing": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/libp2p-railing/-/libp2p-railing-0.7.1.tgz",
-      "integrity": "sha512-IrmBwIhaXpeTMCSoJTTtUPUumO/tQdTV9cmc98rEm+dgJ9Lfl7LgOMQWUdBAcqUC2mrFmBElAphV19DR7jYU1g==",
-      "dev": true,
-      "requires": {
-        "async": "^2.5.0",
-        "debug": "^3.0.1",
-        "lodash": "^4.17.4",
-        "multiaddr": "^3.0.1",
-        "peer-id": "~0.10.1",
-        "peer-info": "~0.11.0"
+        "pump": "^3.0.0",
+        "readable-stream": "^2.3.6",
+        "stream-to-pull-stream": "^1.7.2",
+        "through2": "^2.0.3",
+        "varint": "^5.0.0"
       },
       "dependencies": {
         "debug": {
@@ -6635,7 +7582,28 @@
           "requires": {
             "ms": "2.0.0"
           }
+        },
+        "pump": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+          "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+          "dev": true,
+          "requires": {
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
+          }
         }
+      }
+    },
+    "libp2p-ping": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/libp2p-ping/-/libp2p-ping-0.8.0.tgz",
+      "integrity": "sha512-7GtCCvbs6sEabnjh2ZIdru8wuKP4Qux6alw7wuaMosqWkPeFnnFmQsGaWEGpwEmD49A1dsT+aIYvAx5jFB02Bw==",
+      "dev": true,
+      "requires": {
+        "libp2p-crypto": "~0.13.0",
+        "pull-handshake": "^1.1.4",
+        "pull-stream": "^3.6.7"
       }
     },
     "libp2p-record": {
@@ -6651,12 +7619,67 @@
         "multihashing-async": "~0.4.6",
         "peer-id": "~0.10.0",
         "protons": "^1.0.0"
+      },
+      "dependencies": {
+        "libp2p-crypto": {
+          "version": "0.12.1",
+          "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.12.1.tgz",
+          "integrity": "sha512-1/z8rxZ0DcQNreZhEsl7PnLr7DWOioSvYbKBLGkRwNRiNh1JJLgh0PdTySBb44wkrOGT+TxcGRd7iq3/X6Wxwg==",
+          "dev": true,
+          "requires": {
+            "asn1.js": "^5.0.0",
+            "async": "^2.6.0",
+            "browserify-aes": "^1.1.1",
+            "bs58": "^4.0.1",
+            "keypair": "^1.0.1",
+            "libp2p-crypto-secp256k1": "~0.2.2",
+            "multihashing-async": "~0.4.7",
+            "node-forge": "^0.7.1",
+            "pem-jwk": "^1.5.1",
+            "protons": "^1.0.1",
+            "rsa-pem-to-jwk": "^1.1.3",
+            "tweetnacl": "^1.0.0",
+            "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
+          }
+        },
+        "multihashing-async": {
+          "version": "0.4.8",
+          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.4.8.tgz",
+          "integrity": "sha512-LCc4lfxmTJOHKIjZjFNgvmfB6nXS/ErLInT9uwU8udFrRm2PH+aTPk3mfCREKmCiSHOlCWiv2O8rlnBx+OjlMw==",
+          "dev": true,
+          "requires": {
+            "async": "^2.6.0",
+            "blakejs": "^1.1.0",
+            "js-sha3": "^0.7.0",
+            "multihashes": "~0.4.13",
+            "murmurhash3js": "^3.0.1",
+            "nodeify": "^1.0.1"
+          }
+        },
+        "peer-id": {
+          "version": "0.10.7",
+          "resolved": "https://registry.npmjs.org/peer-id/-/peer-id-0.10.7.tgz",
+          "integrity": "sha512-VEpMFcL9q0NQijmR0jsj38OGbY4yzaWMEareVkDahopmlNT+Cpsot8btPgsgBBApP9NiZj2Enwvh8rZN30ocQw==",
+          "dev": true,
+          "requires": {
+            "async": "^2.6.0",
+            "libp2p-crypto": "~0.12.1",
+            "lodash": "^4.17.5",
+            "multihashes": "~0.4.13"
+          }
+        },
+        "tweetnacl": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.0.tgz",
+          "integrity": "sha1-cT2LgY2kIGh0C/aDhtBHnmb8ins=",
+          "dev": true
+        }
       }
     },
     "libp2p-secio": {
-      "version": "0.9.4",
-      "resolved": "https://registry.npmjs.org/libp2p-secio/-/libp2p-secio-0.9.4.tgz",
-      "integrity": "sha512-tbeOi5pk+eSTrOmE8dB/3cEaNATAkpOktwTKGuY72azBepcJWW2d9etAUTJMUGM6GAcf8kqenI8ZarcCz6Eydg==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/libp2p-secio/-/libp2p-secio-0.10.0.tgz",
+      "integrity": "sha512-/0nirr4UBdQBbETBliGYD6mLzKl+ZUX+2Kzmpk98Pdjdam5W2IhLF8zSeeK6Z4d/gJOaLdf2H8C6wLrwOSil8A==",
       "dev": true,
       "requires": {
         "async": "^2.6.0",
@@ -6664,8 +7687,8 @@
         "interface-connection": "~0.3.2",
         "libp2p-crypto": "~0.12.1",
         "multihashing-async": "~0.4.8",
-        "peer-id": "~0.10.6",
-        "peer-info": "^0.11.6",
+        "peer-id": "~0.10.7",
+        "peer-info": "^0.14.0",
         "protons": "^1.0.1",
         "pull-defer": "^0.2.2",
         "pull-handshake": "^1.1.4",
@@ -6681,30 +7704,92 @@
           "requires": {
             "ms": "2.0.0"
           }
+        },
+        "libp2p-crypto": {
+          "version": "0.12.1",
+          "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.12.1.tgz",
+          "integrity": "sha512-1/z8rxZ0DcQNreZhEsl7PnLr7DWOioSvYbKBLGkRwNRiNh1JJLgh0PdTySBb44wkrOGT+TxcGRd7iq3/X6Wxwg==",
+          "dev": true,
+          "requires": {
+            "asn1.js": "^5.0.0",
+            "async": "^2.6.0",
+            "browserify-aes": "^1.1.1",
+            "bs58": "^4.0.1",
+            "keypair": "^1.0.1",
+            "libp2p-crypto-secp256k1": "~0.2.2",
+            "multihashing-async": "~0.4.7",
+            "node-forge": "^0.7.1",
+            "pem-jwk": "^1.5.1",
+            "protons": "^1.0.1",
+            "rsa-pem-to-jwk": "^1.1.3",
+            "tweetnacl": "^1.0.0",
+            "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
+          }
+        },
+        "multihashing-async": {
+          "version": "0.4.8",
+          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.4.8.tgz",
+          "integrity": "sha512-LCc4lfxmTJOHKIjZjFNgvmfB6nXS/ErLInT9uwU8udFrRm2PH+aTPk3mfCREKmCiSHOlCWiv2O8rlnBx+OjlMw==",
+          "dev": true,
+          "requires": {
+            "async": "^2.6.0",
+            "blakejs": "^1.1.0",
+            "js-sha3": "^0.7.0",
+            "multihashes": "~0.4.13",
+            "murmurhash3js": "^3.0.1",
+            "nodeify": "^1.0.1"
+          }
+        },
+        "peer-id": {
+          "version": "0.10.7",
+          "resolved": "https://registry.npmjs.org/peer-id/-/peer-id-0.10.7.tgz",
+          "integrity": "sha512-VEpMFcL9q0NQijmR0jsj38OGbY4yzaWMEareVkDahopmlNT+Cpsot8btPgsgBBApP9NiZj2Enwvh8rZN30ocQw==",
+          "dev": true,
+          "requires": {
+            "async": "^2.6.0",
+            "libp2p-crypto": "~0.12.1",
+            "lodash": "^4.17.5",
+            "multihashes": "~0.4.13"
+          }
+        },
+        "tweetnacl": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.0.tgz",
+          "integrity": "sha1-cT2LgY2kIGh0C/aDhtBHnmb8ins=",
+          "dev": true
         }
       }
     },
     "libp2p-switch": {
-      "version": "0.36.1",
-      "resolved": "https://registry.npmjs.org/libp2p-switch/-/libp2p-switch-0.36.1.tgz",
-      "integrity": "sha512-rVlxKQJ0h5W7T2ugpwyE8KaCUZJ9lLJVxwCCMV3tkc6ziF0L/lREIfM731yJS9ubdUyRFTgn6F2RlgcTwqfd4A==",
+      "version": "0.40.5",
+      "resolved": "https://registry.npmjs.org/libp2p-switch/-/libp2p-switch-0.40.5.tgz",
+      "integrity": "sha512-D5XVm6IkH4AL5RoS2yN7YeFJgQrSXaaohxCCwpagoGTsfOrHqvQmK2+0T90/PoQBjllmmtVqh3LQQY0fraTyJA==",
       "dev": true,
       "requires": {
         "async": "^2.6.0",
+        "big.js": "^5.1.2",
         "debug": "^3.1.0",
+        "hashlru": "^2.2.1",
         "interface-connection": "~0.3.2",
         "ip-address": "^5.8.9",
-        "libp2p-circuit": "~0.1.4",
-        "libp2p-identify": "~0.6.3",
+        "libp2p-circuit": "~0.2.0",
+        "libp2p-identify": "~0.7.1",
         "lodash.includes": "^4.3.0",
-        "multiaddr": "^3.0.2",
-        "multistream-select": "~0.14.1",
+        "moving-average": "^1.0.0",
+        "multiaddr": "^5.0.0",
+        "multistream-select": "~0.14.2",
         "once": "^1.4.0",
-        "peer-id": "~0.10.6",
-        "peer-info": "~0.11.6",
-        "pull-stream": "^3.6.1"
+        "peer-id": "~0.10.7",
+        "peer-info": "~0.14.1",
+        "pull-stream": "^3.6.7"
       },
       "dependencies": {
+        "big.js": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.1.2.tgz",
+          "integrity": "sha512-qG6ZOc1lY84Bn8p/z9xvJisj9F4PRyo0pOGqGNYc7gS3p1WciS/3XcLuNI3Z/yYZpMNFhHeX3YNENwgrQq0NTA==",
+          "dev": true
+        },
         "debug": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
@@ -6713,22 +7798,76 @@
           "requires": {
             "ms": "2.0.0"
           }
+        },
+        "libp2p-crypto": {
+          "version": "0.12.1",
+          "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.12.1.tgz",
+          "integrity": "sha512-1/z8rxZ0DcQNreZhEsl7PnLr7DWOioSvYbKBLGkRwNRiNh1JJLgh0PdTySBb44wkrOGT+TxcGRd7iq3/X6Wxwg==",
+          "dev": true,
+          "requires": {
+            "asn1.js": "^5.0.0",
+            "async": "^2.6.0",
+            "browserify-aes": "^1.1.1",
+            "bs58": "^4.0.1",
+            "keypair": "^1.0.1",
+            "libp2p-crypto-secp256k1": "~0.2.2",
+            "multihashing-async": "~0.4.7",
+            "node-forge": "^0.7.1",
+            "pem-jwk": "^1.5.1",
+            "protons": "^1.0.1",
+            "rsa-pem-to-jwk": "^1.1.3",
+            "tweetnacl": "^1.0.0",
+            "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
+          }
+        },
+        "multihashing-async": {
+          "version": "0.4.8",
+          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.4.8.tgz",
+          "integrity": "sha512-LCc4lfxmTJOHKIjZjFNgvmfB6nXS/ErLInT9uwU8udFrRm2PH+aTPk3mfCREKmCiSHOlCWiv2O8rlnBx+OjlMw==",
+          "dev": true,
+          "requires": {
+            "async": "^2.6.0",
+            "blakejs": "^1.1.0",
+            "js-sha3": "^0.7.0",
+            "multihashes": "~0.4.13",
+            "murmurhash3js": "^3.0.1",
+            "nodeify": "^1.0.1"
+          }
+        },
+        "peer-id": {
+          "version": "0.10.7",
+          "resolved": "https://registry.npmjs.org/peer-id/-/peer-id-0.10.7.tgz",
+          "integrity": "sha512-VEpMFcL9q0NQijmR0jsj38OGbY4yzaWMEareVkDahopmlNT+Cpsot8btPgsgBBApP9NiZj2Enwvh8rZN30ocQw==",
+          "dev": true,
+          "requires": {
+            "async": "^2.6.0",
+            "libp2p-crypto": "~0.12.1",
+            "lodash": "^4.17.5",
+            "multihashes": "~0.4.13"
+          }
+        },
+        "tweetnacl": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.0.tgz",
+          "integrity": "sha1-cT2LgY2kIGh0C/aDhtBHnmb8ins=",
+          "dev": true
         }
       }
     },
     "libp2p-tcp": {
-      "version": "0.11.6",
-      "resolved": "https://registry.npmjs.org/libp2p-tcp/-/libp2p-tcp-0.11.6.tgz",
-      "integrity": "sha512-ob6wIZRmwJ6X7SIZHxjQvqc3wfl/RFPXXK/C94zFi0tEraGK3bvnKdXtZEpb2kYU4fx9RUPEkHV3PJ37/HNCzA==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/libp2p-tcp/-/libp2p-tcp-0.12.0.tgz",
+      "integrity": "sha512-zuq8bpnra1XGUK6DcsiDT0fY2QWoJQBmdQgx6Hz4L2IJTPmGBN3ww3Z8VhSqNaPmm/Dcfs7pug+pamIu3olmuQ==",
       "dev": true,
       "requires": {
+        "class-is": "^1.1.0",
         "debug": "^3.1.0",
         "interface-connection": "~0.3.2",
         "ip-address": "^5.8.9",
         "lodash.includes": "^4.3.0",
         "lodash.isfunction": "^3.0.9",
-        "mafmt": "^4.0.0",
-        "multiaddr": "^3.0.2",
+        "mafmt": "^6.0.0",
+        "multiaddr": "^4.0.0",
         "once": "^1.4.0",
         "stream-to-pull-stream": "^1.7.2"
       },
@@ -6741,32 +7880,55 @@
           "requires": {
             "ms": "2.0.0"
           }
+        },
+        "multiaddr": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-4.0.0.tgz",
+          "integrity": "sha512-zUatrOCfBd/tJNOSoJ10d2EI2FDXB9PyPZhqUMdXE9mOyR3C+HLuOjga2Ga/eChwvEHIpTYRMoIKF2Nv7af2qQ==",
+          "dev": true,
+          "requires": {
+            "bs58": "^4.0.1",
+            "class-is": "^1.1.0",
+            "ip": "^1.1.5",
+            "ip-address": "^5.8.9",
+            "lodash.filter": "^4.6.0",
+            "lodash.map": "^4.6.0",
+            "varint": "^5.0.0",
+            "xtend": "^4.0.1"
+          }
+        },
+        "xtend": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+          "dev": true
         }
       }
     },
     "libp2p-webrtc-star": {
-      "version": "0.13.4",
-      "resolved": "https://registry.npmjs.org/libp2p-webrtc-star/-/libp2p-webrtc-star-0.13.4.tgz",
-      "integrity": "sha512-ZSSWNf2RDZ9kXFEZmMfgdK+r1j6FIv+NGH5VmbRZsPSZnNnod0jvn2z7X45oq9QqTUOxzKUGkh5FIvlPVMV/yg==",
+      "version": "0.15.3",
+      "resolved": "https://registry.npmjs.org/libp2p-webrtc-star/-/libp2p-webrtc-star-0.15.3.tgz",
+      "integrity": "sha512-bt6d9Oxd7/fF8zHybM4xVJKV2tl7+08kyRw+R5YkNbX5lrYT7f0NKWJUBrOrw4BnsIdEn32bDPR/yQNinKm0Vg==",
       "dev": true,
       "requires": {
-        "async": "^2.6.0",
+        "async": "^2.6.1",
+        "class-is": "^1.1.0",
         "debug": "^3.1.0",
         "detect-node": "^2.0.3",
         "epimetheus": "^1.0.55",
         "hapi": "^16.6.2",
         "inert": "^4.2.1",
         "interface-connection": "~0.3.2",
-        "mafmt": "^4.0.0",
+        "mafmt": "^6.0.0",
         "minimist": "^1.2.0",
-        "multiaddr": "^3.0.2",
+        "multiaddr": "^5.0.0",
         "once": "^1.4.0",
-        "peer-id": "~0.10.6",
-        "peer-info": "~0.11.6",
-        "pull-stream": "^3.6.2",
-        "simple-peer": "^8.5.0",
-        "socket.io": "^2.0.4",
-        "socket.io-client": "^2.0.4",
+        "peer-id": "~0.10.7",
+        "peer-info": "~0.14.1",
+        "pull-stream": "^3.6.8",
+        "simple-peer": "^9.1.2",
+        "socket.io": "^2.1.1",
+        "socket.io-client": "^2.1.1",
         "stream-to-pull-stream": "^1.7.2",
         "webrtcsupport": "github:ipfs/webrtcsupport#0669f576582c53a3a42aa5ac014fcc5966809615"
       },
@@ -6779,29 +7941,83 @@
           "requires": {
             "ms": "2.0.0"
           }
+        },
+        "libp2p-crypto": {
+          "version": "0.12.1",
+          "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.12.1.tgz",
+          "integrity": "sha512-1/z8rxZ0DcQNreZhEsl7PnLr7DWOioSvYbKBLGkRwNRiNh1JJLgh0PdTySBb44wkrOGT+TxcGRd7iq3/X6Wxwg==",
+          "dev": true,
+          "requires": {
+            "asn1.js": "^5.0.0",
+            "async": "^2.6.0",
+            "browserify-aes": "^1.1.1",
+            "bs58": "^4.0.1",
+            "keypair": "^1.0.1",
+            "libp2p-crypto-secp256k1": "~0.2.2",
+            "multihashing-async": "~0.4.7",
+            "node-forge": "^0.7.1",
+            "pem-jwk": "^1.5.1",
+            "protons": "^1.0.1",
+            "rsa-pem-to-jwk": "^1.1.3",
+            "tweetnacl": "^1.0.0",
+            "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
+          }
+        },
+        "multihashing-async": {
+          "version": "0.4.8",
+          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.4.8.tgz",
+          "integrity": "sha512-LCc4lfxmTJOHKIjZjFNgvmfB6nXS/ErLInT9uwU8udFrRm2PH+aTPk3mfCREKmCiSHOlCWiv2O8rlnBx+OjlMw==",
+          "dev": true,
+          "requires": {
+            "async": "^2.6.0",
+            "blakejs": "^1.1.0",
+            "js-sha3": "^0.7.0",
+            "multihashes": "~0.4.13",
+            "murmurhash3js": "^3.0.1",
+            "nodeify": "^1.0.1"
+          }
+        },
+        "peer-id": {
+          "version": "0.10.7",
+          "resolved": "https://registry.npmjs.org/peer-id/-/peer-id-0.10.7.tgz",
+          "integrity": "sha512-VEpMFcL9q0NQijmR0jsj38OGbY4yzaWMEareVkDahopmlNT+Cpsot8btPgsgBBApP9NiZj2Enwvh8rZN30ocQw==",
+          "dev": true,
+          "requires": {
+            "async": "^2.6.0",
+            "libp2p-crypto": "~0.12.1",
+            "lodash": "^4.17.5",
+            "multihashes": "~0.4.13"
+          }
+        },
+        "tweetnacl": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.0.tgz",
+          "integrity": "sha1-cT2LgY2kIGh0C/aDhtBHnmb8ins=",
+          "dev": true
         }
       }
     },
     "libp2p-websocket-star": {
-      "version": "0.7.7",
-      "resolved": "https://registry.npmjs.org/libp2p-websocket-star/-/libp2p-websocket-star-0.7.7.tgz",
-      "integrity": "sha512-unAy7kzWdUpCFVsm47B4Gk17E/XuPQo3f1cWMGTSd5AtWqsCNNTOD8dBG58DLY//o4ps511KEsNp/yp70n60AA==",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/libp2p-websocket-star/-/libp2p-websocket-star-0.8.1.tgz",
+      "integrity": "sha512-lDzL9fGWXveu6HEc6xuIEi036Bg1IQ+PliJJHxgSS9ozTkUwMT5dfvyugSWsZ7Gh4q7BYzr5cDZCNkR42GcRZw==",
       "dev": true,
       "requires": {
-        "async": "^2.6.0",
+        "async": "^2.6.1",
+        "class-is": "^1.1.0",
         "data-queue": "0.0.3",
         "debug": "^3.1.0",
-        "interface-connection": "^0.3.2",
-        "libp2p-crypto": "^0.12.1",
-        "mafmt": "^4.0.0",
+        "interface-connection": "~0.3.2",
+        "libp2p-crypto": "~0.13.0",
+        "mafmt": "^6.0.0",
         "merge-recursive": "0.0.3",
-        "multiaddr": "^3.0.2",
+        "multiaddr": "^5.0.0",
         "once": "^1.4.0",
-        "peer-id": "^0.10.6",
-        "peer-info": "^0.11.6",
-        "pull-stream": "^3.6.2",
-        "socket.io-client": "^2.0.4",
-        "socket.io-pull-stream": "^0.1.4",
+        "peer-id": "~0.10.7",
+        "peer-info": "~0.14.1",
+        "pull-stream": "^3.6.8",
+        "socket.io-client": "^2.1.1",
+        "socket.io-pull-stream": "~0.1.5",
         "uuid": "^3.2.1"
       },
       "dependencies": {
@@ -6813,19 +8029,75 @@
           "requires": {
             "ms": "2.0.0"
           }
+        },
+        "multihashing-async": {
+          "version": "0.4.8",
+          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.4.8.tgz",
+          "integrity": "sha512-LCc4lfxmTJOHKIjZjFNgvmfB6nXS/ErLInT9uwU8udFrRm2PH+aTPk3mfCREKmCiSHOlCWiv2O8rlnBx+OjlMw==",
+          "dev": true,
+          "requires": {
+            "async": "^2.6.0",
+            "blakejs": "^1.1.0",
+            "js-sha3": "^0.7.0",
+            "multihashes": "~0.4.13",
+            "murmurhash3js": "^3.0.1",
+            "nodeify": "^1.0.1"
+          }
+        },
+        "peer-id": {
+          "version": "0.10.7",
+          "resolved": "https://registry.npmjs.org/peer-id/-/peer-id-0.10.7.tgz",
+          "integrity": "sha512-VEpMFcL9q0NQijmR0jsj38OGbY4yzaWMEareVkDahopmlNT+Cpsot8btPgsgBBApP9NiZj2Enwvh8rZN30ocQw==",
+          "dev": true,
+          "requires": {
+            "async": "^2.6.0",
+            "libp2p-crypto": "~0.12.1",
+            "lodash": "^4.17.5",
+            "multihashes": "~0.4.13"
+          },
+          "dependencies": {
+            "libp2p-crypto": {
+              "version": "0.12.1",
+              "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.12.1.tgz",
+              "integrity": "sha512-1/z8rxZ0DcQNreZhEsl7PnLr7DWOioSvYbKBLGkRwNRiNh1JJLgh0PdTySBb44wkrOGT+TxcGRd7iq3/X6Wxwg==",
+              "dev": true,
+              "requires": {
+                "asn1.js": "^5.0.0",
+                "async": "^2.6.0",
+                "browserify-aes": "^1.1.1",
+                "bs58": "^4.0.1",
+                "keypair": "^1.0.1",
+                "libp2p-crypto-secp256k1": "~0.2.2",
+                "multihashing-async": "~0.4.7",
+                "node-forge": "^0.7.1",
+                "pem-jwk": "^1.5.1",
+                "protons": "^1.0.1",
+                "rsa-pem-to-jwk": "^1.1.3",
+                "tweetnacl": "^1.0.0",
+                "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
+              }
+            }
+          }
+        },
+        "tweetnacl": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.0.tgz",
+          "integrity": "sha1-cT2LgY2kIGh0C/aDhtBHnmb8ins=",
+          "dev": true
         }
       }
     },
     "libp2p-websockets": {
-      "version": "0.10.5",
-      "resolved": "https://registry.npmjs.org/libp2p-websockets/-/libp2p-websockets-0.10.5.tgz",
-      "integrity": "sha512-umSnkUylBStVtsTJ2v1iWpCCUTFskbSOzUSyZ20mUwfwwPNSd+rmPkisnMRCz64l4UQ8EUs2kp7cS7kExAZODA==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/libp2p-websockets/-/libp2p-websockets-0.12.0.tgz",
+      "integrity": "sha512-I4m0MNqzBOwoIneCF/5mXHGaavNf0Hoe/7NFg2WUm74o7240dZEIuNkAoLu1+OJyOPyu4RXeIBhUOS4cjBdCew==",
       "dev": true,
       "requires": {
+        "class-is": "^1.1.0",
         "interface-connection": "~0.3.2",
         "lodash.includes": "^4.3.0",
-        "mafmt": "^4.0.0",
-        "pull-ws": "^3.3.0"
+        "mafmt": "^6.0.0",
+        "pull-ws": "^3.3.1"
       }
     },
     "load-json-file": {
@@ -6883,8 +8155,7 @@
     "lodash": {
       "version": "4.17.10",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
-      "dev": true
+      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
     },
     "lodash.clone": {
       "version": "4.5.0",
@@ -6920,12 +8191,6 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.find/-/lodash.find-4.6.0.tgz",
       "integrity": "sha1-ywcE1Hq3F4n/oN6Ll92Sb7iLE7E=",
-      "dev": true
-    },
-    "lodash.flatmap": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.flatmap/-/lodash.flatmap-4.5.0.tgz",
-      "integrity": "sha1-74y/QI9uSCaGYzRTBcaswLd4cC4=",
       "dev": true
     },
     "lodash.flatten": {
@@ -7102,12 +8367,36 @@
       "integrity": "sha1-81ypHEk/e3PaDgdJUwTxezH4fuU="
     },
     "mafmt": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/mafmt/-/mafmt-4.0.0.tgz",
-      "integrity": "sha512-zTqHhC9UUYlOkTwOXkdNqCE5U7vuz5UzlRJa4Et3ddCu/Sq36Z8F9mWCGdoqzahDcnRiGc515XjsnkAQHdH55g==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/mafmt/-/mafmt-6.0.0.tgz",
+      "integrity": "sha512-ikjvRXcbEu/kpSQSUlCX5mj2sRZs18rjFAR3azO7mTJ1HPtTcd1XL5y/ey5wSuRjX4dsgGIPEc9VYF3dUaudPw==",
       "dev": true,
       "requires": {
-        "multiaddr": "^3.0.2"
+        "multiaddr": "^4.0.0"
+      },
+      "dependencies": {
+        "multiaddr": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-4.0.0.tgz",
+          "integrity": "sha512-zUatrOCfBd/tJNOSoJ10d2EI2FDXB9PyPZhqUMdXE9mOyR3C+HLuOjga2Ga/eChwvEHIpTYRMoIKF2Nv7af2qQ==",
+          "dev": true,
+          "requires": {
+            "bs58": "^4.0.1",
+            "class-is": "^1.1.0",
+            "ip": "^1.1.5",
+            "ip-address": "^5.8.9",
+            "lodash.filter": "^4.6.0",
+            "lodash.map": "^4.6.0",
+            "varint": "^5.0.0",
+            "xtend": "^4.0.1"
+          }
+        },
+        "xtend": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+          "dev": true
+        }
       }
     },
     "make-dir": {
@@ -7190,23 +8479,23 @@
       }
     },
     "memdown": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/memdown/-/memdown-1.4.1.tgz",
-      "integrity": "sha1-tOThkhdGZP+65BNhqlAPMRnv4hU=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/memdown/-/memdown-3.0.0.tgz",
+      "integrity": "sha512-tbV02LfZMWLcHcq4tw++NuqMO+FZX8tNJEiD2aNRm48ZZusVg5N8NART+dmBkepJVye986oixErf7jfXboMGMA==",
       "dev": true,
       "requires": {
-        "abstract-leveldown": "~2.7.1",
-        "functional-red-black-tree": "^1.0.1",
-        "immediate": "^3.2.3",
+        "abstract-leveldown": "~5.0.0",
+        "functional-red-black-tree": "~1.0.1",
+        "immediate": "~3.2.3",
         "inherits": "~2.0.1",
         "ltgt": "~2.2.0",
         "safe-buffer": "~5.1.1"
       },
       "dependencies": {
         "abstract-leveldown": {
-          "version": "2.7.2",
-          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.7.2.tgz",
-          "integrity": "sha512-+OVvxH2rHVEhWLdbudP6p0+dNMXu8JA1CbhP19T8paTYAcX7oJ4OVjT+ZUVpv7mITxXHqDMej+GdqXBmXkw09w==",
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-5.0.0.tgz",
+          "integrity": "sha512-5mU5P1gXtsMIXg65/rsYGsi93+MlogXZ9FA8JnwKurHQg64bfXwGYVdVdijNTVNOlAsuIiOwHdvFFD5JqCJQ7A==",
           "dev": true,
           "requires": {
             "xtend": "~4.0.0"
@@ -7258,10 +8547,39 @@
         "semaphore": ">=1.0.1"
       },
       "dependencies": {
+        "abstract-leveldown": {
+          "version": "2.7.2",
+          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.7.2.tgz",
+          "integrity": "sha512-+OVvxH2rHVEhWLdbudP6p0+dNMXu8JA1CbhP19T8paTYAcX7oJ4OVjT+ZUVpv7mITxXHqDMej+GdqXBmXkw09w==",
+          "dev": true,
+          "requires": {
+            "xtend": "~4.0.0"
+          }
+        },
         "async": {
           "version": "1.5.2",
           "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
           "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+          "dev": true
+        },
+        "memdown": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/memdown/-/memdown-1.4.1.tgz",
+          "integrity": "sha1-tOThkhdGZP+65BNhqlAPMRnv4hU=",
+          "dev": true,
+          "requires": {
+            "abstract-leveldown": "~2.7.1",
+            "functional-red-black-tree": "^1.0.1",
+            "immediate": "^3.2.3",
+            "inherits": "~2.0.1",
+            "ltgt": "~2.2.0",
+            "safe-buffer": "~5.1.1"
+          }
+        },
+        "xtend": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
           "dev": true
         }
       }
@@ -7312,9 +8630,9 @@
       }
     },
     "mime": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.3.1.tgz",
+      "integrity": "sha512-OEUllcVoydBHGN1z84yfQDimn58pZNNNXgZlHXSboxMlFvgI6MXSWpWKpFRra7H1HxpVhHTkrghfRW49k6yjeg==",
       "dev": true
     },
     "mime-db": {
@@ -7489,6 +8807,18 @@
         }
       }
     },
+    "mortice": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/mortice/-/mortice-1.2.1.tgz",
+      "integrity": "sha512-O9O2Cx6u/AcPLLELYbCGZkcg2yvPo7zJk3+v7h8Emlne5+sg48W/shwtG5UAD+2UIuMMayC+fJ/OlZXwHfA08g==",
+      "dev": true,
+      "requires": {
+        "observable-webworkers": "^1.0.0",
+        "p-queue": "^2.4.2",
+        "promise-timeout": "^1.3.0",
+        "shortid": "^2.2.8"
+      }
+    },
     "move-concurrently": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
@@ -7516,13 +8846,15 @@
       "dev": true
     },
     "multiaddr": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-3.1.0.tgz",
-      "integrity": "sha512-QhmsD/TufS5KB7brd1rkzLz2sJqybQlDT9prroiWacaw61DtHoe2X/vcAnOu8mZc7s7ZzevFPvY5tzv3yjBXlQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-5.0.0.tgz",
+      "integrity": "sha512-IMEo+iCv53MT8c/6SQWbJpJUEENTYr6qp7o635BKJLQG2nkxOIO9LSEFhF5e56Az+DkmI6HGAAjp69AT7Sjulw==",
       "dev": true,
       "requires": {
         "bs58": "^4.0.1",
+        "class-is": "^1.1.0",
         "ip": "^1.1.5",
+        "ip-address": "^5.8.9",
         "lodash.filter": "^4.6.0",
         "lodash.map": "^4.6.0",
         "varint": "^5.0.0",
@@ -7547,12 +8879,12 @@
       }
     },
     "multicast-dns": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-6.2.3.tgz",
-      "integrity": "sha512-ji6J5enbMyGRHIAkAOu3WdV8nggqviKCEKtXcOqfphZZtQrmHKycfynJ2V7eVPUA4NhJ6V7Wf4TmGbTwKE9B6g==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-7.0.0.tgz",
+      "integrity": "sha512-BqB5TtIXHo+8gN33N1CA1clsvPsAJlnc6D49SzfQA0xq75cxj15g2y9NaRdf4x2u4v1P66PBC+Wg6YgPO5Bc/g==",
       "dev": true,
       "requires": {
-        "dns-packet": "^1.3.1",
+        "dns-packet": "^4.0.0",
         "thunky": "^1.0.2"
       }
     },
@@ -7575,36 +8907,17 @@
       }
     },
     "multihashing-async": {
-      "version": "0.4.8",
-      "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.4.8.tgz",
-      "integrity": "sha512-LCc4lfxmTJOHKIjZjFNgvmfB6nXS/ErLInT9uwU8udFrRm2PH+aTPk3mfCREKmCiSHOlCWiv2O8rlnBx+OjlMw==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.5.1.tgz",
+      "integrity": "sha512-Ft5lQNcJCfsns1QN1TDXqPZrrNwBYqIokprYJR2h2Jj01x0GFcYmJYAqHvme6vJoyI3XptEcmZpdr9g5Oy7q3Q==",
       "dev": true,
       "requires": {
-        "async": "^2.6.0",
+        "async": "^2.6.1",
         "blakejs": "^1.1.0",
         "js-sha3": "^0.7.0",
         "multihashes": "~0.4.13",
         "murmurhash3js": "^3.0.1",
         "nodeify": "^1.0.1"
-      }
-    },
-    "multiplex": {
-      "version": "github:dignifiedquire/multiplex#b5d5edd30454e2c978ee8c52df86f5f4840d2eab",
-      "from": "github:dignifiedquire/multiplex",
-      "dev": true,
-      "requires": {
-        "debug": "^2.6.1",
-        "duplexify": "^3.4.2",
-        "readable-stream": "^2.0.2",
-        "varint": "^4.0.0"
-      },
-      "dependencies": {
-        "varint": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/varint/-/varint-4.0.1.tgz",
-          "integrity": "sha1-SQgpuULSSEY7KzUJeZXDv3NxmOk=",
-          "dev": true
-        }
       }
     },
     "multistream-select": {
@@ -7647,6 +8960,12 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.7.0.tgz",
       "integrity": "sha1-2Vv3IeyHfgjbJ27T/G63j5CDrUY="
+    },
+    "nanoid": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-1.0.7.tgz",
+      "integrity": "sha512-DCTnU68QAckm8vgPbFhM1XcK3/zX8LWL4/kEXzPH5w2qy2ibBWHig+685aF8ff8rd5lUXkhVB3W60pb4mbRcDA==",
+      "dev": true
     },
     "nanomatch": {
       "version": "1.2.9",
@@ -7923,6 +9242,12 @@
         "isobject": "^3.0.1"
       }
     },
+    "observable-webworkers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/observable-webworkers/-/observable-webworkers-1.0.0.tgz",
+      "integrity": "sha512-+cECwCR8IEh8UY5nefQVLO9Cydqpk1izO+o7BABmKjXfJZyEOzBWY3ss5jbOPM6KmEa9aQExvAtTW6tVTOsNAQ==",
+      "dev": true
+    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -8024,10 +9349,10 @@
       }
     },
     "orbit-db-pubsub": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/orbit-db-pubsub/-/orbit-db-pubsub-0.5.3.tgz",
-      "integrity": "sha512-5Yg5RHOOkWN6FZwlqCMASWC7wGnEIUqszNkeptmyovh7XQtaScWEwq8LFcdxKvR/Bp4Ne8LpNeKYM0Hhuw9Gdw==",
+      "version": "github:mistakia/orbit-db-pubsub#3d767dbb4631a3981a677c13f31a021a9465d4a4",
+      "from": "github:mistakia/orbit-db-pubsub#fix/unsubscribe",
       "requires": {
+        "async": "^2.6.1",
         "ipfs-pubsub-peer-monitor": "~0.0.5",
         "logplease": "~1.2.14"
       }
@@ -8127,6 +9452,12 @@
       "requires": {
         "p-reduce": "^1.0.0"
       }
+    },
+    "p-queue": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-2.4.2.tgz",
+      "integrity": "sha512-n8/y+yDJwBjoLQe1GSJbbaYQLTI7QHNZI2+rpmCDbe++WLf9HC3gf6iqj5yfPAV71W4UF3ql5W1+UBPXoXTxng==",
+      "dev": true
     },
     "p-reduce": {
       "version": "1.0.0",
@@ -8303,37 +9634,170 @@
       }
     },
     "peer-book": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/peer-book/-/peer-book-0.5.4.tgz",
-      "integrity": "sha512-BuI/mO6OarE5839h9KLG+gSF8UPHlN8VIo6A9ZF4RlcYfOjAuOtDwgAmKIEpf3lTmVqqIkwD92KIij237yphaw==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/peer-book/-/peer-book-0.8.0.tgz",
+      "integrity": "sha512-0An5viX2NnYeaqmwe2Vpzl03K9yxJ08mrktzkCPJyyd6rO4xz6QV2JK2Ku2vTHATP8Ag0ambxvr0QbrkT4UCYA==",
       "dev": true,
       "requires": {
         "bs58": "^4.0.1",
-        "peer-id": "^0.10.5",
-        "peer-info": "^0.11.6"
+        "peer-id": "^0.10.7",
+        "peer-info": "^0.14.1"
+      },
+      "dependencies": {
+        "libp2p-crypto": {
+          "version": "0.12.1",
+          "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.12.1.tgz",
+          "integrity": "sha512-1/z8rxZ0DcQNreZhEsl7PnLr7DWOioSvYbKBLGkRwNRiNh1JJLgh0PdTySBb44wkrOGT+TxcGRd7iq3/X6Wxwg==",
+          "dev": true,
+          "requires": {
+            "asn1.js": "^5.0.0",
+            "async": "^2.6.0",
+            "browserify-aes": "^1.1.1",
+            "bs58": "^4.0.1",
+            "keypair": "^1.0.1",
+            "libp2p-crypto-secp256k1": "~0.2.2",
+            "multihashing-async": "~0.4.7",
+            "node-forge": "^0.7.1",
+            "pem-jwk": "^1.5.1",
+            "protons": "^1.0.1",
+            "rsa-pem-to-jwk": "^1.1.3",
+            "tweetnacl": "^1.0.0",
+            "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
+          }
+        },
+        "multihashing-async": {
+          "version": "0.4.8",
+          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.4.8.tgz",
+          "integrity": "sha512-LCc4lfxmTJOHKIjZjFNgvmfB6nXS/ErLInT9uwU8udFrRm2PH+aTPk3mfCREKmCiSHOlCWiv2O8rlnBx+OjlMw==",
+          "dev": true,
+          "requires": {
+            "async": "^2.6.0",
+            "blakejs": "^1.1.0",
+            "js-sha3": "^0.7.0",
+            "multihashes": "~0.4.13",
+            "murmurhash3js": "^3.0.1",
+            "nodeify": "^1.0.1"
+          }
+        },
+        "peer-id": {
+          "version": "0.10.7",
+          "resolved": "https://registry.npmjs.org/peer-id/-/peer-id-0.10.7.tgz",
+          "integrity": "sha512-VEpMFcL9q0NQijmR0jsj38OGbY4yzaWMEareVkDahopmlNT+Cpsot8btPgsgBBApP9NiZj2Enwvh8rZN30ocQw==",
+          "dev": true,
+          "requires": {
+            "async": "^2.6.0",
+            "libp2p-crypto": "~0.12.1",
+            "lodash": "^4.17.5",
+            "multihashes": "~0.4.13"
+          }
+        },
+        "tweetnacl": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.0.tgz",
+          "integrity": "sha1-cT2LgY2kIGh0C/aDhtBHnmb8ins=",
+          "dev": true
+        }
       }
     },
     "peer-id": {
-      "version": "0.10.7",
-      "resolved": "https://registry.npmjs.org/peer-id/-/peer-id-0.10.7.tgz",
-      "integrity": "sha512-VEpMFcL9q0NQijmR0jsj38OGbY4yzaWMEareVkDahopmlNT+Cpsot8btPgsgBBApP9NiZj2Enwvh8rZN30ocQw==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/peer-id/-/peer-id-0.11.0.tgz",
+      "integrity": "sha512-C/lRJk4CWIgOdKvfO572NvHbPcUwe49I6G0toIhDB5tCohqv/qzy0uBcAK9Ww8TvYI6U4J3C8ACShV9fWjNU4w==",
       "dev": true,
       "requires": {
-        "async": "^2.6.0",
-        "libp2p-crypto": "~0.12.1",
-        "lodash": "^4.17.5",
+        "async": "^2.6.1",
+        "libp2p-crypto": "~0.13.0",
+        "lodash": "^4.17.10",
         "multihashes": "~0.4.13"
       }
     },
     "peer-info": {
-      "version": "0.11.6",
-      "resolved": "https://registry.npmjs.org/peer-info/-/peer-info-0.11.6.tgz",
-      "integrity": "sha512-xrVNiAF1IhVJNGEg5P2UQN+subaEkszT8YkC3zdy06MK0vTH3cMHB+HH+ZURkoSLssc3HbK58ecXeKpQ/4zq5w==",
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/peer-info/-/peer-info-0.14.1.tgz",
+      "integrity": "sha512-I9K+q7sisU0gg5ej6ekbhgolwlcm1tc2wDtLmumptoLYx0DkIT8WVHtgoTnupYwRRqcYADtwddFdiXfb8QFqzg==",
       "dev": true,
       "requires": {
         "lodash.uniqby": "^4.7.0",
-        "multiaddr": "^3.0.2",
-        "peer-id": "~0.10.5"
+        "mafmt": "^6.0.0",
+        "multiaddr": "^4.0.0",
+        "peer-id": "~0.10.7"
+      },
+      "dependencies": {
+        "libp2p-crypto": {
+          "version": "0.12.1",
+          "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.12.1.tgz",
+          "integrity": "sha512-1/z8rxZ0DcQNreZhEsl7PnLr7DWOioSvYbKBLGkRwNRiNh1JJLgh0PdTySBb44wkrOGT+TxcGRd7iq3/X6Wxwg==",
+          "dev": true,
+          "requires": {
+            "asn1.js": "^5.0.0",
+            "async": "^2.6.0",
+            "browserify-aes": "^1.1.1",
+            "bs58": "^4.0.1",
+            "keypair": "^1.0.1",
+            "libp2p-crypto-secp256k1": "~0.2.2",
+            "multihashing-async": "~0.4.7",
+            "node-forge": "^0.7.1",
+            "pem-jwk": "^1.5.1",
+            "protons": "^1.0.1",
+            "rsa-pem-to-jwk": "^1.1.3",
+            "tweetnacl": "^1.0.0",
+            "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
+          }
+        },
+        "multiaddr": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-4.0.0.tgz",
+          "integrity": "sha512-zUatrOCfBd/tJNOSoJ10d2EI2FDXB9PyPZhqUMdXE9mOyR3C+HLuOjga2Ga/eChwvEHIpTYRMoIKF2Nv7af2qQ==",
+          "dev": true,
+          "requires": {
+            "bs58": "^4.0.1",
+            "class-is": "^1.1.0",
+            "ip": "^1.1.5",
+            "ip-address": "^5.8.9",
+            "lodash.filter": "^4.6.0",
+            "lodash.map": "^4.6.0",
+            "varint": "^5.0.0",
+            "xtend": "^4.0.1"
+          }
+        },
+        "multihashing-async": {
+          "version": "0.4.8",
+          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.4.8.tgz",
+          "integrity": "sha512-LCc4lfxmTJOHKIjZjFNgvmfB6nXS/ErLInT9uwU8udFrRm2PH+aTPk3mfCREKmCiSHOlCWiv2O8rlnBx+OjlMw==",
+          "dev": true,
+          "requires": {
+            "async": "^2.6.0",
+            "blakejs": "^1.1.0",
+            "js-sha3": "^0.7.0",
+            "multihashes": "~0.4.13",
+            "murmurhash3js": "^3.0.1",
+            "nodeify": "^1.0.1"
+          }
+        },
+        "peer-id": {
+          "version": "0.10.7",
+          "resolved": "https://registry.npmjs.org/peer-id/-/peer-id-0.10.7.tgz",
+          "integrity": "sha512-VEpMFcL9q0NQijmR0jsj38OGbY4yzaWMEareVkDahopmlNT+Cpsot8btPgsgBBApP9NiZj2Enwvh8rZN30ocQw==",
+          "dev": true,
+          "requires": {
+            "async": "^2.6.0",
+            "libp2p-crypto": "~0.12.1",
+            "lodash": "^4.17.5",
+            "multihashes": "~0.4.13"
+          }
+        },
+        "tweetnacl": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.0.tgz",
+          "integrity": "sha1-cT2LgY2kIGh0C/aDhtBHnmb8ins=",
+          "dev": true
+        },
+        "xtend": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+          "dev": true
+        }
       }
     },
     "pem-jwk": {
@@ -8511,10 +9975,11 @@
       "dev": true
     },
     "prom-client": {
-      "version": "10.2.3",
-      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-10.2.3.tgz",
-      "integrity": "sha512-Xboq5+TdUwuQtSSDRZRNnb5NprINlgQN999VqUjZxnLKydUNLeIPx6Eiahg6oJua3XBg2TGnh5Cth1s4I6+r7g==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-11.1.1.tgz",
+      "integrity": "sha512-itUicyrq3Rko56v3ovQAMYwxEouK7lIylp26bjnlt1b/3fzn783riZnZn432I4udYmPsRgNx1F/u9RFvLyH7zA==",
       "dev": true,
+      "optional": true,
       "requires": {
         "tdigest": "^0.1.1"
       }
@@ -8543,6 +10008,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
       "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
+      "dev": true
+    },
+    "promise-timeout": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/promise-timeout/-/promise-timeout-1.3.0.tgz",
+      "integrity": "sha512-5yANTE0tmi5++POym6OgtFmwfDvOXABD9oj/jLQr5GPEyuNEb7jH4wbbANJceJid49jwhi1RddxnhnEAb/doqg==",
       "dev": true
     },
     "promisify-es6": {
@@ -8725,9 +10196,9 @@
       "dev": true
     },
     "pull-reader": {
-      "version": "1.2.9",
-      "resolved": "https://registry.npmjs.org/pull-reader/-/pull-reader-1.2.9.tgz",
-      "integrity": "sha1-0umtALz7VOYqpm1Cwtu8tetoQ7A=",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pull-reader/-/pull-reader-1.3.1.tgz",
+      "integrity": "sha512-CBkejkE5nX50SiSEzu0Qoz4POTJMS/mw8G6aj3h3M/RJoKgggLxyF0IyTZ0mmpXFlXRcLmLmIEW4xeYn7AeDYw==",
       "dev": true
     },
     "pull-sort": {
@@ -8816,24 +10287,6 @@
         "relative-url": "^1.0.2",
         "safe-buffer": "^5.1.1",
         "ws": "^1.1.0"
-      },
-      "dependencies": {
-        "ultron": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
-          "integrity": "sha1-rOEWq1V80Zc4ak6I9GhTeMiy5Po=",
-          "dev": true
-        },
-        "ws": {
-          "version": "1.1.5",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.5.tgz",
-          "integrity": "sha512-o3KqipXNUdS7wpQzBHSe180lBGO60SoK0yVo3CYJgb2MkobuWuBX6dhkYP5ORCLd55y+SaflMOV5fqAB53ux4w==",
-          "dev": true,
-          "requires": {
-            "options": ">=0.0.5",
-            "ultron": "1.0.x"
-          }
-        }
       }
     },
     "pull-zip": {
@@ -8975,13 +10428,58 @@
       }
     },
     "read-pkg-up": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
-      "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-4.0.0.tgz",
+      "integrity": "sha512-6etQSH7nJGsK0RbG/2TeDzZFa8shjQ1um+SwQQ5cwKy0dhSXdOncEhb1CPpvQG4h7FyOV6EB6YlV0yJvZQNAkA==",
       "dev": true,
       "requires": {
-        "find-up": "^2.0.0",
+        "find-up": "^3.0.0",
         "read-pkg": "^3.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.0.0.tgz",
+          "integrity": "sha512-fl5s52lI5ahKCernzzIyAP0QAZbGIovtVHGwpcu1Jr/EpzLVDI2myISHwGqK7m8uQFugVWSrbxH7XnhGtvEc+A==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "p-try": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
+          "integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ==",
+          "dev": true
+        }
       }
     },
     "readable-stream": {
@@ -8997,6 +10495,12 @@
         "string_decoder": "~1.1.1",
         "util-deprecate": "~1.0.1"
       }
+    },
+    "readable-stream-node-to-web": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/readable-stream-node-to-web/-/readable-stream-node-to-web-1.0.1.tgz",
+      "integrity": "sha1-i3YU+qFGXr+g2pucpjA/onBzt88=",
+      "dev": true
     },
     "readdirp": {
       "version": "2.1.0",
@@ -9100,6 +10604,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/relative-url/-/relative-url-1.0.2.tgz",
       "integrity": "sha1-0hxSpy1gYQGLzun5yfwQa/fWUoc=",
+      "dev": true
+    },
+    "remedial": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/remedial/-/remedial-1.0.8.tgz",
+      "integrity": "sha512-/62tYiOe6DzS5BqVsNpH/nkGlX45C/Sp6V+NtiN6JQNS1Viay7cWkazmRkrQrdFj2eshDe96SIQNIoMxqhzBOg==",
       "dev": true
     },
     "remove-trailing-separator": {
@@ -9210,10 +10720,13 @@
       }
     },
     "rlp": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/rlp/-/rlp-2.0.0.tgz",
-      "integrity": "sha1-nbOE/0uJqPYVY9kjldhiWxjzr7A=",
-      "dev": true
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/rlp/-/rlp-2.1.0.tgz",
+      "integrity": "sha512-93U7IKH5j7nmXFVg19MeNBGzQW5uXW1pmCuKY8veeKIhYTE32C2d0mOegfiIAfXcHOKJjjPlJisn8iHDF5AezA==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "^5.1.1"
+      }
     },
     "rsa-pem-to-jwk": {
       "version": "1.1.3",
@@ -9447,6 +10960,15 @@
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
       "dev": true
     },
+    "shortid": {
+      "version": "2.2.11",
+      "resolved": "https://registry.npmjs.org/shortid/-/shortid-2.2.11.tgz",
+      "integrity": "sha512-uK/fkCpqyznl+ZIsFP1p0O91lXVczSwUyTQTSAJ06lU91HX+JR5gb1w3ZBUOJ5cB7d7llLxG5baSIrLQ6S3hdg==",
+      "dev": true,
+      "requires": {
+        "nanoid": "^1.0.7"
+      }
+    },
     "shot": {
       "version": "3.4.2",
       "resolved": "https://registry.npmjs.org/shot/-/shot-3.4.2.tgz",
@@ -9517,9 +11039,9 @@
       }
     },
     "simple-peer": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/simple-peer/-/simple-peer-8.5.0.tgz",
-      "integrity": "sha512-L901ld7sqQv7c8ehThEZGIDqgBrTC1iJLlcqFlqtH3YhUb+S8uBjdQpzaJGth+NkSoWNJSsXjNyWbzaM99cMQg==",
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/simple-peer/-/simple-peer-9.1.2.tgz",
+      "integrity": "sha512-MUWWno5o5cvISKOH4pYQ18PQJLpDaNWoKUbrPPKuspCLCkkh+zhtuQyTE8h2U2Ags+/OUN5wnUe92+9B8/Sm2Q==",
       "dev": true,
       "requires": {
         "debug": "^3.1.0",
@@ -10037,9 +11559,9 @@
       }
     },
     "stream-http": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.3.tgz",
-      "integrity": "sha512-+TSkfINHDo4J+ZobQLWiMouQYB+UVYFttRA94FpEzzJ7ZdqcL4uUUQ7WkdkI4DSozGmgBUE/a47L+38PenXhUw==",
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.2.tgz",
+      "integrity": "sha512-QllfrBhqF1DPcz46WxKTs6Mz1Bpc+8Qm6vbqOpVav5odAXwbyzwnEczoWqtxrsmlO+cJqtPrp/8gWKWjaKLLlA==",
       "dev": true,
       "requires": {
         "builtin-status-codes": "^3.0.0",
@@ -10205,6 +11727,12 @@
           "requires": {
             "ms": "2.0.0"
           }
+        },
+        "mime": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+          "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+          "dev": true
         }
       }
     },
@@ -10359,6 +11887,12 @@
         "setimmediate": "^1.0.4"
       }
     },
+    "tiny-each-async": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-each-async/-/tiny-each-async-2.0.3.tgz",
+      "integrity": "sha1-jru/1tYpXxNwAD+7NxYq/loKUdE=",
+      "dev": true
+    },
     "to-array": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/to-array/-/to-array-0.1.4.tgz",
@@ -10460,12 +11994,6 @@
         "utf8-byte-length": "^1.0.1"
       }
     },
-    "truthy": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/truthy/-/truthy-0.0.1.tgz",
-      "integrity": "sha1-eJ8zBZ3B8C/dkM8FY6yxpnZvx7w=",
-      "dev": true
-    },
     "tty-browserify": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
@@ -10560,9 +12088,9 @@
       }
     },
     "ultron": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
-      "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
+      "integrity": "sha1-rOEWq1V80Zc4ak6I9GhTeMiy5Po=",
       "dev": true
     },
     "union-value": {
@@ -11421,14 +12949,13 @@
       }
     },
     "ws": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
-      "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.5.tgz",
+      "integrity": "sha512-o3KqipXNUdS7wpQzBHSe180lBGO60SoK0yVo3CYJgb2MkobuWuBX6dhkYP5ORCLd55y+SaflMOV5fqAB53ux4w==",
       "dev": true,
       "requires": {
-        "async-limiter": "~1.0.0",
-        "safe-buffer": "~5.1.0",
-        "ultron": "~1.1.0"
+        "options": ">=0.0.5",
+        "ultron": "1.0.x"
       }
     },
     "xdg-basedir": {
@@ -11447,6 +12974,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/xor-distance/-/xor-distance-1.0.0.tgz",
       "integrity": "sha1-2nNdmyT8yo282bN00W0qAe6VQcY=",
+      "dev": true
+    },
+    "xregexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-4.0.0.tgz",
+      "integrity": "sha512-PHyM+sQouu7xspQQwELlGwwd05mXUFqwFYfqPO0cC7x4fxyHnnuetmQr6CjJiafIDoH4MogHb9dOoJzR/Y4rFg==",
       "dev": true
     },
     "xtend": {
@@ -11470,14 +13003,14 @@
       "dev": true
     },
     "yargs": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-11.0.0.tgz",
-      "integrity": "sha512-Rjp+lMYQOWtgqojx1dEWorjCofi1YN7AoFvYV7b1gx/7dAAeuI4kN5SZiEvr0ZmsZTOpDRcCqrpI10L31tFkBw==",
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.1.tgz",
+      "integrity": "sha512-B0vRAp1hRX4jgIOWFtjfNjd9OA9RWYZ6tqGA9/I/IrTMsxmKvtWy+ersM+jzpQqbC3YfLzeABPdeTgcJ9eu1qQ==",
       "dev": true,
       "requires": {
         "cliui": "^4.0.0",
-        "decamelize": "^1.1.1",
-        "find-up": "^2.1.0",
+        "decamelize": "^2.0.0",
+        "find-up": "^3.0.0",
         "get-caller-file": "^1.0.1",
         "os-locale": "^2.0.0",
         "require-directory": "^2.1.1",
@@ -11485,8 +13018,8 @@
         "set-blocking": "^2.0.0",
         "string-width": "^2.0.0",
         "which-module": "^2.0.0",
-        "y18n": "^3.2.1",
-        "yargs-parser": "^9.0.2"
+        "y18n": "^3.2.1 || ^4.0.0",
+        "yargs-parser": "^10.1.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -11495,10 +13028,62 @@
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
         },
+        "decamelize": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-2.0.0.tgz",
+          "integrity": "sha512-Ikpp5scV3MSYxY39ymh45ZLEecsTdv/Xj2CaQfI8RLMuwi7XvjX9H/fhraiSuU+C5w5NTDu4ZU72xNiZnurBPg==",
+          "dev": true,
+          "requires": {
+            "xregexp": "4.0.0"
+          }
+        },
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.0.0.tgz",
+          "integrity": "sha512-fl5s52lI5ahKCernzzIyAP0QAZbGIovtVHGwpcu1Jr/EpzLVDI2myISHwGqK7m8uQFugVWSrbxH7XnhGtvEc+A==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "p-try": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
+          "integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ==",
           "dev": true
         },
         "string-width": {
@@ -11523,13 +13108,19 @@
       }
     },
     "yargs-parser": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
-      "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
+      "integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
       "dev": true,
       "requires": {
         "camelcase": "^4.1.0"
       }
+    },
+    "yargs-promise": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/yargs-promise/-/yargs-promise-1.1.0.tgz",
+      "integrity": "sha1-l+u1GY33NLs7EXRRM65bUBsWqx8=",
+      "dev": true
     },
     "yeast": {
       "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
     "orbit-db-feedstore": "~1.4.0",
     "orbit-db-keystore": "~0.1.0",
     "orbit-db-kvstore": "~1.4.0",
-    "orbit-db-store": "~2.5.0",
-    "orbit-db-pubsub": "~0.5.3"
+    "orbit-db-pubsub": "github:mistakia/orbit-db-pubsub#fix/unsubscribe",
+    "orbit-db-store": "~2.5.0"
   },
   "devDependencies": {
     "babel-core": "^6.26.0",
@@ -34,9 +34,9 @@
     "babel-preset-es2015": "^6.24.1",
     "datastore-level": "~0.7.0",
     "go-ipfs-dep": "0.4.13",
-    "ipfs": "~0.28.2",
-    "ipfs-repo": "~0.18.7",
-    "ipfsd-ctl": "~0.30.3",
+    "ipfs": "~0.30.0",
+    "ipfs-repo": "~0.22.1",
+    "ipfsd-ctl": "^0.37.5",
     "mocha": "^4.0.1",
     "p-each-series": "^1.0.0",
     "p-map-series": "^1.0.0",

--- a/src/OrbitDB.js
+++ b/src/OrbitDB.js
@@ -97,8 +97,9 @@ class OrbitDB {
     Object.keys(this._directConnections).forEach(removeDirectConnect)
 
     // Disconnect from pubsub
-    if (this._pubsub)
-      this._pubsub.disconnect()
+    if (this._pubsub) {
+      await this._pubsub.disconnect()
+    }
 
     // Remove all databases from the state
     this.stores = {}
@@ -191,12 +192,13 @@ class OrbitDB {
   }
 
   // Callback when database was closed
-  _onClose (address) {
+  async _onClose (address) {
     logger.debug(`Close ${address}`)
 
     // Unsubscribe from pubsub
-    if(this._pubsub)
-      this._pubsub.unsubscribe(address)
+    if (this._pubsub) {
+      await this._pubsub.unsubscribe(address)
+    }
 
     delete this.stores[address]
   }


### PR DESCRIPTION
Update to latest ipfs packages (`js-ipfs`, `ipfs-repo`, `ipfsd-ctl`) with a fix for [breaking changes to `pubsub.unsubscribe` in js-ipfs-api](https://github.com/ipfs/js-ipfs-api/blob/master/CHANGELOG.md#breaking-changes) which affects `orbit-db-pubsub`.

Also, the latest ipfs is throwing the following warning on tests:
```
WARNING, trying to set config on uninitialized repo, maybe forgot to set "init: true"
```

Follow up to orbitdb/orbit-db#370.
Needs orbitdb/orbit-db-pubsub#12 merged.