### PR TITLE
Bumped NodeJS version

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:carbon
+FROM node:10
 
 ENV NPM_CONFIG_PREFIX=/home/node/.npm-global
 


### PR DESCRIPTION
- Bumped NodeJS version to 10 (container was building but not running any of the examples with the other version)
- Added SSL ignore to fix ssl issues when performing npm install