### PR TITLE
Document replicate option

### DIFF
--- a/API.md
+++ b/API.md
@@ -92,6 +92,7 @@ Returns a `Promise` that resolves to [a database instance](#store-api). `name` (
 - `directory` (string): The directory where data will be stored (Default: uses directory option passed to OrbitDB constructor or `./orbitdb` if none was provided).
 - `write` (array): An array of hex encoded public keys which are used to set write acces to the database. `["*"]` can be passed in to give write access to everyone. See the [GETTING STARTED](https://github.com/orbitdb/orbit-db/blob/master/GUIDE.md) guide for more info. (Default: uses the OrbitDB instance key `orbitdb.key`, which would give write access only to yourself)
 - `overwrite` (boolean): Overwrite an existing database (Default: `false`)
+- `replicate` (boolean): Replicate the database with peers, requires IPFS PubSub. (Default: `true`)
 ```javascript
 const db = await orbitdb.create('user.posts', 'eventlog', {
   write: [
@@ -113,7 +114,7 @@ Returns a `Promise` that resolves to [a database instance](#store-api). `address
 - `create` (boolean): Whether or not to create the database if a valid OrbitDB address is not provided. (Default: `false`)
 - `type` (string): A supported database type (i.e. `eventlog` or [an added custom type](https://github.com/orbitdb/orbit-db#custom-store-types)). Required if create is set to `true`. Otherwise it's used to validate the manifest.
 - `overwrite` (boolean): Overwrite an existing database (Default: `false`)
-
+- `replicate` (boolean): Replicate the database with peers, requires IPFS PubSub. (Default: `true`)
 ```javascript
 const db = await orbitdb.open('/orbitdb/Qmd8TmZrWASypEp4Er9tgWP4kCNQnW4ncSnvjvyHQ3EVSU/first-database')
 ```


### PR DESCRIPTION
Add missing `replicate` config option for `OrbitDB.create()` and `OrbitDB.open()`.

Related #425 