### PR TITLE
Use the npm module of orbit-db-cache

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8961,8 +8961,9 @@
       "dev": true
     },
     "orbit-db-cache": {
-      "version": "github:orbitdb/orbit-db-cache#f534134468ccf82c1970bf4592e412a65f5c13c0",
-      "from": "github:orbitdb/orbit-db-cache",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/orbit-db-cache/-/orbit-db-cache-0.2.4.tgz",
+      "integrity": "sha512-0Z0t6C948UOLr7YqZd6opmaCuzCNXFrNS5yG37S4GOJmqZbUi4EuwsqPOX53v4/0fNMsVa18U1ocyHfSShb4+Q==",
       "requires": {
         "level-js": "~3.0.0",
         "leveldown": "~3.0.2",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "ipfs-pubsub-1on1": "~0.0.4",
     "logplease": "^1.2.14",
     "multihashes": "^0.4.12",
-    "orbit-db-cache": "orbitdb/orbit-db-cache",
+    "orbit-db-cache": "~0.2.4",
     "orbit-db-counterstore": "~1.4.0",
     "orbit-db-docstore": "~1.4.3",
     "orbit-db-eventstore": "~1.4.0",


### PR DESCRIPTION
This PR will amend https://github.com/orbitdb/orbit-db/pull/414 as I was a bit too trigger happy to merge it. This PR will use the orbit-db-cache module from npm (as opposed to from master).