### PR TITLE
Examples folder default permission

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,12 +3,14 @@ FROM node:10
 ENV NPM_CONFIG_PREFIX=/home/node/.npm-global
 
 WORKDIR /home/node
-USER node
 
 COPY package.json ./
 COPY examples/ ./examples
 COPY src/ ./src
 COPY conf/ ./conf
+
+RUN chown -R node:node package.json examples src conf
+USER node
 
 RUN npm install babel-cli webpack \
  && npm install


### PR DESCRIPTION
When running the container and building the examples (on Windows 10), the following error occurs:
```
Error: EACCES: permission denied, open '/home/node/examples/browser/browser-webpack-example/bundle.js'
```

Commands used to test this fix:
```
docker build -t orbit-db -f docker/Dockerfile . --no-cache
docker run -ti --rm orbit-db npm run build:examples
```