### PR TITLE
chore: Add maintainers to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,5 +62,10 @@
     "build:debug": "webpack --config conf/webpack.debug.config.js --sort-modules-by size && mkdir -p examples/browser/lib && cp dist/orbitdb.js examples/browser/lib/orbitdb.js && cp dist/orbitdb.js.map examples/browser/lib/orbitdb.js.map",
     "build:docs/toc": "markdown-toc --no-first1 -i README.md && markdown-toc --no-first1 -i API.md && markdown-toc --no-first1 -i GUIDE.md && markdown-toc --no-first1 -i CHANGELOG.md && markdown-toc --no-first1 -i FAQ.md ",
     "build:es5": "babel src --out-dir ./dist/es5/ --presets babel-preset-es2015 --plugins babel-plugin-transform-runtime"
-  }
+  },
+  "maintainers": [
+    "haad <haad@orbitdb.org>",
+    "shamb0t <shamb0t@orbitdb.org>",
+    "aphelionz <mark@orbitdb.org>"
+  ]
 }


### PR DESCRIPTION
Upon merging this, access rights should be given to both @shamb0t and @aphelionz to enable them to publish this package. This is in accordance with the OrbitDB [npm policy](https://github.com/orbitdb/welcome/blob/master/npm-policy.md). All maintianers must have 2FA enabled before given access.


- [ ] Enable 2FA (@haadcode)
- [x] Enable 2FA (@shamb0t)
- [x] Enable 2FA (@aphelionz)
- [ ] Give access to @aphelionz (@haadcode)
- [ ] Give access to @shamb0t (@haadcode)

I could also have publish rights, as needed. So could @vvp, I think.

I want to test this process with this repository, first. If anyone has any comments about how this is supposed to go, raise them here!