### PR TITLE
feat: Accept identity as an option when opening a DB

### DIFF
--- a/src/OrbitDB.js
+++ b/src/OrbitDB.js
@@ -168,8 +168,9 @@ let databaseTypes = {
       cache: cache,
       onClose: this._onClose.bind(this),
     })
+    const identity = options.identity || this.identity
 
-    const store = new Store(this._ipfs, this.identity, address, opts)
+    const store = new Store(this._ipfs, identity, address, opts)
     store.events.on('write', this._onWrite.bind(this))
     // ID of the store is the address as a string
     const addr = address.toString()

--- a/test/create-open.test.js
+++ b/test/create-open.test.js
@@ -9,6 +9,7 @@ const levelup = require('levelup')
 const leveldown = require('leveldown')
 const OrbitDB = require('../src/OrbitDB')
 const OrbitDBAddress = require('../src/orbit-db-address')
+const Identities = require('orbit-db-identity-provider')
 const io = require('orbit-db-io')
 // Include test utilities
 const {
@@ -256,6 +257,15 @@ Object.keys(testAPIs).forEach(API => {
         assert.equal(db.address.toString().indexOf('/orbitdb'), 0)
         assert.equal(db.address.toString().indexOf('zd'), 9)
         assert.equal(db.address.toString().indexOf('abc'), 59)
+      })
+
+      it('opens a database - with a different identity', async () => {
+        const identity = await Identities.createIdentity({ id: 'test-id' })
+        db = await orbitdb.open('abc', { create: true, type: 'feed', overwrite: true, identity })
+        assert.equal(db.address.toString().indexOf('/orbitdb'), 0)
+        assert.equal(db.address.toString().indexOf('zd'), 9)
+        assert.equal(db.address.toString().indexOf('abc'), 59)
+        assert.equal(db.identity, identity)
       })
 
       it('opens the same database - from an address', async () => {


### PR DESCRIPTION
This code adds the ability to pass an identity when you open a DB. This allows you to have multiple DBs open with different identities at the same time.