### PR TITLE
adds optional meta field to manifest

### DIFF
--- a/src/OrbitDB.js
+++ b/src/OrbitDB.js
@@ -380,7 +380,7 @@ class OrbitDB {
     await this._addManifestToCache(options.cache, dbAddress)
 
     // Open the the database
-    options = Object.assign({}, options, { accessControllerAddress: manifest.accessController })
+    options = Object.assign({}, options, { accessControllerAddress: manifest.accessController, meta: manifest.meta })
     return this._createStore(manifest.type, dbAddress, options)
   }
 

--- a/src/db-manifest.js
+++ b/src/db-manifest.js
@@ -6,7 +6,9 @@ const createDBManifest = async (ipfs, name, type, accessControllerAddress, optio
   const manifest = {
     name: name,
     type: type,
-    accessController: path.join('/ipfs', accessControllerAddress)
+    accessController: path.join('/ipfs', accessControllerAddress),
+    // meta field is only added to manifest if options.meta is defined
+    ...(options.meta !== undefined ? { meta: options.meta } : {})
   }
 
   return io.write(ipfs, options.format || 'dag-cbor', manifest, options)

--- a/src/db-manifest.js
+++ b/src/db-manifest.js
@@ -3,13 +3,14 @@ const io = require('orbit-db-io')
 
 // Creates a DB manifest file and saves it in IPFS
 const createDBManifest = async (ipfs, name, type, accessControllerAddress, options) => {
-  const manifest = {
+  const manifest = Object.assign({
     name: name,
     type: type,
-    accessController: path.join('/ipfs', accessControllerAddress),
-    // meta field is only added to manifest if options.meta is defined
-    ...(options.meta !== undefined ? { meta: options.meta } : {})
-  }
+    accessController: path.join('/ipfs', accessControllerAddress)
+  },
+  // meta field is only added to manifest if options.meta is defined
+  options.meta !== undefined ? { meta: options.meta } : {}
+  )
 
   return io.write(ipfs, options.format || 'dag-cbor', manifest, options)
 }

--- a/test/create-open.test.js
+++ b/test/create-open.test.js
@@ -225,7 +225,7 @@ Object.keys(testAPIs).forEach(API => {
           it('creates a manifest with no meta field', async () => {
             db = await orbitdb.create('no-meta', 'feed')
             const manifest = await io.read(ipfs, db.address.root)
-            assert.strictEqual(db.options.meta, undefined)
+            assert.strictEqual(manifest.meta, undefined)
             assert.deepStrictEqual(Object.keys(manifest).filter(k => k === 'meta'), [])
           })
 
@@ -233,7 +233,7 @@ Object.keys(testAPIs).forEach(API => {
             const meta = { test: 123 }
             db = await orbitdb.create('meta', 'feed', { meta })
             const manifest = await io.read(ipfs, db.address.root)
-            assert.deepStrictEqual(db.options.meta, meta)
+            assert.deepStrictEqual(manifest.meta, meta)
             assert.deepStrictEqual(Object.keys(manifest).filter(k => k === 'meta'), ['meta'])
           })
         })

--- a/test/create-open.test.js
+++ b/test/create-open.test.js
@@ -207,6 +207,36 @@ Object.keys(testAPIs).forEach(API => {
             assert.deepEqual(db.access.write, [orbitdb.identity.id])
           })
         })
+        describe('Meta', function() {
+          before(async () => {
+            if (db) {
+              await db.close()
+              await db.drop()
+            }
+          })
+
+          afterEach(async () => {
+            if (db) {
+              await db.close()
+              await db.drop()
+            }
+          })
+
+          it('creates a manifest with no meta field', async () => {
+            db = await orbitdb.create('no-meta', 'feed')
+            const manifest = await io.read(ipfs, db.address.root)
+            assert.strictEqual(db.options.meta, undefined)
+            assert.deepStrictEqual(Object.keys(manifest).filter(k => k === 'meta'), [])
+          })
+
+          it('creates a manifest with a meta field', async () => {
+            const meta = { test: 123 }
+            db = await orbitdb.create('meta', 'feed', { meta })
+            const manifest = await io.read(ipfs, db.address.root)
+            assert.deepStrictEqual(db.options.meta, meta)
+            assert.deepStrictEqual(Object.keys(manifest).filter(k => k === 'meta'), ['meta'])
+          })
+        })
       })
     })
 


### PR DESCRIPTION
This PR would give users the ability to add additional data to the db manifest. This could be useful when wanting to package information with the db that should not change during the lifetime of the db. An example could be adding a public ECDH key that the owner of the db controls.

The meta field would only exist in the manifest if `options.meta !== undefined` is true when creating the database. This keeps db addresses the same as before when creating a db without a meta field. When creating a db with a meta field, make options.meta equal to a JSON serialize-able value so it can safely traverse to/from ipfs. This value with be readable in the db instance property db.options.meta (if the manifest does not contain a meta field db.options.meta is undefined).

The tests added will check when creating a db that 1) the meta field is only added to the manifest if options.meta is defined 2) if there is no meta field in the manifest db.options.meta is undefined 3) if there is a meta field when options.meta is defined and options.meta is equal to db.options.meta