### PR TITLE
Allow hashes to begining with 'ba'

### DIFF
--- a/src/orbit-db-address.js
+++ b/src/orbit-db-address.js
@@ -27,7 +27,7 @@ class OrbitDBAddress {
     let accessControllerHash
 
     try {
-      accessControllerHash = (parts[0].indexOf('zd') > -1 || parts[0].indexOf('Qm') > -1)
+      accessControllerHash = (parts[0].indexOf('zd') > -1 || parts[0].indexOf('Qm') > -1 || parts[0].indexOf('ba') > -1)
         ? new CID(parts[0]).toBaseEncodedString()
         : null
     } catch (e) {


### PR DESCRIPTION
Re https://github.com/orbitdb/orbit-db-http-api/issues/23 
On some occasions an ipfs address can start with `ba`
```
ipfs dag get bafyreicjqmfea2dlhcbyszyneaxcpdhlxjpsycxxaibpp4wlzfctiujxdm
{"accessController":"/ipfs/zdpuAzt2GWKYeF4Pbo3hcMipCimE7SqCKZcckGduqcDJ3tmRx","name":"docstore","type":"docstore"}

 ipfs cid format -f "%P" bafyreicjqmfea2dlhcbyszyneaxcpdhlxjpsycxxaibpp4wlzfctiujxdm
cidv1-cbor-sha2-256-32
```