### PR TITLE
fix: exchanges heads with peer, once the heads are available

### DIFF
--- a/src/exchange-heads.js
+++ b/src/exchange-heads.js
@@ -33,11 +33,19 @@ const exchangeHeads = async (ipfs, address, peer, getStore, getDirectConnection,
   logger.debug(`Connected to ${peer}`)
 
   // Send the heads if we have any
-  const heads = getHeadsForDatabase(getStore(address))
+  const store = getStore(address)
+  const heads = getHeadsForDatabase(store)
+
   logger.debug(`Send latest heads of '${address}':\n`, JSON.stringify(heads.map(e => e.hash), null, 2))
   if (heads) {
     await channel.send(JSON.stringify({ address: address, heads: heads }))
   }
+
+  // resend if store was originally not ready
+  store.events.on('ready', () => {
+    const heads = getHeadsForDatabase(store)
+    if (heads) channel.send(JSON.stringify({ address: address, heads: heads }))
+  })
 
   return channel
 }


### PR DESCRIPTION
Fixes a bug where a peer connects before the db is 'ready' (before it has store._oplog.heads available), and  it doesn't exchanges any heads with the peer as a result. 

This listens for ready event on given store, and will exchange heads again if the store was not ready on original call. 

Seemed like simplest implementation of fix, but maybe better fix exist that manages this state and only sends once. Either way overhead seemed low, to just send redundantly in these cases. 