### PR TITLE
adds toJSON method to orbitdb address class

### DIFF
--- a/src/orbit-db-address.js
+++ b/src/orbit-db-address.js
@@ -14,6 +14,10 @@ class OrbitDBAddress {
     return OrbitDBAddress.join(this.root, this.path)
   }
 
+  toJSON () {
+    return this.toString()
+  }
+
   static isValid (address) {
     address = address.toString().replace(/\\/g, '/')
 

--- a/test/orbit-db-address.test.js
+++ b/test/orbit-db-address.test.js
@@ -63,6 +63,24 @@ Object.keys(testAPIs).forEach(API => {
         assert.equal(result.toString().indexOf('zd'), 9)
       })
 
+      it('parse address after json serialization', () => {
+        const address = JSON.parse(JSON.stringify(
+          OrbitDB.parseAddress(
+            '/orbitdb/zdpuAuK3BHpS7NvMBivynypqciYCuy2UW77XYBPUYRnLjnw13/first-database'
+          )
+        ))
+        const result = OrbitDB.parseAddress(address)
+
+        const isInstanceOf = result instanceof OrbitDBAddress
+        assert.equal(isInstanceOf, true)
+
+        assert.equal(result.root, 'zdpuAuK3BHpS7NvMBivynypqciYCuy2UW77XYBPUYRnLjnw13')
+        assert.equal(result.path, 'first-database')
+
+        assert.equal(result.toString().indexOf('/orbitdb'), 0)
+        assert.equal(result.toString().indexOf('zd'), 9)
+      })
+
       it('parse address with backslashes (win32) successfully', () => {
         const address = '\\orbitdb\\Qmdgwt7w4uBsw8LXduzCd18zfGXeTmBsiR8edQ1hSfzcJC\\first-database'
         const result = OrbitDB.parseAddress(address)


### PR DESCRIPTION
Currently json serializing an orbitdb address results in the json value `{ root: "<root>", path: "<path>" }` which throws an error when fed back into address.parse.

Adding a toJSON method that returns this.toString() would make the json serialized address again parseable by the address class.

This is small change but is breaking the behavior of how json.stringify serializes the address currently.