### PR TITLE
feat: Enable creation of DBs with old address format.

### DIFF
--- a/src/OrbitDB.js
+++ b/src/OrbitDB.js
@@ -251,7 +251,7 @@ let databaseTypes = {
     const accessControllerAddress = await AccessControllers.create(this, options.accessController.type, options.accessController || {})
 
     // Save the manifest to IPFS
-    const manifestHash = await createDBManifest(this._ipfs, name, type, accessControllerAddress, onlyHash)
+    const manifestHash = await createDBManifest(this._ipfs, name, type, accessControllerAddress, onlyHash, options.accessController.legacy)
 
     // Create the database address
     return OrbitDBAddress.parse(path.join('/orbitdb', manifestHash, name))

--- a/src/db-manifest.js
+++ b/src/db-manifest.js
@@ -2,14 +2,15 @@ const path = require('path')
 const io = require('orbit-db-io')
 
 // Creates a DB manifest file and saves it in IPFS
-const createDBManifest = async (ipfs, name, type, accessControllerAddress, onlyHash) => {
+const createDBManifest = async (ipfs, name, type, accessControllerAddress, onlyHash, legacy) => {
   const manifest = {
     name: name,
     type: type,
     accessController: path.join('/ipfs', accessControllerAddress),
   }
+  const codec = legacy ? 'dag-pb' : 'dag-cbor'
 
-  return io.write(ipfs, 'dag-cbor', manifest, { onlyHash })
+  return io.write(ipfs, codec, manifest, { onlyHash })
 }
 
 module.exports = createDBManifest


### PR DESCRIPTION
This change enables the creation of DBs with the old address format, by passing an additional option to the accessController. 

The main reason for this change is that in 3Box we are not saving the addresses of the users DBs. Rather, we generate the addresses by opening the DB with it's name and the writing key. Without this change we can only open a new db where the users data won't be available.

This PR depends on https://github.com/orbitdb/orbit-db-io/pull/2 and https://github.com/orbitdb/orbit-db-access-controllers/pull/29