### PR TITLE
Use latest orbit-db-cache and leveldb modules

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,18 +34,11 @@
       "dev": true
     },
     "abstract-leveldown": {
-      "version": "0.12.4",
-      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-0.12.4.tgz",
-      "integrity": "sha1-KeGOYy5g5OIh1YECR4UqY9ey5BA=",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-5.0.0.tgz",
+      "integrity": "sha512-5mU5P1gXtsMIXg65/rsYGsi93+MlogXZ9FA8JnwKurHQg64bfXwGYVdVdijNTVNOlAsuIiOwHdvFFD5JqCJQ7A==",
       "requires": {
-        "xtend": "~3.0.0"
-      },
-      "dependencies": {
-        "xtend": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
-          "integrity": "sha1-XM50B7r2Qsunvs2laBEcST9ZZlo="
-        }
+        "xtend": "~4.0.0"
       }
     },
     "accept": {
@@ -2285,65 +2278,6 @@
             "ltgt": "^2.1.2",
             "xtend": "^4.0.1"
           }
-        },
-        "leveldown": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/leveldown/-/leveldown-3.0.2.tgz",
-          "integrity": "sha512-+ANRScj1npQQzv6e4DYAKRjVQZZ+ahMoubKrNP68nIq+l9bYgb+WiXF+14oTcQTg2f7qE9WHGW7rBG9nGSsA+A==",
-          "dev": true,
-          "requires": {
-            "abstract-leveldown": "~4.0.0",
-            "bindings": "~1.3.0",
-            "fast-future": "~1.0.2",
-            "nan": "~2.10.0",
-            "prebuild-install": "^4.0.0"
-          },
-          "dependencies": {
-            "abstract-leveldown": {
-              "version": "4.0.3",
-              "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-4.0.3.tgz",
-              "integrity": "sha512-qsIHFQy0u17JqSY+3ZUT+ykqxYY17yOfvAsLkFkw8kSQqi05d1jyj0bCuSX6sjYlXuY9cKpgUt5EudQdP4aXyA==",
-              "dev": true,
-              "requires": {
-                "xtend": "~4.0.0"
-              }
-            }
-          }
-        },
-        "nan": {
-          "version": "2.10.0",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
-          "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
-          "dev": true
-        },
-        "prebuild-install": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-4.0.0.tgz",
-          "integrity": "sha512-7tayxeYboJX0RbVzdnKyGl2vhQRWr6qfClEXDhOkXjuaOKCw2q8aiuFhONRYVsG/czia7KhpykIlI2S2VaPunA==",
-          "dev": true,
-          "requires": {
-            "detect-libc": "^1.0.3",
-            "expand-template": "^1.0.2",
-            "github-from-package": "0.0.0",
-            "minimist": "^1.2.0",
-            "mkdirp": "^0.5.1",
-            "node-abi": "^2.2.0",
-            "noop-logger": "^0.1.1",
-            "npmlog": "^4.0.1",
-            "os-homedir": "^1.0.1",
-            "pump": "^2.0.1",
-            "rc": "^1.1.6",
-            "simple-get": "^2.7.0",
-            "tar-fs": "^1.13.0",
-            "tunnel-agent": "^0.6.0",
-            "which-pm-runs": "^1.0.0"
-          }
-        },
-        "xtend": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
-          "dev": true
         }
       }
     },
@@ -2413,12 +2347,6 @@
           "requires": {
             "xtend": "~4.0.0"
           }
-        },
-        "xtend": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
-          "dev": true
         }
       }
     },
@@ -2692,23 +2620,6 @@
         "level-codec": "^9.0.0",
         "level-errors": "^2.0.0",
         "xtend": "^4.0.1"
-      },
-      "dependencies": {
-        "abstract-leveldown": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-5.0.0.tgz",
-          "integrity": "sha512-5mU5P1gXtsMIXg65/rsYGsi93+MlogXZ9FA8JnwKurHQg64bfXwGYVdVdijNTVNOlAsuIiOwHdvFFD5JqCJQ7A==",
-          "dev": true,
-          "requires": {
-            "xtend": "~4.0.0"
-          }
-        },
-        "xtend": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
-          "dev": true
-        }
       }
     },
     "end-of-stream": {
@@ -3298,17 +3209,6 @@
       "requires": {
         "from2": "^2.1.0",
         "typedarray-to-buffer": "^3.0.4"
-      },
-      "dependencies": {
-        "typedarray-to-buffer": {
-          "version": "3.1.5",
-          "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
-          "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
-          "dev": true,
-          "requires": {
-            "is-typedarray": "^1.0.0"
-          }
-        }
       }
     },
     "filesize": {
@@ -3512,15 +3412,6 @@
       "optional": true,
       "requires": {
         "nan": "^2.10.0"
-      },
-      "dependencies": {
-        "nan": {
-          "version": "2.10.0",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
-          "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
-          "dev": true,
-          "optional": true
-        }
       }
     },
     "fs-write-stream-atomic": {
@@ -3793,13 +3684,6 @@
         "ms": {
           "version": "2.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "nan": {
-          "version": "2.10.0",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
-          "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
           "dev": true,
           "optional": true
         },
@@ -4397,13 +4281,6 @@
         "ms": {
           "version": "2.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "nan": {
-          "version": "2.10.0",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
-          "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
           "dev": true,
           "optional": true
         },
@@ -5160,20 +5037,7 @@
       "dev": true,
       "requires": {
         "xtend": "^4.0.1"
-      },
-      "dependencies": {
-        "xtend": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
-          "dev": true
-        }
       }
-    },
-    "idb-wrapper": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/idb-wrapper/-/idb-wrapper-1.7.2.tgz",
-      "integrity": "sha512-zfNREywMuf0NzDo9mVsL0yegjsirJxHpKHvWcyRozIqQy89g0a3U+oBPOCN4cc0oCiOuYgZHimzaW/R46G1Mpg=="
     },
     "ieee754": {
       "version": "1.1.12",
@@ -5190,8 +5054,7 @@
     "immediate": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.2.3.tgz",
-      "integrity": "sha1-0UD6j2FGWb1lQSMwl92qwlzdmRw=",
-      "dev": true
+      "integrity": "sha1-0UD6j2FGWb1lQSMwl92qwlzdmRw="
     },
     "import-lazy": {
       "version": "2.1.0",
@@ -5772,12 +5635,6 @@
             "varint": "^5.0.0",
             "xtend": "^4.0.1"
           }
-        },
-        "xtend": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
-          "dev": true
         }
       }
     },
@@ -6302,8 +6159,7 @@
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-      "dev": true
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
     },
     "is-windows": {
       "version": "1.0.2",
@@ -6315,11 +6171,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-    },
-    "isbuffer": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/isbuffer/-/isbuffer-0.0.0.tgz",
-      "integrity": "sha1-OMFG2d9Si4v5sHAcPUPPEt8/w5s="
     },
     "isemail": {
       "version": "2.2.1",
@@ -6419,12 +6270,6 @@
             "varint": "^5.0.0",
             "xtend": "^4.0.1"
           }
-        },
-        "xtend": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
-          "dev": true
         }
       }
     },
@@ -6622,27 +6467,18 @@
         "inherits": "^2.0.1",
         "readable-stream": "^2.0.5",
         "xtend": "^4.0.0"
-      },
-      "dependencies": {
-        "xtend": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
-          "dev": true
-        }
       }
     },
     "level-js": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/level-js/-/level-js-2.2.4.tgz",
-      "integrity": "sha1-vAVfQYBjXUSJtWHJSG+jcOjBFpc=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/level-js/-/level-js-3.0.0.tgz",
+      "integrity": "sha512-e2dVpjCWNwIcyboZUsLqx2vERM0I5OPZOE9wfD22fk8b8OeuZRoV4scr0Y+YIyDXE5cwOsO/1LyjsdJ36o+9Ag==",
       "requires": {
-        "abstract-leveldown": "~0.12.0",
-        "idb-wrapper": "^1.5.0",
-        "isbuffer": "~0.0.0",
+        "abstract-leveldown": "~5.0.0",
+        "immediate": "~3.2.3",
+        "inherits": "^2.0.3",
         "ltgt": "^2.1.2",
-        "typedarray-to-buffer": "~1.0.0",
-        "xtend": "~2.1.2"
+        "typedarray-to-buffer": "~3.1.5"
       }
     },
     "level-ws": {
@@ -6678,33 +6514,37 @@
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
           "dev": true
+        },
+        "xtend": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
+          "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
+          "dev": true,
+          "requires": {
+            "object-keys": "~0.4.0"
+          }
         }
       }
     },
     "leveldown": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/leveldown/-/leveldown-1.9.0.tgz",
-      "integrity": "sha512-3MwcrnCUIuFiKp/jSrG1UqDTV4k1yH8f5HH6T9dpqCKG+lRxcfo2KwAqbzTT+TTKfCbaATeHMy9mm1y6sI3ZvA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/leveldown/-/leveldown-3.0.2.tgz",
+      "integrity": "sha512-+ANRScj1npQQzv6e4DYAKRjVQZZ+ahMoubKrNP68nIq+l9bYgb+WiXF+14oTcQTg2f7qE9WHGW7rBG9nGSsA+A==",
       "requires": {
-        "abstract-leveldown": "~2.7.0",
+        "abstract-leveldown": "~4.0.0",
         "bindings": "~1.3.0",
         "fast-future": "~1.0.2",
-        "nan": "~2.7.0",
-        "prebuild-install": "^2.1.0"
+        "nan": "~2.10.0",
+        "prebuild-install": "^4.0.0"
       },
       "dependencies": {
         "abstract-leveldown": {
-          "version": "2.7.2",
-          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.7.2.tgz",
-          "integrity": "sha512-+OVvxH2rHVEhWLdbudP6p0+dNMXu8JA1CbhP19T8paTYAcX7oJ4OVjT+ZUVpv7mITxXHqDMej+GdqXBmXkw09w==",
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-4.0.3.tgz",
+          "integrity": "sha512-qsIHFQy0u17JqSY+3ZUT+ykqxYY17yOfvAsLkFkw8kSQqi05d1jyj0bCuSX6sjYlXuY9cKpgUt5EudQdP4aXyA==",
           "requires": {
             "xtend": "~4.0.0"
           }
-        },
-        "xtend": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
         }
       }
     },
@@ -6728,12 +6568,6 @@
           "requires": {
             "errno": "~0.1.1"
           }
-        },
-        "xtend": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
-          "dev": true
         }
       }
     },
@@ -6991,12 +6825,6 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.0.tgz",
           "integrity": "sha1-cT2LgY2kIGh0C/aDhtBHnmb8ins=",
-          "dev": true
-        },
-        "xtend": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
           "dev": true
         }
       }
@@ -7698,12 +7526,6 @@
             "varint": "^5.0.0",
             "xtend": "^4.0.1"
           }
-        },
-        "xtend": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
-          "dev": true
         }
       }
     },
@@ -8193,12 +8015,6 @@
             "varint": "^5.0.0",
             "xtend": "^4.0.1"
           }
-        },
-        "xtend": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
-          "dev": true
         }
       }
     },
@@ -8293,23 +8109,6 @@
         "inherits": "~2.0.1",
         "ltgt": "~2.2.0",
         "safe-buffer": "~5.1.1"
-      },
-      "dependencies": {
-        "abstract-leveldown": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-5.0.0.tgz",
-          "integrity": "sha512-5mU5P1gXtsMIXg65/rsYGsi93+MlogXZ9FA8JnwKurHQg64bfXwGYVdVdijNTVNOlAsuIiOwHdvFFD5JqCJQ7A==",
-          "dev": true,
-          "requires": {
-            "xtend": "~4.0.0"
-          }
-        },
-        "xtend": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
-          "dev": true
-        }
       }
     },
     "memory-fs": {
@@ -8471,12 +8270,6 @@
           "version": "0.10.31",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-          "dev": true
-        },
-        "xtend": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
           "dev": true
         }
       }
@@ -8756,14 +8549,6 @@
         "lodash.map": "^4.6.0",
         "varint": "^5.0.0",
         "xtend": "^4.0.1"
-      },
-      "dependencies": {
-        "xtend": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
-          "dev": true
-        }
       }
     },
     "multibase": {
@@ -8854,9 +8639,9 @@
       "dev": true
     },
     "nan": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.7.0.tgz",
-      "integrity": "sha1-2Vv3IeyHfgjbJ27T/G63j5CDrUY="
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
+      "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA=="
     },
     "nanoid": {
       "version": "1.1.0",
@@ -9118,7 +8903,8 @@
     "object-keys": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
-      "integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY="
+      "integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY=",
+      "dev": true
     },
     "object-visit": {
       "version": "1.0.1",
@@ -9175,12 +8961,11 @@
       "dev": true
     },
     "orbit-db-cache": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/orbit-db-cache/-/orbit-db-cache-0.2.3.tgz",
-      "integrity": "sha512-b7ic6K1cc7N9x9jfiplL9TKA3b/eJUmvZE2CvdB2wX/sVE/zmLr2TOlnLjteeBQXmlop4jrnqy+PGl8bYHUPkA==",
+      "version": "github:orbitdb/orbit-db-cache#f534134468ccf82c1970bf4592e412a65f5c13c0",
+      "from": "github:orbitdb/orbit-db-cache",
       "requires": {
-        "level-js": "~2.2.4",
-        "leveldown": "^1.9.0",
+        "level-js": "~3.0.0",
+        "leveldown": "~3.0.2",
         "logplease": "^1.2.14",
         "mkdirp": "^0.5.1"
       }
@@ -9697,12 +9482,6 @@
           "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.0.tgz",
           "integrity": "sha1-cT2LgY2kIGh0C/aDhtBHnmb8ins=",
           "dev": true
-        },
-        "xtend": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
-          "dev": true
         }
       }
     },
@@ -9824,9 +9603,9 @@
       "dev": true
     },
     "prebuild-install": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-2.5.3.tgz",
-      "integrity": "sha512-/rI36cN2g7vDQnKWN8Uzupi++KjyqS9iS+/fpwG4Ea8d0Pip0PQ5bshUNzVwt+/D2MRfhVAplYMMvWLqWrCF/g==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-4.0.0.tgz",
+      "integrity": "sha512-7tayxeYboJX0RbVzdnKyGl2vhQRWr6qfClEXDhOkXjuaOKCw2q8aiuFhONRYVsG/czia7KhpykIlI2S2VaPunA==",
       "requires": {
         "detect-libc": "^1.0.3",
         "expand-template": "^1.0.2",
@@ -11475,14 +11254,6 @@
         "readable-stream": "^2.3.6",
         "to-arraybuffer": "^1.0.0",
         "xtend": "^4.0.0"
-      },
-      "dependencies": {
-        "xtend": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
-          "dev": true
-        }
       }
     },
     "stream-shift": {
@@ -11688,13 +11459,6 @@
         "readable-stream": "^2.3.0",
         "to-buffer": "^1.1.0",
         "xtend": "^4.0.0"
-      },
-      "dependencies": {
-        "xtend": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
-        }
       }
     },
     "tdigest": {
@@ -11747,14 +11511,6 @@
       "requires": {
         "readable-stream": "^2.1.5",
         "xtend": "~4.0.1"
-      },
-      "dependencies": {
-        "xtend": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
-          "dev": true
-        }
       }
     },
     "thunky": {
@@ -11928,9 +11684,12 @@
       "dev": true
     },
     "typedarray-to-buffer": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-1.0.4.tgz",
-      "integrity": "sha1-m7i6DoQfs/TPH+fCRenz+opf6Zw="
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+      "requires": {
+        "is-typedarray": "^1.0.0"
+      }
     },
     "typeforce": {
       "version": "1.12.0",
@@ -12890,12 +12649,9 @@
       "dev": true
     },
     "xtend": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
-      "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
-      "requires": {
-        "object-keys": "~0.4.0"
-      }
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
     },
     "y18n": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "ipfs-pubsub-1on1": "~0.0.4",
     "logplease": "^1.2.14",
     "multihashes": "^0.4.12",
-    "orbit-db-cache": "~0.2.2",
+    "orbit-db-cache": "orbitdb/orbit-db-cache",
     "orbit-db-counterstore": "~1.4.0",
     "orbit-db-docstore": "~1.4.3",
     "orbit-db-eventstore": "~1.4.0",

--- a/test/create-open.test.js
+++ b/test/create-open.test.js
@@ -115,7 +115,7 @@ Object.keys(testAPIs).forEach(API => {
         it('saves database manifest reference locally', async () => {
           const manifestHash = db.address.root
           const address = db.address.toString()
-          levelup(localDataPath, (err, db) => {
+          levelup(leveldown(localDataPath), (err, db) => {
             if (err) {
               assert.equal(err, null)
             }


### PR DESCRIPTION
This PR will update dependencies to use the latest orbit-db-cache which brings in LevelDB v3 modules.

Fixes #392.