### PR TITLE
Use latest orbit-db-pubsub module

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -523,9 +523,9 @@
       }
     },
     "babel-loader": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-7.1.4.tgz",
-      "integrity": "sha512-/hbyEvPzBJuGpk9o80R0ZyTej6heEOr59GoEUtn8qFKbnx4cJm9FWES6J/iv644sYgrtVw9JJQkjaLW/bqb5gw==",
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-7.1.5.tgz",
+      "integrity": "sha512-iCHfbieL5d1LfOQeeVJEUyD9rTwBcP/fcEbRCfempxTDuqrKpu0AZjLAQHEQa3Yqyj9ORKe2iHfoj4rHLf7xpw==",
       "dev": true,
       "requires": {
         "find-cache-dir": "^1.0.0",
@@ -1043,9 +1043,9 @@
       "dev": true
     },
     "bcrypt-pbkdf": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-      "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
       "dev": true,
       "optional": true,
       "requires": {
@@ -1362,14 +1362,15 @@
       }
     },
     "browserify-des": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.1.tgz",
-      "integrity": "sha512-zy0Cobe3hhgpiOM32Tj7KQ3Vl91m0njwsjzZQK1L+JDf11dzP9qIvjreVinsvXrgfjhStXwUWAEpB9D7Gwmayw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.2.tgz",
+      "integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
       "dev": true,
       "requires": {
         "cipher-base": "^1.0.1",
         "des.js": "^1.0.0",
-        "inherits": "^2.0.1"
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.1.2"
       }
     },
     "browserify-rsa": {
@@ -1536,14 +1537,6 @@
         "ssri": "^5.2.4",
         "unique-filename": "^1.1.0",
         "y18n": "^4.0.0"
-      },
-      "dependencies": {
-        "y18n": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-          "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
-          "dev": true
-        }
       }
     },
     "cache-base": {
@@ -1904,9 +1897,9 @@
       }
     },
     "commander": {
-      "version": "2.15.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
-      "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.16.0.tgz",
+      "integrity": "sha512-sVXqklSaotK9at437sFlFpyOcJonxe0yST/AG9DkQKUdIE6IqGIMv4SfAQSKaJbSdVEJYItASCrBiVQHq1HQew==",
       "dev": true
     },
     "commondir": {
@@ -2288,10 +2281,13 @@
       }
     },
     "decamelize": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-      "dev": true
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-2.0.0.tgz",
+      "integrity": "sha512-Ikpp5scV3MSYxY39ymh45ZLEecsTdv/Xj2CaQfI8RLMuwi7XvjX9H/fhraiSuU+C5w5NTDu4ZU72xNiZnurBPg==",
+      "dev": true,
+      "requires": {
+        "xregexp": "4.0.0"
+      }
     },
     "decode-uri-component": {
       "version": "0.2.0",
@@ -2604,9 +2600,9 @@
       "dev": true
     },
     "encoding-down": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/encoding-down/-/encoding-down-5.0.3.tgz",
-      "integrity": "sha512-grBSxdQBY6xNkMJoqXWUUsqneXyxcBk966OWbSF6FHjLRv1FiExseSM0poga7aZDC0TziUMCzQDo8NnLJ5Rvlw==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/encoding-down/-/encoding-down-5.0.4.tgz",
+      "integrity": "sha512-8CIZLDcSKxgzT+zX8ZVfgNbu8Md2wq/iqa1Y7zyVR18QBEAc0Nmzuvj/N5ykSKpfGzjM8qxbaFntLPwnVoUhZw==",
       "dev": true,
       "requires": {
         "abstract-leveldown": "^5.0.0",
@@ -2809,9 +2805,9 @@
       }
     },
     "es5-ext": {
-      "version": "0.10.44",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.44.tgz",
-      "integrity": "sha512-TO4Vt9IhW3FzDKLDOpoA8VS9BCV4b9WTf6BqvMOgfoa8wX73F3Kh3y2J7yTstTaXlQ0k1vq4DH2vw6RSs42z+g==",
+      "version": "0.10.45",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.45.tgz",
+      "integrity": "sha512-FkfM6Vxxfmztilbxxz5UKSD4ICMf5tSpRFtDNtkAhOxZ0EKtX6qwmXNyH/sFyIbX2P/nU5AMiA9jilWsUGJzCQ==",
       "dev": true,
       "requires": {
         "es6-iterator": "~2.0.3",
@@ -2917,16 +2913,6 @@
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
       "dev": true
-    },
-    "eth-hash-to-cid": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/eth-hash-to-cid/-/eth-hash-to-cid-0.1.1.tgz",
-      "integrity": "sha512-qRmanZnp+YqLGpZaaBX49jEBVpUhYvosNBA/6lrgDDdVhzGCeMbpFycJYyR3prgrxMRPDoMk1H7iMeKRVZKLPA==",
-      "dev": true,
-      "requires": {
-        "cids": "^0.5.3",
-        "multihashes": "^0.4.13"
-      }
     },
     "ethereum-common": {
       "version": "0.2.0",
@@ -4639,9 +4625,9 @@
       "dev": true
     },
     "get-caller-file": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
-      "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
+      "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
       "dev": true
     },
     "get-folder-size": {
@@ -4835,9 +4821,9 @@
           "dev": true
         },
         "isemail": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.1.2.tgz",
-          "integrity": "sha512-zfRhJn9rFSGhzU5tGZqepRSAj3+g6oTOHxMGGriWNJZzyLPUK8H7VHpqKntegnW8KLyGA9zwuNaCoopl40LTpg==",
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.1.3.tgz",
+          "integrity": "sha512-5xbsG5wYADIcB+mfLsd+nst1V/D+I7EU7LEZPo2GOIMu4JzfcRs5yQoypP4avA7QtUqgxYLKBYNv4IdzBmbhdw==",
           "dev": true,
           "requires": {
             "punycode": "2.x.x"
@@ -4970,12 +4956,12 @@
       }
     },
     "hash.js": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.4.tgz",
-      "integrity": "sha512-A6RlQvvZEtFS5fLU43IDu0QUmBy+fDO9VMdTXvufKwIkt/rFfvICAViCax5fbDO4zdNzaC3/27ZhKUok5bAJyw==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.5.tgz",
+      "integrity": "sha512-eWI5HG9Np+eHV1KQhisXWwM+4EPPYe5dFX1UZZH7k/E3JzDEazVH+VGlZi6R94ZqImq+A3D1mCEtrFIfg/E7sA==",
       "requires": {
         "inherits": "^2.0.3",
-        "minimalistic-assert": "^1.0.0"
+        "minimalistic-assert": "^1.0.1"
       }
     },
     "hashlru": {
@@ -5069,9 +5055,9 @@
       }
     },
     "hosted-git-info": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.6.0.tgz",
-      "integrity": "sha512-lIbgIIQA3lz5XaB6vxakj6sDHADJiZadYEJB+FgA+C4nubM1NwcuvUr9EJPmnH1skZqpqUzWborWo8EIUi0Sdw==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
+      "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
       "dev": true
     },
     "http-signature": {
@@ -5104,6 +5090,7 @@
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/idb-readable-stream/-/idb-readable-stream-0.0.4.tgz",
       "integrity": "sha1-MoPaZkW/ayINxhumHfYr7l2uSs8=",
+      "dev": true,
       "requires": {
         "xtend": "^4.0.1"
       },
@@ -5111,7 +5098,8 @@
         "xtend": {
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+          "dev": true
         }
       }
     },
@@ -5297,9 +5285,9 @@
       }
     },
     "ipfs": {
-      "version": "0.30.0",
-      "resolved": "https://registry.npmjs.org/ipfs/-/ipfs-0.30.0.tgz",
-      "integrity": "sha512-31Rz0m+tSyn5QX5NOU6Aw41tX7MA10ao8YdnOiJ9MkzpT5EfZ0Vulc7FAc9dyVXOZK22qAkblp1zAIyaOnVmYw==",
+      "version": "0.30.1",
+      "resolved": "https://registry.npmjs.org/ipfs/-/ipfs-0.30.1.tgz",
+      "integrity": "sha512-Vks8ADqtuRR9lMDr7hS7qpA2C6TiJDwwsK7m9Bih0nvy+ZWlnvDWajJD9h+zUtkIJZT2PldcT5/6rZhQKd5TcQ==",
       "dev": true,
       "requires": {
         "@nodeutils/defaults-deep": "^1.1.0",
@@ -5328,7 +5316,7 @@
         "ipfs-block": "~0.7.1",
         "ipfs-block-service": "~0.14.0",
         "ipfs-http-response": "~0.1.2",
-        "ipfs-mfs": "~0.0.14",
+        "ipfs-mfs": "~0.1.0",
         "ipfs-multipart": "~0.1.0",
         "ipfs-repo": "~0.22.1",
         "ipfs-unixfs": "~0.1.15",
@@ -5421,9 +5409,9 @@
       }
     },
     "ipfs-api": {
-      "version": "22.2.3",
-      "resolved": "https://registry.npmjs.org/ipfs-api/-/ipfs-api-22.2.3.tgz",
-      "integrity": "sha512-RXoVh1t9qI+F0RkJlX0HNRps2z7UTKLTp07NSBLHvlDgFi5Kvo7Ieu8la1NTAj0WpuFbJExvYngBGSZuPTz6zw==",
+      "version": "22.2.4",
+      "resolved": "https://registry.npmjs.org/ipfs-api/-/ipfs-api-22.2.4.tgz",
+      "integrity": "sha512-9RReGD3/O8XQ+K83o9eqge3ULqQGDO9ijg+x3RKskb431Ftqp8Z4MiPRiQxpXKtTkDa1jhStXj2sfENpCQRu9w==",
       "dev": true,
       "requires": {
         "async": "^2.6.1",
@@ -5431,6 +5419,7 @@
         "bs58": "^4.0.1",
         "cids": "~0.5.3",
         "concat-stream": "^1.6.2",
+        "debug": "^3.1.0",
         "detect-node": "^2.0.3",
         "flatmap": "0.0.3",
         "glob": "^7.1.2",
@@ -5469,6 +5458,15 @@
           "integrity": "sha512-qG6ZOc1lY84Bn8p/z9xvJisj9F4PRyo0pOGqGNYc7gS3p1WciS/3XcLuNI3Z/yYZpMNFhHeX3YNENwgrQq0NTA==",
           "dev": true
         },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
         "pump": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
@@ -5478,25 +5476,6 @@
             "end-of-stream": "^1.1.0",
             "once": "^1.3.1"
           }
-        },
-        "stream-http": {
-          "version": "2.8.3",
-          "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.3.tgz",
-          "integrity": "sha512-+TSkfINHDo4J+ZobQLWiMouQYB+UVYFttRA94FpEzzJ7ZdqcL4uUUQ7WkdkI4DSozGmgBUE/a47L+38PenXhUw==",
-          "dev": true,
-          "requires": {
-            "builtin-status-codes": "^3.0.0",
-            "inherits": "^2.0.1",
-            "readable-stream": "^2.3.6",
-            "to-arraybuffer": "^1.0.0",
-            "xtend": "^4.0.0"
-          }
-        },
-        "xtend": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
-          "dev": true
         }
       }
     },
@@ -5594,18 +5573,18 @@
       }
     },
     "ipfs-log": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/ipfs-log/-/ipfs-log-4.1.0.tgz",
-      "integrity": "sha512-teHxC0mUA9Jffq5nDzephsxsdx+RKB7pLhR+G7xtXsNLAYdUvrCFgItz8BRunNZOAE009u6QRyr6LJHF9F3rnQ==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/ipfs-log/-/ipfs-log-4.1.2.tgz",
+      "integrity": "sha512-YYP3vhoFgxGAZk1fzf72Wst0e6Y00GHslbNImkmxaQavNH0Qg5LFrmlNmlGEaRnl17z8vkrX8PKdgS8YnIvHzg==",
       "requires": {
         "p-map": "^1.1.1",
         "p-whilst": "^1.0.0"
       }
     },
     "ipfs-mfs": {
-      "version": "0.0.16",
-      "resolved": "https://registry.npmjs.org/ipfs-mfs/-/ipfs-mfs-0.0.16.tgz",
-      "integrity": "sha512-UR5zy1jVJvZas1bAXrHp7ujpaU5CO/DqMc49zOLeSpiO0mB8ZZ3eK3fBjKDpLrEWCd8pG+yDL60w3AinVOlKTA==",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/ipfs-mfs/-/ipfs-mfs-0.1.0.tgz",
+      "integrity": "sha512-vkgAykdAKim7eR+3uX/O6ocjgC6pFexrfwAKhr5ttljPuA0pQWnngFkumb4an/RORqdvOZBaUbN8lopFyBiWtw==",
       "dev": true,
       "requires": {
         "async": "^2.6.1",
@@ -5696,6 +5675,15 @@
         "pull-stream": "^3.6.7"
       },
       "dependencies": {
+        "abstract-leveldown": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.4.1.tgz",
+          "integrity": "sha1-s7/tuITraToSd18MVenwpCDM7mQ=",
+          "dev": true,
+          "requires": {
+            "xtend": "~4.0.0"
+          }
+        },
         "big.js": {
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.1.2.tgz",
@@ -5715,30 +5703,6 @@
             "leveldown": "^3.0.2",
             "levelup": "^2.0.2",
             "pull-stream": "^3.6.1"
-          },
-          "dependencies": {
-            "level-js": {
-              "version": "github:timkuijsten/level.js#18e03adab34c49523be7d3d58fafb0c632f61303",
-              "from": "github:timkuijsten/level.js#idbunwrapper",
-              "dev": true,
-              "requires": {
-                "abstract-leveldown": "~2.4.1",
-                "idb-readable-stream": "0.0.4",
-                "ltgt": "^2.1.2",
-                "xtend": "^4.0.1"
-              },
-              "dependencies": {
-                "abstract-leveldown": {
-                  "version": "2.4.1",
-                  "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.4.1.tgz",
-                  "integrity": "sha1-s7/tuITraToSd18MVenwpCDM7mQ=",
-                  "dev": true,
-                  "requires": {
-                    "xtend": "~4.0.0"
-                  }
-                }
-              }
-            }
           }
         },
         "debug": {
@@ -5780,9 +5744,9 @@
           }
         },
         "level-iterator-stream": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-2.0.0.tgz",
-          "integrity": "sha512-TWOYw8HR5mhj6xwoVLo0yu26RPL6v28KgvhK1kY1CJf9LyL+rJXjx99zhORTYhN9ysOBIH+iaxAiqRteA+C1/g==",
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-2.0.3.tgz",
+          "integrity": "sha512-I6Heg70nfF+e5Y3/qfthJFexhRw/Gi3bIymCoXAlijZdAcLaPuWSJs3KXyTYf23ID6g0o2QF62Yh+grOXY3Rig==",
           "dev": true,
           "requires": {
             "inherits": "^2.0.1",
@@ -5793,7 +5757,9 @@
         "level-js": {
           "version": "github:timkuijsten/level.js#18e03adab34c49523be7d3d58fafb0c632f61303",
           "from": "github:timkuijsten/level.js#idbunwrapper",
+          "dev": true,
           "requires": {
+            "abstract-leveldown": "~2.4.1",
             "idb-readable-stream": "0.0.4",
             "ltgt": "^2.1.2",
             "xtend": "^4.0.1"
@@ -5883,7 +5849,8 @@
         "xtend": {
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+          "dev": true
         }
       }
     },
@@ -5969,9 +5936,9 @@
       }
     },
     "ipld": {
-      "version": "0.17.2",
-      "resolved": "https://registry.npmjs.org/ipld/-/ipld-0.17.2.tgz",
-      "integrity": "sha512-IRW7wbn5dM10I/xEM1AhHwo6pjzbTgdY0lI3DtbkpfV4jS+awnyx8mWMY/M0ND1GjSwfaH9l+odVIHRPZoxo0Q==",
+      "version": "0.17.3",
+      "resolved": "https://registry.npmjs.org/ipld/-/ipld-0.17.3.tgz",
+      "integrity": "sha512-nUWbYfB59PTf/Hq0OEnitbR2hQb7k8/DOINpR6dXQ9MXVWh1cKxGs3ENOHuRr944T/ge2cJwI3XertcWqm0lXg==",
       "dev": true,
       "requires": {
         "async": "^2.6.1",
@@ -5979,20 +5946,20 @@
         "interface-datastore": "~0.4.2",
         "ipfs-block": "~0.7.1",
         "ipfs-block-service": "~0.14.0",
-        "ipfs-repo": "~0.22.0",
-        "ipld-bitcoin": "~0.1.5",
-        "ipld-dag-cbor": "~0.12.0",
-        "ipld-dag-pb": "~0.14.4",
-        "ipld-ethereum": "^2.0.0",
-        "ipld-git": "~0.2.0",
-        "ipld-raw": "^2.0.0",
-        "ipld-zcash": "~0.1.3",
+        "ipfs-repo": "~0.22.1",
+        "ipld-bitcoin": "~0.1.6",
+        "ipld-dag-cbor": "~0.12.1",
+        "ipld-dag-pb": "~0.14.5",
+        "ipld-ethereum": "^2.0.1",
+        "ipld-git": "~0.2.1",
+        "ipld-raw": "^2.0.1",
+        "ipld-zcash": "~0.1.4",
         "is-ipfs": "~0.3.2",
         "lodash.flatten": "^4.4.0",
         "lodash.includes": "^4.3.0",
         "memdown": "^3.0.0",
         "multihashes": "~0.4.13",
-        "pull-defer": "^0.2.2",
+        "pull-defer": "~0.2.2",
         "pull-sort": "^1.0.1",
         "pull-stream": "^3.6.8",
         "pull-traverse": "^1.0.3"
@@ -6055,16 +6022,15 @@
       }
     },
     "ipld-ethereum": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ipld-ethereum/-/ipld-ethereum-2.0.0.tgz",
-      "integrity": "sha512-wpWmba4bwjctTrHZbYQIdbizCBprEh4ueDhAJtYiiaEoDA4yWdrDF/gHNL3dBXFMFZ/FYudSI08GrQeEuC8tQg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ipld-ethereum/-/ipld-ethereum-2.0.1.tgz",
+      "integrity": "sha512-p+OIsTg7+NeXnE2Uq7g5HV7KVbJTQ9kVHSywOAUxUfj6loJb+6ReTCRrayQ+SbIXuVVVIVPU8OOUoGaugwFEjg==",
       "dev": true,
       "requires": {
         "async": "^2.6.0",
         "cids": "~0.5.2",
-        "eth-hash-to-cid": "~0.1.0",
         "ethereumjs-account": "^2.0.4",
-        "ethereumjs-block": "^1.7.0",
+        "ethereumjs-block": "^1.7.1",
         "ethereumjs-tx": "^1.3.3",
         "ipfs-block": "~0.6.1",
         "merkle-patricia-tree": "^2.2.0",
@@ -6352,23 +6318,6 @@
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
       "dev": true
     },
-    "is-odd": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-odd/-/is-odd-2.0.0.tgz",
-      "integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
-      "dev": true,
-      "requires": {
-        "is-number": "^4.0.0"
-      },
-      "dependencies": {
-        "is-number": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
-          "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
-          "dev": true
-        }
-      }
-    },
     "is-path-inside": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
@@ -6487,9 +6436,9 @@
       },
       "dependencies": {
         "isemail": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.1.2.tgz",
-          "integrity": "sha512-zfRhJn9rFSGhzU5tGZqepRSAj3+g6oTOHxMGGriWNJZzyLPUK8H7VHpqKntegnW8KLyGA9zwuNaCoopl40LTpg==",
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.1.3.tgz",
+          "integrity": "sha512-5xbsG5wYADIcB+mfLsd+nst1V/D+I7EU7LEZPo2GOIMu4JzfcRs5yQoypP4avA7QtUqgxYLKBYNv4IdzBmbhdw==",
           "dev": true,
           "requires": {
             "punycode": "2.x.x"
@@ -7341,28 +7290,28 @@
       }
     },
     "libp2p-kad-dht": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/libp2p-kad-dht/-/libp2p-kad-dht-0.10.0.tgz",
-      "integrity": "sha512-JbudRVI6iTFcQ+YtO+BByslR5uASKi5gEWadhDwZNuVlpSlNx177QiOb4uxxLVdo/JR13ulppMdUHFgVFXZiLA==",
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/libp2p-kad-dht/-/libp2p-kad-dht-0.10.1.tgz",
+      "integrity": "sha512-1Ao1Xns75cBd1nIQ2cIEVrg5mEne07x1aAosuXnklqy5arYYPghe5AqdcheGJ2Dm+mWABbULwpClTs/QjV3o0w==",
       "dev": true,
       "requires": {
-        "async": "^2.6.0",
-        "base32.js": "^0.1.0",
+        "async": "^2.6.1",
+        "base32.js": "~0.1.0",
         "cids": "~0.5.3",
         "debug": "^3.1.0",
         "hashlru": "^2.2.1",
-        "heap": "^0.2.6",
+        "heap": "~0.2.6",
         "interface-datastore": "~0.4.2",
-        "k-bucket": "^4.0.0",
+        "k-bucket": "^4.0.1",
         "libp2p-crypto": "~0.13.0",
         "libp2p-record": "~0.5.1",
-        "multihashing-async": "~0.4.8",
-        "peer-id": "~0.10.7",
-        "peer-info": "~0.14.0",
-        "priorityqueue": "^0.2.1",
+        "multihashing-async": "~0.5.1",
+        "peer-id": "~0.11.0",
+        "peer-info": "~0.14.1",
+        "priorityqueue": "~0.2.1",
         "protons": "^1.0.1",
-        "pull-length-prefixed": "^1.3.0",
-        "pull-stream": "^3.6.7",
+        "pull-length-prefixed": "^1.3.1",
+        "pull-stream": "^3.6.8",
         "varint": "^5.0.0",
         "xor-distance": "^1.0.0"
       },
@@ -7375,61 +7324,6 @@
           "requires": {
             "ms": "2.0.0"
           }
-        },
-        "multihashing-async": {
-          "version": "0.4.8",
-          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.4.8.tgz",
-          "integrity": "sha512-LCc4lfxmTJOHKIjZjFNgvmfB6nXS/ErLInT9uwU8udFrRm2PH+aTPk3mfCREKmCiSHOlCWiv2O8rlnBx+OjlMw==",
-          "dev": true,
-          "requires": {
-            "async": "^2.6.0",
-            "blakejs": "^1.1.0",
-            "js-sha3": "^0.7.0",
-            "multihashes": "~0.4.13",
-            "murmurhash3js": "^3.0.1",
-            "nodeify": "^1.0.1"
-          }
-        },
-        "peer-id": {
-          "version": "0.10.7",
-          "resolved": "https://registry.npmjs.org/peer-id/-/peer-id-0.10.7.tgz",
-          "integrity": "sha512-VEpMFcL9q0NQijmR0jsj38OGbY4yzaWMEareVkDahopmlNT+Cpsot8btPgsgBBApP9NiZj2Enwvh8rZN30ocQw==",
-          "dev": true,
-          "requires": {
-            "async": "^2.6.0",
-            "libp2p-crypto": "~0.12.1",
-            "lodash": "^4.17.5",
-            "multihashes": "~0.4.13"
-          },
-          "dependencies": {
-            "libp2p-crypto": {
-              "version": "0.12.1",
-              "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.12.1.tgz",
-              "integrity": "sha512-1/z8rxZ0DcQNreZhEsl7PnLr7DWOioSvYbKBLGkRwNRiNh1JJLgh0PdTySBb44wkrOGT+TxcGRd7iq3/X6Wxwg==",
-              "dev": true,
-              "requires": {
-                "asn1.js": "^5.0.0",
-                "async": "^2.6.0",
-                "browserify-aes": "^1.1.1",
-                "bs58": "^4.0.1",
-                "keypair": "^1.0.1",
-                "libp2p-crypto-secp256k1": "~0.2.2",
-                "multihashing-async": "~0.4.7",
-                "node-forge": "^0.7.1",
-                "pem-jwk": "^1.5.1",
-                "protons": "^1.0.1",
-                "rsa-pem-to-jwk": "^1.1.3",
-                "tweetnacl": "^1.0.0",
-                "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
-              }
-            }
-          }
-        },
-        "tweetnacl": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.0.tgz",
-          "integrity": "sha1-cT2LgY2kIGh0C/aDhtBHnmb8ins=",
-          "dev": true
         }
       }
     },
@@ -7767,9 +7661,9 @@
       }
     },
     "libp2p-switch": {
-      "version": "0.40.5",
-      "resolved": "https://registry.npmjs.org/libp2p-switch/-/libp2p-switch-0.40.5.tgz",
-      "integrity": "sha512-D5XVm6IkH4AL5RoS2yN7YeFJgQrSXaaohxCCwpagoGTsfOrHqvQmK2+0T90/PoQBjllmmtVqh3LQQY0fraTyJA==",
+      "version": "0.40.6",
+      "resolved": "https://registry.npmjs.org/libp2p-switch/-/libp2p-switch-0.40.6.tgz",
+      "integrity": "sha512-2nnvaH8o1Mn7lBkR/p9eB6brRPRd4g/pbm9eRrSwdK0J5Dq8f6ps3u6NYm4DuftfEiWbJOrsm0EwAa/lC34FPg==",
       "dev": true,
       "requires": {
         "async": "^2.6.0",
@@ -8344,12 +8238,12 @@
       "dev": true
     },
     "loose-envify": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
-      "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
       "dev": true,
       "requires": {
-        "js-tokens": "^3.0.0"
+        "js-tokens": "^3.0.0 || ^4.0.0"
       }
     },
     "lowercase-keys": {
@@ -8643,18 +8537,18 @@
       "dev": true
     },
     "mime-db": {
-      "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
-      "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==",
+      "version": "1.35.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.35.0.tgz",
+      "integrity": "sha512-JWT/IcCTsB0Io3AhWUMjRqucrHSPsSf2xKLaRldJVULioggvkJvggZ3VXNNSRkCddE6D+BUI4HEIZIA2OjwIvg==",
       "dev": true
     },
     "mime-types": {
-      "version": "2.1.18",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
-      "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+      "version": "2.1.19",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.19.tgz",
+      "integrity": "sha512-P1tKYHVSZ6uFo26mtnve4HQFE3koh1UWVkp8YUC+ESBHe945xWSoXuHHiGarDqcEZ+whpCDnlNw5LON0kLo+sw==",
       "dev": true,
       "requires": {
-        "mime-db": "~1.33.0"
+        "mime-db": "~1.35.0"
       }
     },
     "mimic-fn": {
@@ -8664,9 +8558,9 @@
       "dev": true
     },
     "mimic-response": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.0.tgz",
-      "integrity": "sha1-3z02Uqc/3ta5sLJBRub9BSNTRY4="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="
     },
     "mimos": {
       "version": "3.0.3",
@@ -8969,15 +8863,15 @@
       "integrity": "sha1-2Vv3IeyHfgjbJ27T/G63j5CDrUY="
     },
     "nanoid": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-1.0.7.tgz",
-      "integrity": "sha512-DCTnU68QAckm8vgPbFhM1XcK3/zX8LWL4/kEXzPH5w2qy2ibBWHig+685aF8ff8rd5lUXkhVB3W60pb4mbRcDA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-1.1.0.tgz",
+      "integrity": "sha512-iOCqgXieGrk8/wDt1n9rZS2KB1dYVssemY0NTWjfzVr+1t1gAmdTp1u2+YHppKro3Bk5S+Gs+xmYCfpuXauYXQ==",
       "dev": true
     },
     "nanomatch": {
-      "version": "1.2.9",
-      "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.9.tgz",
-      "integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
+      "version": "1.2.13",
+      "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
+      "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
       "dev": true,
       "requires": {
         "arr-diff": "^4.0.0",
@@ -8985,7 +8879,6 @@
         "define-property": "^2.0.2",
         "extend-shallow": "^3.0.2",
         "fragment-cache": "^0.2.1",
-        "is-odd": "^2.0.0",
         "is-windows": "^1.0.2",
         "kind-of": "^6.0.2",
         "object.pick": "^1.3.0",
@@ -9356,8 +9249,9 @@
       }
     },
     "orbit-db-pubsub": {
-      "version": "github:mistakia/orbit-db-pubsub#e40e30e7a71e980dbd35fc040316762d1c6283ca",
-      "from": "github:mistakia/orbit-db-pubsub#fix/unsubscribe",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/orbit-db-pubsub/-/orbit-db-pubsub-0.5.5.tgz",
+      "integrity": "sha512-o8vATfW7sJ61OrsmaGd2myXdbAc64Plap4Cs4vQ5wlpt4rM74tSo5FY6hIfySei5MuCbxph2y6dDILMhWdcMng==",
       "requires": {
         "ipfs-pubsub-peer-monitor": "~0.0.5",
         "logplease": "~1.2.14",
@@ -10145,13 +10039,13 @@
       }
     },
     "pull-length-prefixed": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/pull-length-prefixed/-/pull-length-prefixed-1.3.0.tgz",
-      "integrity": "sha512-FkxMYPNUSFjEDEXuS6MAaKwagQAN0sonifeC+NeutQmgXy+WBdPOtPzDT1dyT69Io1wzraZ+GzXAbBGnFcjdFQ==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pull-length-prefixed/-/pull-length-prefixed-1.3.1.tgz",
+      "integrity": "sha512-Ho0KoVKOILITGPusghadRVcUzflFHAHcv1Hvi/OkUSJLkGK2LNmVjsmIaJbWkizI//okIj2n376JyTFwCWdsYA==",
       "dev": true,
       "requires": {
         "pull-pushable": "^2.0.1",
-        "pull-reader": "^1.2.9",
+        "pull-reader": "^1.3.0",
         "safe-buffer": "^5.0.1",
         "varint": "^5.0.0"
       }
@@ -10844,9 +10738,9 @@
       },
       "dependencies": {
         "ajv": {
-          "version": "6.5.1",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.1.tgz",
-          "integrity": "sha512-pgZos1vgOHDiC7gKNbZW8eKvCnNXARv2oqrGQT7Hzbq5Azp7aZG6DJzADnkuSq7RH6qkXp4J/m68yPX/2uBHyQ==",
+          "version": "6.5.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.2.tgz",
+          "integrity": "sha512-hOs7GfvI6tUI1LfZddH82ky6mOMyTuY0mk7kE2pWpmhhUSkumzaTO5vbVwij39MdwPQWCV4Zv57Eo06NtL/GVA==",
           "dev": true,
           "requires": {
             "fast-deep-equal": "^2.0.1",
@@ -10977,9 +10871,9 @@
       "dev": true
     },
     "shortid": {
-      "version": "2.2.11",
-      "resolved": "https://registry.npmjs.org/shortid/-/shortid-2.2.11.tgz",
-      "integrity": "sha512-uK/fkCpqyznl+ZIsFP1p0O91lXVczSwUyTQTSAJ06lU91HX+JR5gb1w3ZBUOJ5cB7d7llLxG5baSIrLQ6S3hdg==",
+      "version": "2.2.12",
+      "resolved": "https://registry.npmjs.org/shortid/-/shortid-2.2.12.tgz",
+      "integrity": "sha512-sw0knB/ioTu/jVYgJz1IP1b5uhPZtZYwQ9ir/EqXZHI4+Jh8rzzGLM3LKptGHBKoDsgTBDfr4yCRNUX7hEIksQ==",
       "dev": true,
       "requires": {
         "nanoid": "^1.0.7"
@@ -11575,9 +11469,9 @@
       }
     },
     "stream-http": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.2.tgz",
-      "integrity": "sha512-QllfrBhqF1DPcz46WxKTs6Mz1Bpc+8Qm6vbqOpVav5odAXwbyzwnEczoWqtxrsmlO+cJqtPrp/8gWKWjaKLLlA==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.3.tgz",
+      "integrity": "sha512-+TSkfINHDo4J+ZobQLWiMouQYB+UVYFttRA94FpEzzJ7ZdqcL4uUUQ7WkdkI4DSozGmgBUE/a47L+38PenXhUw==",
       "dev": true,
       "requires": {
         "builtin-status-codes": "^3.0.0",
@@ -12080,9 +11974,9 @@
       "optional": true
     },
     "uglifyjs-webpack-plugin": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-1.2.6.tgz",
-      "integrity": "sha512-NDP94ahjW7ZH+qzdjxjIV04n5YGnrYD2jeHgKgnpUKmdAfcXEO5DbVo21fXAm/KPMyX9k21zWFBMYm9m9R2ptg==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-1.2.7.tgz",
+      "integrity": "sha512-1VicfKhCYHLS8m1DCApqBhoulnASsEoJ/BvpUpP4zoNAPpKzdH+ghk0olGJMmwX2/jprK2j3hAHdUbczBSy2FA==",
       "dev": true,
       "requires": {
         "cacache": "^10.0.4",
@@ -12363,21 +12257,10 @@
       }
     },
     "use": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/use/-/use-3.1.0.tgz",
-      "integrity": "sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==",
-      "dev": true,
-      "requires": {
-        "kind-of": "^6.0.2"
-      },
-      "dependencies": {
-        "kind-of": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-          "dev": true
-        }
-      }
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
+      "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
+      "dev": true
     },
     "utf8-byte-length": {
       "version": "1.0.4",
@@ -12408,9 +12291,9 @@
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "uuid": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
-      "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
       "dev": true
     },
     "validate-npm-package-license": {
@@ -12530,9 +12413,9 @@
       },
       "dependencies": {
         "ajv": {
-          "version": "6.5.1",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.1.tgz",
-          "integrity": "sha512-pgZos1vgOHDiC7gKNbZW8eKvCnNXARv2oqrGQT7Hzbq5Azp7aZG6DJzADnkuSq7RH6qkXp4J/m68yPX/2uBHyQ==",
+          "version": "6.5.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.2.tgz",
+          "integrity": "sha512-hOs7GfvI6tUI1LfZddH82ky6mOMyTuY0mk7kE2pWpmhhUSkumzaTO5vbVwij39MdwPQWCV4Zv57Eo06NtL/GVA==",
           "dev": true,
           "requires": {
             "fast-deep-equal": "^2.0.1",
@@ -12563,6 +12446,12 @@
             "right-align": "^0.1.1",
             "wordwrap": "0.0.2"
           }
+        },
+        "decamelize": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+          "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+          "dev": true
         },
         "fast-deep-equal": {
           "version": "2.0.1",
@@ -12715,6 +12604,12 @@
           "version": "0.0.2",
           "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
           "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+          "dev": true
+        },
+        "y18n": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+          "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
           "dev": true
         },
         "yargs": {
@@ -13007,9 +12902,9 @@
       }
     },
     "y18n": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-      "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
       "dev": true
     },
     "yallist": {
@@ -13043,15 +12938,6 @@
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
-        },
-        "decamelize": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-2.0.0.tgz",
-          "integrity": "sha512-Ikpp5scV3MSYxY39ymh45ZLEecsTdv/Xj2CaQfI8RLMuwi7XvjX9H/fhraiSuU+C5w5NTDu4ZU72xNiZnurBPg==",
-          "dev": true,
-          "requires": {
-            "xregexp": "4.0.0"
-          }
         },
         "find-up": {
           "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "orbit-db-feedstore": "~1.4.0",
     "orbit-db-keystore": "~0.1.0",
     "orbit-db-kvstore": "~1.4.0",
-    "orbit-db-pubsub": "github:mistakia/orbit-db-pubsub#fix/unsubscribe",
+    "orbit-db-pubsub": "~0.5.5",
     "orbit-db-store": "~2.5.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR will change package.json to use latest published orbit-db-pubsub from npm instead of a branch.