### PR TITLE
docs: Stub out a Contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,4 @@
+# Contributing
+
+Check out our organization-wide [Contributing Guide](https://github.com/orbitdb/welcome/blob/master/contributing.md) before contributing to this repository. Thank you.
+


### PR DESCRIPTION
This will direct people to the correct document, and flag the guide as something to read when people open a PR or an issue on GitHub.