### PR TITLE
Dockerfile for OrbitDB base image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:carbon
+
+ENV NPM_CONFIG_PREFIX=/home/node/.npm-global
+
+WORKDIR /home/node
+USER node
+
+COPY package.json ./
+COPY examples/ ./examples
+COPY src/ ./src
+COPY conf/ ./conf
+
+RUN npm install babel-cli webpack \
+ && npm install

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,26 @@
+# Running OrbitDB code in containers
+
+[Docker](https://github.com/docker/docker-ce) is a tool for running software in containers ie. OS-level virtualization. This directory contains the needed configuration files to:
+
+- Build base Docker images for OrbitDB
+
+
+## Base Docker image
+
+[Dockerfile](Dockerfile) defines OrbitDB base images that are based on [official node.js -image](https://hub.docker.com/_/node/). 
+
+Build local images with command (in repository root):
+
+```bash
+docker build -t orbit-db -f docker/Dockerfile .
+```
+
+After building local image, run node.js-examples inside container:
+
+```bash
+docker run -ti --rm orbit-db npm run examples:node
+```
+
+## Tested versions
+
+- Docker 1.13.1 (Fedora Linux 27)

--- a/docker/README.md
+++ b/docker/README.md
@@ -24,8 +24,8 @@ docker run -ti --rm orbit-db npm run examples:node
 ## Why would you want to run OrbitDB in container?
 
 Containers are nice because as software execution environments they are:
-- Reproducible, which helps testing and development because you can revert container to original state by destroying it and creating it again,
-- Isolated, which guarantees that external factors like npm versions, operating system version, or other installed software like native compilers do not affect the execution.
+- Reproducible, which helps testing and development because you can revert the container to original state by destroying it and creating it again,
+- Isolated, which guarantees that external factors like npm versions, the operating system version, or other installed software like native compilers do not affect the execution.
 
 They also make implementing virtualized networks for testing and benchmarking easier, which may help projects that use OrbitDB.
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -21,6 +21,15 @@ After building local image, run node.js-examples inside container:
 docker run -ti --rm orbit-db npm run examples:node
 ```
 
+## Why would you want to run OrbitDB in container?
+
+Containers are nice because as software execution environments they are:
+- Reproducible, which helps testing and development because you can revert container to original state by destroying it and creating it again,
+- Isolated, which guarantees that external factors like npm versions, operating system version, or other installed software like native compilers do not affect the execution.
+
+They also make implementing virtualized networks for testing and benchmarking easier, which may help projects that use OrbitDB.
+
 ## Tested versions
 
-- Docker 1.13.1 (Fedora Linux 27)
+- Docker 1.13.1 (Linux 4.17.5-100.fc27.x86_64)
+- Docker 18.06.1-ce (Linux 4.17.5-100.fc27.x86_64)


### PR DESCRIPTION
This PR defines the base image for running OrbitDB code in containers. It's something that I've personally been using for a while, so it can already be used locally for running tests or examples in isolated container. Besides the initial Dockerfile for building OrbitDB base images, there's some instructions how to use it with Docker. 

There is optimization left to do in base image itself to make it leaner (smaller nodejs-base image, multi-stage builds etc). Also I've only been using it on Linux where there are usually no problems with containers, so it'd be great to hear experiences from Docker for Mac/Windows users.