### PR TITLE
Ensure webpack compiles in downstream projects

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12354,6 +12354,17 @@
         "logplease": "~1.2.15",
         "mkdirp": "^0.5.1",
         "orbit-db-storage-adapter": "^0.4.1"
+      },
+      "dependencies": {
+        "orbit-db-storage-adapter": {
+          "version": "0.4.2",
+          "resolved": "https://registry.npmjs.org/orbit-db-storage-adapter/-/orbit-db-storage-adapter-0.4.2.tgz",
+          "integrity": "sha512-2uj0MuFh2H+mdZJ309ULbwyaOVQ2/eOlbC3hiFMiceYQFoYkYRaGxnUv0fmctgaa6PZHe+brE9w6MqNKYp4s/Q==",
+          "requires": {
+            "level": "^5.0.1",
+            "mkdirp": "^0.5.1"
+          }
+        }
       }
     },
     "orbit-db-counterstore": {
@@ -12466,9 +12477,9 @@
       }
     },
     "orbit-db-storage-adapter": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/orbit-db-storage-adapter/-/orbit-db-storage-adapter-0.4.2.tgz",
-      "integrity": "sha512-2uj0MuFh2H+mdZJ309ULbwyaOVQ2/eOlbC3hiFMiceYQFoYkYRaGxnUv0fmctgaa6PZHe+brE9w6MqNKYp4s/Q==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/orbit-db-storage-adapter/-/orbit-db-storage-adapter-0.5.0.tgz",
+      "integrity": "sha512-3rmEg/Z/fo5re5bppSyzD61RNveVSLFknj5mFv4L8zcEAcWE0gSHMaYeZMqmUiKXvoKdPs7ntzmZzr0iLvQm0A==",
       "requires": {
         "level": "^5.0.1",
         "mkdirp": "^0.5.1"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "orbit-db-keystore": "next",
     "orbit-db-kvstore": "next",
     "orbit-db-pubsub": "~0.5.5",
-    "orbit-db-storage-adapter": "^0.4.2",
+    "orbit-db-storage-adapter": "^0.5.0",
     "orbit-db-store": "next"
   },
   "devDependencies": {

--- a/src/OrbitDB.js
+++ b/src/OrbitDB.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const fs = require('fs')
+const fs = require('./fs-shim')
 const path = require('path')
 const EventStore = require('orbit-db-eventstore')
 const FeedStore = require('orbit-db-feedstore')
@@ -17,7 +17,6 @@ const createDBManifest = require('./db-manifest')
 const exchangeHeads = require('./exchange-heads')
 const { isDefined, io } = require('./utils')
 const Storage = require('orbit-db-storage-adapter')
-const leveldown = require('leveldown')
 const migrations = require('./migrations')
 
 const Logger = require('logplease')
@@ -65,12 +64,15 @@ class OrbitDB {
 
     if (!options.storage) {
       let storageOptions = {}
+
       if (fs && fs.mkdirSync) {
         storageOptions.preCreate = async (directory) => {
           fs.mkdirSync(directory, { recursive: true })
         }
       }
-      options.storage = Storage(leveldown, storageOptions)
+
+      // Create default `level` store
+      options.storage = Storage(null, storageOptions)
     }
 
     if (!options.keystore) {

--- a/src/fs-shim.js
+++ b/src/fs-shim.js
@@ -1,0 +1,4 @@
+const fs = (typeof window === 'object' || typeof self === 'object') ? null
+  : eval('require("fs")')
+
+module.exports = fs

--- a/src/migrations/0.21-0.22.js
+++ b/src/migrations/0.21-0.22.js
@@ -1,5 +1,5 @@
 const path = require('path')
-const fs = require('fs')
+const fs = require('../fs-shim')
 
 const Cache = require('orbit-db-cache')
 


### PR DESCRIPTION
This PR removes `leveldown` as a direct dependency, instead relying on the implementation of `level` in `orbit-db-storage-adapter`, which in turn handles browser vs node dependency switching.

In addition, it utilizes a neat trick that uses eval to require the `fs` module, ensuring webpack compilation while still allowing node to use `fs`