### PR TITLE
Fix assert.notEqual

### DIFF
--- a/test/create-open.test.js
+++ b/test/create-open.test.js
@@ -142,7 +142,7 @@ Object.keys(testAPIs).forEach(API => {
         it('saves database manifest file locally', async () => {
           const manifestHash = db.id.split('/')[2]
           const manifest = await io.read(ipfs, manifestHash)
-          assert.notEqual(manifest)
+          assert.notEqual(manifest, false)
           assert.equal(manifest.name, 'second')
           assert.equal(manifest.type, 'feed')
           assert.notEqual(manifest.accessController, null)


### PR DESCRIPTION
Fixes the following errors:
```
 2) orbit-db - Create & Open (js-ipfs)
       Create
         Success
           saves database manifest file locally:
     TypeError [ERR_MISSING_ARGS]: The "actual" and "expected" arguments must be specified
      at Function.notEqual (assert.js:418:11)
      at Context.<anonymous> (test/create-open.test.js:145:18)

  3) orbit-db - Create & Open (go-ipfs)
       Create
         Success
           saves database manifest file locally:
     TypeError [ERR_MISSING_ARGS]: The "actual" and "expected" arguments must be specified
      at Function.notEqual (assert.js:418:11)
      at Context.<anonymous> (test/create-open.test.js:145:18)
      at runMicrotasks (<anonymous>)
      at processTicksAndRejections (internal/process/task_queues.js:97:5)
```