### PR TITLE
Add event peer.exchanged

### DIFF
--- a/API.md
+++ b/API.md
@@ -60,6 +60,7 @@ Read the **[GETTING STARTED](https://github.com/orbitdb/orbit-db/blob/master/GUI
   * [`ready`](#ready)
   * [`write`](#write)
   * [`closed`](#closed)
+  * [`peer.exchanged`](#peerexchanged)
 
 <!-- tocstop -->
 
@@ -560,3 +561,10 @@ Emitted once the database has finished closing.
 ```javascript
 db.events.on('closed', (dbname) => ... )
 ```
+
+### `peer.exchanged`
+```javascript
+db.events.on('peer.exchanged', (peer, address, heads) => ... )
+```
+
+Emitted after heads have been exchanged with a peer for a specific database. This will be emitted after every exchange, even if no heads are received from the peer, or if all received heads are already present. (This is in contrast with the `replicated` event, which will only fire when new heads have been received.) Note that `heads` here contains heads *received* as part of the exchange, not heads sent.

--- a/src/OrbitDB.js
+++ b/src/OrbitDB.js
@@ -156,13 +156,14 @@ class OrbitDB {
   }
 
   // Callback for receiving a message from the network
-  async _onMessage (address, heads) {
+  async _onMessage (address, heads, peer) {
     const store = this.stores[address]
     try {
       logger.debug(`Received ${heads.length} heads for '${address}':\n`, JSON.stringify(heads.map(e => e.hash), null, 2))
       if (store && heads && heads.length > 0) {
         await store.sync(heads)
       }
+      store.events.emit('peer.exchanged', peer, address, heads)
     } catch (e) {
       logger.error(e)
     }
@@ -175,7 +176,7 @@ class OrbitDB {
     const getStore = address => this.stores[address]
     const getDirectConnection = peer => this._directConnections[peer]
     const onChannelCreated = channel => this._directConnections[channel._receiverID] = channel
-    const onMessage = (address, heads) => this._onMessage(address, heads)
+    const onMessage = (address, heads) => this._onMessage(address, heads, peer)
 
     const channel = await exchangeHeads(
       this._ipfs,

--- a/src/OrbitDB.js
+++ b/src/OrbitDB.js
@@ -160,10 +160,12 @@ class OrbitDB {
     const store = this.stores[address]
     try {
       logger.debug(`Received ${heads.length} heads for '${address}':\n`, JSON.stringify(heads.map(e => e.hash), null, 2))
-      if (store && heads && heads.length > 0) {
-        await store.sync(heads)
+      if (store && heads) {
+        if (heads.length > 0) {
+          await store.sync(heads)
+        }
+        store.events.emit('peer.exchanged', peer, address, heads)
       }
-      store.events.emit('peer.exchanged', peer, address, heads)
     } catch (e) {
       logger.error(e)
     }


### PR DESCRIPTION
Requires: https://github.com/orbitdb/orbit-db-store/pull/38

This adds a new event:

```javascript
db.events.on('peer.exchanged', (peer, address, heads) => ... )
```

>Emitted after heads have been exchanged with a peer for a specific database. This will be emitted after every exchange, even if no heads are received from the peer, or if all received heads are already present. (This is in contrast with the `replicated` event, which will only fire when new heads have been received.) Note that `heads` here contains heads *received* as part of the exchange, not heads sent.

I'm open to a better event name.

This offers 2 things that the `replicated` event does not:
1. It should always fire when peers exchange heads for a database (and only after all of the sent heads have been synced). The `replicated` event does not fire if there are no heads sent, or if all heads sent are already present.
2. It includes the `peer` in the callback. `replicated` does not tell you which peer was replicated.

This solves the issue I described in https://github.com/orbitdb/orbit-db/issues/509.