### PR TITLE
Add offline mode

### DIFF
--- a/API.md
+++ b/API.md
@@ -81,9 +81,11 @@ Creates and returns an instance of OrbitDB. Use the optional `options` argument 
 
 - `keystore` (Keystore Instance) : By default creates an instance of [Keystore](https://github.com/orbitdb/orbit-db-keystore). A custom keystore instance can be used, see [this](https://github.com/orbitdb/orbit-db/blob/master/test/utils/custom-test-keystore.js) for an example.
 
-- 'cache' (Cache Instance) : By default creates an instance of [Cache](https://github.com/orbitdb/orbit-db-cache). A custom cache instance can also be used.
+- `cache` (Cache Instance) : By default creates an instance of [Cache](https://github.com/orbitdb/orbit-db-cache). A custom cache instance can also be used.
 
 - `identity` (Identity Instance): By default it creates an instance of [Identity](https://github.com/orbitdb/orbit-db-identity-provider/blob/master/src/identity.js)
+
+- `offline` (boolean): Start the OrbitDB instance in offline mode. Databases are not be replicated when the instance is started in offline mode. If the OrbitDB instance was started offline mode and you want to start replicating databases, the OrbitDB instance needs to be re-created. Default: `false`.
 
 After creating an `OrbitDB` instance, you can access the different data stores. Creating a database instance, eg. with `orbitdb.keyvalue(...)`, returns a *Promise* that resolves to a [database instance](#store-api). See the [Store](#store-api) section for details of common methods and properties.
 

--- a/test/offline-mode.js
+++ b/test/offline-mode.js
@@ -1,0 +1,78 @@
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+const assert = require('assert')
+const mapSeries = require('p-map-series')
+const rmrf = require('rimraf')
+const IPFS = require('ipfs')
+const OrbitDB = require('../src/OrbitDB')
+const Identities = require('orbit-db-identity-provider')
+const Keystore = require('orbit-db-keystore')
+const leveldown = require('leveldown')
+const storage = require('orbit-db-storage-adapter')(leveldown)
+
+// Include test utilities
+const {
+  config,
+  startIpfs,
+  stopIpfs,
+  testAPIs,
+} = require('./utils')
+
+const dbPath1 = './orbitdb/tests/offline/db1'
+const dbPath2 = './orbitdb/tests/offline/db2'
+const ipfsPath = './orbitdb/tests/offline/ipfs'
+
+Object.keys(testAPIs).forEach(API => {
+  describe(`orbit-db - Offline mode (${API})`, function() {
+    this.timeout(config.timeout)
+
+    let ipfsd1, ipfsd2, ipfs1, ipfs2, orbitdb, db, keystore
+    let identity1, identity2
+    let localDataPath
+
+    before(async () => {
+      config.daemon1.repo = path.join(ipfsPath, '/1')
+      config.daemon2.repo = path.join(ipfsPath, '/2')
+      rmrf.sync(config.daemon1.repo)
+      rmrf.sync(config.daemon2.repo)
+      rmrf.sync(path.join(ipfsPath, '/2'))
+      rmrf.sync('./orbitdb/tests/offline')
+      rmrf.sync(dbPath1)
+      rmrf.sync(dbPath2)
+      ipfsd1 = await startIpfs(API, config.daemon1)
+      ipfsd2 = await startIpfs(API, config.daemon2)
+      ipfs1 = ipfsd1.api
+      ipfs2 = ipfsd2.api
+    })
+
+    after(async () => {
+      if(orbitdb)
+        await orbitdb.stop()
+
+      if (ipfsd1)
+        await stopIpfs(ipfsd1)
+      if (ipfsd2)
+        await stopIpfs(ipfsd2)
+    })
+
+    it('starts in offline mode', async () => {
+      orbitdb = await OrbitDB.createInstance(ipfs1, { offline: true, directory: dbPath1 })
+      assert.equal(orbitdb._pubsub, null)
+      await orbitdb.stop()
+    })
+
+    it('does not start in offline mode', async () => {
+      orbitdb = await OrbitDB.createInstance(ipfs1, { offline: false, directory: dbPath1 })
+      assert.notEqual(orbitdb._pubsub, null)
+      await orbitdb.stop()
+    })
+
+    it('does not start in offline mode - default', async () => {
+      orbitdb = await OrbitDB.createInstance(ipfs1, { directory: dbPath1 })
+      assert.notEqual(orbitdb._pubsub, null)
+      await orbitdb.stop()
+    })
+  })
+})


### PR DESCRIPTION
This PR adds an options flag to start an OrbitDB instance in offline mode. 

Inside OrbitDB, if `options.offline: true` is set, Pubsub won't be started, thus no exchange of updates will happen.

This is a useful feature for example when starting IPFS nodes offline (with `new IPFS({start: false})`). For example, we should optimize some of the tests to use offline IPFS and OrbitDB nodes for faster startup times and to decrease overall testing time.

The flag is documented as:

- `offline` (boolean): Start the OrbitDB instance in offline mode. Databases are not be replicated when the instance is started in offline mode. If the OrbitDB instance was started offline mode and you want to start replicating databases, the OrbitDB instance needs to be re-created. Default: `false`.

And would be used like:
```js
const orbitdb = await OrbitDB.createInstance(ipfs, {offline: true})
...
```

**Note**, as per the API doc, if the OrbitDB instance was started offline mode and you want to start replicating databases, the OrbitDB instance needs to be re-created. There's currently no support for "going online" if the node has been started in offline mode, but this is something we can add in the future.

