### PR TITLE
Upgrade to non-rc IPFS

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "datastore-level": "0.10.0",
     "fs-extra": "^7.0.1",
     "go-ipfs-dep": "aphelionz/npm-go-ipfs-dep",
-    "ipfs": "0.38.0-rc.4",
+    "ipfs": "^0.38.0",
     "ipfs-http-client": "^37.0.1",
     "ipfs-repo": "~0.26.6",
     "ipfsd-ctl": "~0.42.3",


### PR DESCRIPTION
`ipfs@0.38.0` has shipped so no need to depend on the release candidate any more.