### PR TITLE
Keep package-lock on make clean, add make rebuild command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,10 @@ build: test
 clean:
 	rm -rf orbitdb/
 	rm -rf node_modules/
-	rm package-lock.json
+
+clean-dependencies: clean
+	if [ -a package-lock.json ]; then rm package-lock.json; fi;
+
+rebuild: | clean-dependencies build
 
 .PHONY: test build


### PR DESCRIPTION
This PR will update the Makefile to keep package-lock.json file on `clean` as per https://github.com/orbitdb/orbit-db/pull/401. 

This PR will also ass `rebuild` command which addresses the concerns I had in #401.

Closes #401.