### PR TITLE
docs: Add a Gitter badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # OrbitDB
 
+[![Gitter](https://img.shields.io/gitter/room/nwjs/nw.js.svg)](https://gitter.im/orbitdb/Lobby)
 [![](https://img.shields.io/badge/freenode-%23orbitdb-blue.svg?style=flat-square)](http://webchat.freenode.net/?channels=%23orbitdb)
 [![CircleCI Status](https://circleci.com/gh/orbitdb/orbit-db.svg?style=shield)](https://circleci.com/gh/orbitdb/orbit-db)
 [![npm version](https://badge.fury.io/js/orbit-db.svg)](https://www.npmjs.com/package/orbit-db)


### PR DESCRIPTION
This adds a Gitter badge to our Gitter room at https://gitter.im/orbitdb/Lobby. For more on how we plan to use Gitter in the OrbitDB community, take a look at https://github.com/orbitdb/welcome/issues/28.