### PR TITLE
docs(api): fix outdated doc

### DIFF
--- a/API.md
+++ b/API.md
@@ -332,7 +332,6 @@ Returns a `Promise` that resolves to the multihash of the entry as a `String`.
 Returns an `Array` with a single `Object` if key exists.
   ```javascript
   const profile = db.get('shamb0t')
-    .map((e) => e.payload.value)
   // [{ _id: 'shamb0t', name: 'shamb0t', followers: 500 }]
   ```
 


### PR DESCRIPTION
In the latest docstore code, the docstore.get() function does not use the `fullOp` option to retrieve a document ([code](https://github.com/orbitdb/orbit-db-docstore/blob/master/src/DocumentStore.js#L30)). Therefore, the docstore.get() function should by default return the payload value ([code](https://github.com/orbitdb/orbit-db-docstore/blob/master/src/DocumentIndex.js#L11)) and there is no need to add the secondary mapper function any more.