### PR TITLE
Error if address path mismatches manifest name

### DIFF
--- a/src/OrbitDB.js
+++ b/src/OrbitDB.js
@@ -433,8 +433,9 @@ class OrbitDB {
     logger.debug(`Manifest for '${dbAddress}':\n${JSON.stringify(manifest, null, 2)}`)
 
     // Make sure the type from the manifest matches the type that was given as an option
+    if (manifest.name !== dbAddress.path) { throw new Error(`Manifest '${manifest.name}' cannot be opened as '${dbAddress.path}'`) }
     if (options.type && manifest.type !== options.type) { throw new Error(`Database '${dbAddress}' is type '${manifest.type}' but was opened as '${options.type}'`) }
-
+    
     // Save the database locally
     await this._addManifestToCache(options.cache, dbAddress)
 

--- a/test/create-type.test.js
+++ b/test/create-type.test.js
@@ -53,7 +53,7 @@ Object.keys(testAPIs).forEach(API => {
     describe('addDatabaseType', function () {
       it('should have the correct custom type', async () => {
         OrbitDB.addDatabaseType(CustomStore.type, CustomStore)
-        let store = await orbitdb.create(dbPath, CustomStore.type)
+        let store = await orbitdb.create(dbPath.replace(/^\.\//, ''), CustomStore.type)
         assert.equal(store._type, CustomStore.type)
       })
 


### PR DESCRIPTION
Currently it's possible to open a db via an address with a different path component then what the original manifest name was set to. This Pr prevents the issue by throwing an error is such a mismatch occurs.