### PR TITLE
Wait for send to complete on exchange heads

### DIFF
--- a/src/exchange-heads.js
+++ b/src/exchange-heads.js
@@ -36,7 +36,7 @@ const exchangeHeads = async (ipfs, address, peer, getStore, getDirectConnection,
   const heads = getHeadsForDatabase(getStore(address))
   logger.debug(`Send latest heads of '${address}':\n`, JSON.stringify(heads.map(e => e.hash), null, 2))
   if (heads) {
-    channel.send(JSON.stringify({ address: address, heads: heads }))
+    await channel.send(JSON.stringify({ address: address, heads: heads }))
   }
 
   return channel


### PR DESCRIPTION
For ipfs-api, during heavy load when multiple db heads are being exchanged if there is no wait here for the send to complete then the actually publish won't complete and the peers would not receive the heads sent to it. This seems to alleviate the problem, though it's not totally predictable.