### PR TITLE
Remove CircleCI 1.0 config file

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,0 @@
-machine:
-  node:
-    version: 8.2.0


### PR DESCRIPTION
This PR will remove the obsolete CircleCI 1.0 config file. We updated to 2.0 in https://github.com/orbitdb/orbit-db/pull/404 but I forgot to remove the old file.