### PR TITLE
fix: assert value exists

### DIFF
--- a/test/create-open.test.js
+++ b/test/create-open.test.js
@@ -134,7 +134,7 @@ Object.keys(testAPIs).forEach(API => {
 
         it('saves database manifest file locally', async () => {
           const manifest = await io.read(ipfs, db.address.root)
-          assert.notEqual(manifest, )
+          assert(manifest)
           assert.equal(manifest.name, 'second')
           assert.equal(manifest.type, 'feed')
           assert.notEqual(manifest.accessController, null)


### PR DESCRIPTION
Fixes:

```
     TypeError [ERR_MISSING_ARGS]: The "actual" and "expected" arguments must be specified
      at Function.notEqual (assert.js:406:11)
      at Context.<anonymous> (test/create-open.test.js:137:18)
```