### PR TITLE
fix: support POST-only API of go-ipfs 0.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,13 +160,16 @@ initIPFSInstance().then(ipfs => {
 ```
 
 ### Module with IPFS Daemon
-Alternatively, you can use [ipfs-api](https://npmjs.org/package/ipfs-api) to use `orbit-db` with a locally running IPFS daemon. Use this method if you're using `orbitd-db` to develop **backend** or **desktop** applications, eg. with [Electron](https://electron.atom.io).
+
+Alternatively, you can use [ipfs-http-client](https://www.npmjs.com/package/ipfs-http-client) to use `orbit-db` with a locally running IPFS daemon. Use this method if you're using `orbitd-db` to develop **backend** or **desktop** applications, eg. with [Electron](https://electron.atom.io).
 
 Install dependencies:
 
 ```
-npm install orbit-db ipfs-http-client
+npm install orbit-db ipfs-http-client@41.0.1
 ```
+
+**Note:** need to use v41.0.1 until support for modern JS API is added in [orbit-db#767](https://github.com/orbitdb/orbit-db/pull/767).
 
 ```javascript
 const IpfsClient = require('ipfs-http-client')

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,367 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@hapi/accept": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@hapi/accept/-/accept-3.2.4.tgz",
+      "integrity": "sha512-soThGB+QMgfxlh0Vzhzlf3ZOEOPk5biEwcOXhkF0Eedqx8VnhGiggL9UYHrIsOb1rUg3Be3K8kp0iDL2wbVSOQ==",
+      "requires": {
+        "@hapi/boom": "7.x.x",
+        "@hapi/hoek": "8.x.x"
+      }
+    },
+    "@hapi/address": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.1.4.tgz",
+      "integrity": "sha512-QD1PhQk+s31P1ixsX0H0Suoupp3VMXzIVMSwobR3F3MSUO2YCV0B7xqLcUw/Bh8yuvd3LhpyqLQWTNcRmp6IdQ=="
+    },
+    "@hapi/ammo": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@hapi/ammo/-/ammo-3.1.2.tgz",
+      "integrity": "sha512-ej9OtFmiZv1qr45g1bxEZNGyaR4jRpyMxU6VhbxjaYThymvOwsyIsUKMZnP5Qw2tfYFuwqCJuIBHGpeIbdX9gQ==",
+      "requires": {
+        "@hapi/hoek": "8.x.x"
+      }
+    },
+    "@hapi/b64": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@hapi/b64/-/b64-4.2.1.tgz",
+      "integrity": "sha512-zqHpQuH5CBMw6hADzKfU/IGNrxq1Q+/wTYV+OiZRQN9F3tMyk+9BUMeBvFRMamduuqL8iSp62QAnJ+7ATiYLWA==",
+      "requires": {
+        "@hapi/hoek": "8.x.x"
+      }
+    },
+    "@hapi/boom": {
+      "version": "7.4.11",
+      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-7.4.11.tgz",
+      "integrity": "sha512-VSU/Cnj1DXouukYxxkes4nNJonCnlogHvIff1v1RVoN4xzkKhMXX+GRmb3NyH1iar10I9WFPDv2JPwfH3GaV0A==",
+      "requires": {
+        "@hapi/hoek": "8.x.x"
+      }
+    },
+    "@hapi/bounce": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@hapi/bounce/-/bounce-1.3.2.tgz",
+      "integrity": "sha512-3bnb1AlcEByFZnpDIidxQyw1Gds81z/1rSqlx4bIEE+wUN0ATj0D49B5cE1wGocy90Rp/de4tv7GjsKd5RQeew==",
+      "requires": {
+        "@hapi/boom": "7.x.x",
+        "@hapi/hoek": "^8.3.1"
+      }
+    },
+    "@hapi/bourne": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-1.3.2.tgz",
+      "integrity": "sha512-1dVNHT76Uu5N3eJNTYcvxee+jzX4Z9lfciqRRHCU27ihbUcYi+iSc2iml5Ke1LXe1SyJCLA0+14Jh4tXJgOppA=="
+    },
+    "@hapi/call": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/@hapi/call/-/call-5.1.3.tgz",
+      "integrity": "sha512-5DfWpMk7qZiYhvBhM5oUiT4GQ/O8a2rFR121/PdwA/eZ2C1EsuD547ZggMKAR5bZ+FtxOf0fdM20zzcXzq2mZA==",
+      "requires": {
+        "@hapi/boom": "7.x.x",
+        "@hapi/hoek": "8.x.x"
+      }
+    },
+    "@hapi/catbox": {
+      "version": "10.2.3",
+      "resolved": "https://registry.npmjs.org/@hapi/catbox/-/catbox-10.2.3.tgz",
+      "integrity": "sha512-kN9hXO4NYyOHW09CXiuj5qW1syc/0XeVOBsNNk0Tz89wWNQE5h21WF+VsfAw3uFR8swn/Wj3YEVBnWqo82m/JQ==",
+      "requires": {
+        "@hapi/boom": "7.x.x",
+        "@hapi/hoek": "8.x.x",
+        "@hapi/joi": "16.x.x",
+        "@hapi/podium": "3.x.x"
+      },
+      "dependencies": {
+        "@hapi/joi": {
+          "version": "16.1.8",
+          "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-16.1.8.tgz",
+          "integrity": "sha512-wAsVvTPe+FwSrsAurNt5vkg3zo+TblvC5Bb1zMVK6SJzZqw9UrJnexxR+76cpePmtUZKHAPxcQ2Bf7oVHyahhg==",
+          "requires": {
+            "@hapi/address": "^2.1.2",
+            "@hapi/formula": "^1.2.0",
+            "@hapi/hoek": "^8.2.4",
+            "@hapi/pinpoint": "^1.0.2",
+            "@hapi/topo": "^3.1.3"
+          }
+        }
+      }
+    },
+    "@hapi/catbox-memory": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/catbox-memory/-/catbox-memory-4.1.1.tgz",
+      "integrity": "sha512-T6Hdy8DExzG0jY7C8yYWZB4XHfc0v+p1EGkwxl2HoaPYAmW7I3E59M/IvmSVpis8RPcIoBp41ZpO2aZPBpM2Ww==",
+      "requires": {
+        "@hapi/boom": "7.x.x",
+        "@hapi/hoek": "8.x.x"
+      }
+    },
+    "@hapi/content": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/content/-/content-4.1.1.tgz",
+      "integrity": "sha512-3TWvmwpVPxFSF3KBjKZ8yDqIKKZZIm7VurDSweYpXYENZrJH3C1hd1+qEQW9wQaUaI76pPBLGrXl6I3B7i3ipA==",
+      "requires": {
+        "@hapi/boom": "7.x.x"
+      }
+    },
+    "@hapi/cryptiles": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@hapi/cryptiles/-/cryptiles-4.2.1.tgz",
+      "integrity": "sha512-XoqgKsHK0l/VpqPs+tr6j6vE+VQ3+2bkF2stvttmc7xAOf1oSAwHcJ0tlp/6MxMysktt1IEY0Csy3khKaP9/uQ==",
+      "requires": {
+        "@hapi/boom": "7.x.x"
+      }
+    },
+    "@hapi/file": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/file/-/file-1.0.0.tgz",
+      "integrity": "sha512-Bsfp/+1Gyf70eGtnIgmScvrH8sSypO3TcK3Zf0QdHnzn/ACnAkI6KLtGACmNRPEzzIy+W7aJX5E+1fc9GwIABQ=="
+    },
+    "@hapi/formula": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@hapi/formula/-/formula-1.2.0.tgz",
+      "integrity": "sha512-UFbtbGPjstz0eWHb+ga/GM3Z9EzqKXFWIbSOFURU0A/Gku0Bky4bCk9/h//K2Xr3IrCfjFNhMm4jyZ5dbCewGA=="
+    },
+    "@hapi/hapi": {
+      "version": "18.4.1",
+      "resolved": "https://registry.npmjs.org/@hapi/hapi/-/hapi-18.4.1.tgz",
+      "integrity": "sha512-9HjVGa0Z4Qv9jk9AVoUdJMQLA+KuZ+liKWyEEkVBx3e3H1F0JM6aGbPkY9jRfwsITBWGBU2iXazn65SFKSi/tg==",
+      "requires": {
+        "@hapi/accept": "^3.2.4",
+        "@hapi/ammo": "^3.1.2",
+        "@hapi/boom": "7.x.x",
+        "@hapi/bounce": "1.x.x",
+        "@hapi/call": "^5.1.3",
+        "@hapi/catbox": "10.x.x",
+        "@hapi/catbox-memory": "4.x.x",
+        "@hapi/heavy": "6.x.x",
+        "@hapi/hoek": "8.x.x",
+        "@hapi/joi": "15.x.x",
+        "@hapi/mimos": "4.x.x",
+        "@hapi/podium": "3.x.x",
+        "@hapi/shot": "4.x.x",
+        "@hapi/somever": "2.x.x",
+        "@hapi/statehood": "6.x.x",
+        "@hapi/subtext": "^6.1.3",
+        "@hapi/teamwork": "3.x.x",
+        "@hapi/topo": "3.x.x"
+      }
+    },
+    "@hapi/heavy": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/@hapi/heavy/-/heavy-6.2.2.tgz",
+      "integrity": "sha512-PY1dCCO6dsze7RlafIRhTaGeyTgVe49A/lSkxbhKGjQ7x46o/OFf7hLiRqTCDh3atcEKf6362EaB3+kTUbCsVA==",
+      "requires": {
+        "@hapi/boom": "7.x.x",
+        "@hapi/hoek": "8.x.x",
+        "@hapi/joi": "16.x.x"
+      },
+      "dependencies": {
+        "@hapi/joi": {
+          "version": "16.1.8",
+          "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-16.1.8.tgz",
+          "integrity": "sha512-wAsVvTPe+FwSrsAurNt5vkg3zo+TblvC5Bb1zMVK6SJzZqw9UrJnexxR+76cpePmtUZKHAPxcQ2Bf7oVHyahhg==",
+          "requires": {
+            "@hapi/address": "^2.1.2",
+            "@hapi/formula": "^1.2.0",
+            "@hapi/hoek": "^8.2.4",
+            "@hapi/pinpoint": "^1.0.2",
+            "@hapi/topo": "^3.1.3"
+          }
+        }
+      }
+    },
+    "@hapi/hoek": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.1.tgz",
+      "integrity": "sha512-yN7kbciD87WzLGc5539Tn0sApjyiGHAJgKvG9W8C7O+6c7qmoQMfVs0W4bX17eqz6C78QJqqFrtgdK5EWf6Qow=="
+    },
+    "@hapi/iron": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/@hapi/iron/-/iron-5.1.4.tgz",
+      "integrity": "sha512-+ElC+OCiwWLjlJBmm8ZEWjlfzTMQTdgPnU/TsoU5QsktspIWmWi9IU4kU83nH+X/SSya8TP8h8P11Wr5L7dkQQ==",
+      "requires": {
+        "@hapi/b64": "4.x.x",
+        "@hapi/boom": "7.x.x",
+        "@hapi/bourne": "1.x.x",
+        "@hapi/cryptiles": "4.x.x",
+        "@hapi/hoek": "8.x.x"
+      }
+    },
+    "@hapi/joi": {
+      "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-15.1.1.tgz",
+      "integrity": "sha512-entf8ZMOK8sc+8YfeOlM8pCfg3b5+WZIKBfUaaJT8UsjAAPjartzxIYm3TIbjvA4u+u++KbcXD38k682nVHDAQ==",
+      "requires": {
+        "@hapi/address": "2.x.x",
+        "@hapi/bourne": "1.x.x",
+        "@hapi/hoek": "8.x.x",
+        "@hapi/topo": "3.x.x"
+      }
+    },
+    "@hapi/mimos": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/mimos/-/mimos-4.1.1.tgz",
+      "integrity": "sha512-CXoi/zfcTWfKYX756eEea8rXJRIb9sR4d7VwyAH9d3BkDyNgAesZxvqIdm55npQc6S9mU3FExinMAQVlIkz0eA==",
+      "requires": {
+        "@hapi/hoek": "8.x.x",
+        "mime-db": "1.x.x"
+      }
+    },
+    "@hapi/nigel": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/nigel/-/nigel-3.1.1.tgz",
+      "integrity": "sha512-R9YWx4S8yu0gcCBrMUDCiEFm1SQT895dMlYoeNBp8I6YhF1BFF1iYPueKA2Kkp9BvyHdjmvrxCOns7GMmpl+Fw==",
+      "requires": {
+        "@hapi/hoek": "8.x.x",
+        "@hapi/vise": "3.x.x"
+      }
+    },
+    "@hapi/pez": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@hapi/pez/-/pez-4.1.2.tgz",
+      "integrity": "sha512-8zSdJ8cZrJLFldTgwjU9Fb1JebID+aBCrCsycgqKYe0OZtM2r3Yv3aAwW5z97VsZWCROC1Vx6Mdn4rujh5Ktcg==",
+      "requires": {
+        "@hapi/b64": "4.x.x",
+        "@hapi/boom": "7.x.x",
+        "@hapi/content": "^4.1.1",
+        "@hapi/hoek": "8.x.x",
+        "@hapi/nigel": "3.x.x"
+      }
+    },
+    "@hapi/pinpoint": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/pinpoint/-/pinpoint-1.0.2.tgz",
+      "integrity": "sha512-dtXC/WkZBfC5vxscazuiJ6iq4j9oNx1SHknmIr8hofarpKUZKmlUVYVIhNVzIEgK5Wrc4GMHL5lZtt1uS2flmQ=="
+    },
+    "@hapi/podium": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@hapi/podium/-/podium-3.4.3.tgz",
+      "integrity": "sha512-QJlnYLEYZWlKQ9fSOtuUcpANyoVGwT68GA9P0iQQCAetBK0fI+nbRBt58+aMixoifczWZUthuGkNjqKxgPh/CQ==",
+      "requires": {
+        "@hapi/hoek": "8.x.x",
+        "@hapi/joi": "16.x.x"
+      },
+      "dependencies": {
+        "@hapi/joi": {
+          "version": "16.1.8",
+          "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-16.1.8.tgz",
+          "integrity": "sha512-wAsVvTPe+FwSrsAurNt5vkg3zo+TblvC5Bb1zMVK6SJzZqw9UrJnexxR+76cpePmtUZKHAPxcQ2Bf7oVHyahhg==",
+          "requires": {
+            "@hapi/address": "^2.1.2",
+            "@hapi/formula": "^1.2.0",
+            "@hapi/hoek": "^8.2.4",
+            "@hapi/pinpoint": "^1.0.2",
+            "@hapi/topo": "^3.1.3"
+          }
+        }
+      }
+    },
+    "@hapi/shot": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@hapi/shot/-/shot-4.1.2.tgz",
+      "integrity": "sha512-6LeHLjvsq/bQ0R+fhEyr7mqExRGguNTrxFZf5DyKe3CK6pNabiGgYO4JVFaRrLZ3JyuhkS0fo8iiRE2Ql2oA/A==",
+      "requires": {
+        "@hapi/hoek": "8.x.x",
+        "@hapi/joi": "16.x.x"
+      },
+      "dependencies": {
+        "@hapi/joi": {
+          "version": "16.1.8",
+          "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-16.1.8.tgz",
+          "integrity": "sha512-wAsVvTPe+FwSrsAurNt5vkg3zo+TblvC5Bb1zMVK6SJzZqw9UrJnexxR+76cpePmtUZKHAPxcQ2Bf7oVHyahhg==",
+          "requires": {
+            "@hapi/address": "^2.1.2",
+            "@hapi/formula": "^1.2.0",
+            "@hapi/hoek": "^8.2.4",
+            "@hapi/pinpoint": "^1.0.2",
+            "@hapi/topo": "^3.1.3"
+          }
+        }
+      }
+    },
+    "@hapi/somever": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/somever/-/somever-2.1.1.tgz",
+      "integrity": "sha512-cic5Sto4KGd9B0oQSdKTokju+rYhCbdpzbMb0EBnrH5Oc1z048hY8PaZ1lx2vBD7I/XIfTQVQetBH57fU51XRA==",
+      "requires": {
+        "@hapi/bounce": "1.x.x",
+        "@hapi/hoek": "8.x.x"
+      }
+    },
+    "@hapi/statehood": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/@hapi/statehood/-/statehood-6.1.2.tgz",
+      "integrity": "sha512-pYXw1x6npz/UfmtcpUhuMvdK5kuOGTKcJNfLqdNptzietK2UZH5RzNJSlv5bDHeSmordFM3kGItcuQWX2lj2nQ==",
+      "requires": {
+        "@hapi/boom": "7.x.x",
+        "@hapi/bounce": "1.x.x",
+        "@hapi/bourne": "1.x.x",
+        "@hapi/cryptiles": "4.x.x",
+        "@hapi/hoek": "8.x.x",
+        "@hapi/iron": "5.x.x",
+        "@hapi/joi": "16.x.x"
+      },
+      "dependencies": {
+        "@hapi/joi": {
+          "version": "16.1.8",
+          "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-16.1.8.tgz",
+          "integrity": "sha512-wAsVvTPe+FwSrsAurNt5vkg3zo+TblvC5Bb1zMVK6SJzZqw9UrJnexxR+76cpePmtUZKHAPxcQ2Bf7oVHyahhg==",
+          "requires": {
+            "@hapi/address": "^2.1.2",
+            "@hapi/formula": "^1.2.0",
+            "@hapi/hoek": "^8.2.4",
+            "@hapi/pinpoint": "^1.0.2",
+            "@hapi/topo": "^3.1.3"
+          }
+        }
+      }
+    },
+    "@hapi/subtext": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@hapi/subtext/-/subtext-6.1.3.tgz",
+      "integrity": "sha512-qWN6NbiHNzohVcJMeAlpku/vzbyH4zIpnnMPMPioQMwIxbPFKeNViDCNI6fVBbMPBiw/xB4FjqiJkRG5P9eWWg==",
+      "requires": {
+        "@hapi/boom": "7.x.x",
+        "@hapi/bourne": "1.x.x",
+        "@hapi/content": "^4.1.1",
+        "@hapi/file": "1.x.x",
+        "@hapi/hoek": "8.x.x",
+        "@hapi/pez": "^4.1.2",
+        "@hapi/wreck": "15.x.x"
+      }
+    },
+    "@hapi/teamwork": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@hapi/teamwork/-/teamwork-3.3.1.tgz",
+      "integrity": "sha512-61tiqWCYvMKP7fCTXy0M4VE6uNIwA0qvgFoiDubgfj7uqJ0fdHJFQNnVPGrxhLWlwz0uBPWrQlBH7r8y9vFITQ=="
+    },
+    "@hapi/topo": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-3.1.6.tgz",
+      "integrity": "sha512-tAag0jEcjwH+P2quUfipd7liWCNX2F8NvYjQp2wtInsZxnMlypdw0FtAOLxtvvkO+GSRRbmNi8m/5y42PQJYCQ==",
+      "requires": {
+        "@hapi/hoek": "^8.3.0"
+      }
+    },
+    "@hapi/vise": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/vise/-/vise-3.1.1.tgz",
+      "integrity": "sha512-OXarbiCSadvtg+bSdVPqu31Z1JoBL+FwNYz3cYoBKQ5xq1/Cr4A3IkGpAZbAuxU5y4NL5pZFZG3d2a3ZGm/dOQ==",
+      "requires": {
+        "@hapi/hoek": "8.x.x"
+      }
+    },
+    "@hapi/wreck": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/wreck/-/wreck-15.1.0.tgz",
+      "integrity": "sha512-tQczYRTTeYBmvhsek/D49En/5khcShaBEmzrAaDjMrFXKJRuF8xA8+tlq1ETLBFwGd6Do6g2OC74rt11kzawzg==",
+      "requires": {
+        "@hapi/boom": "7.x.x",
+        "@hapi/bourne": "1.x.x",
+        "@hapi/hoek": "8.x.x"
+      }
+    },
     "@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
@@ -749,12 +1110,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
       "integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
-      "dev": true
-    },
-    "async-iterator-all": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/async-iterator-all/-/async-iterator-all-1.0.0.tgz",
-      "integrity": "sha512-+vC2NFEmAuONF+A2MzM1tUS5pHovDH37/oQbmXW6FgnEns0S9BsR+MJGnzsFHzSN2iFQhbN7L8cFqV1W1F1kpQ==",
       "dev": true
     },
     "async-iterator-to-pull-stream": {
@@ -2016,6 +2371,12 @@
       "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms=",
       "dev": true
     },
+    "callbackify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/callbackify/-/callbackify-1.1.0.tgz",
+      "integrity": "sha1-0qNphtKKppcUUmwREgm+65l50x4=",
+      "dev": true
+    },
     "caller-path": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
@@ -2974,12 +3335,6 @@
           "dev": true
         }
       }
-    },
-    "delay": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/delay/-/delay-4.3.0.tgz",
-      "integrity": "sha512-Lwaf3zVFDMBop1yDuFZ19F9WyGcZcGacsbdlZtWjQmM50tOcMntm1njF/Nb/Vjij3KaSvCF+sEYGKrrjObu2NA==",
-      "dev": true
     },
     "delayed-stream": {
       "version": "1.0.0",
@@ -7827,15 +8182,6 @@
             }
           }
         },
-        "@hapi/accept": {
-          "version": "3.2.3",
-          "resolved": "https://registry.npmjs.org/@hapi/accept/-/accept-3.2.3.tgz",
-          "integrity": "sha512-qEzsOJkCAJZxwj3iF83bSG9Lxy8Bpbrt8mRLNdvSALT6vlU2cYh6ZEHKEZPy4h/Mo31Su3j0rJgFF91+W1RWDQ==",
-          "requires": {
-            "@hapi/boom": "7.x.x",
-            "@hapi/hoek": "8.x.x"
-          }
-        },
         "@hapi/address": {
           "version": "2.1.4",
           "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.1.4.tgz",
@@ -7846,14 +8192,6 @@
           "resolved": "https://registry.npmjs.org/@hapi/ammo/-/ammo-4.0.0.tgz",
           "integrity": "sha512-rMYIKrnpQWuE+fD3fj9svcKNkl5EEfkMkfn0lAJgQ/q1phfn86VwPsPsVzGS7V+p5OzdRKUrll/FQGI7ze4q7w==",
           "dev": true,
-          "requires": {
-            "@hapi/hoek": "8.x.x"
-          }
-        },
-        "@hapi/b64": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/@hapi/b64/-/b64-4.2.1.tgz",
-          "integrity": "sha512-zqHpQuH5CBMw6hADzKfU/IGNrxq1Q+/wTYV+OiZRQN9F3tMyk+9BUMeBvFRMamduuqL8iSp62QAnJ+7ATiYLWA==",
           "requires": {
             "@hapi/hoek": "8.x.x"
           }
@@ -7880,49 +8218,6 @@
           "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-1.3.2.tgz",
           "integrity": "sha512-1dVNHT76Uu5N3eJNTYcvxee+jzX4Z9lfciqRRHCU27ihbUcYi+iSc2iml5Ke1LXe1SyJCLA0+14Jh4tXJgOppA=="
         },
-        "@hapi/call": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/@hapi/call/-/call-5.1.2.tgz",
-          "integrity": "sha512-10XyXbpo0fAXmOf/Q4BCgsQrrTZuwa6/FcSnuKqD06sZz5yMCmJTD8VpmolEjEfwJqXtQBZHj9g/IYcmHk3nxQ==",
-          "requires": {
-            "@hapi/boom": "7.x.x",
-            "@hapi/hoek": "8.x.x"
-          }
-        },
-        "@hapi/catbox": {
-          "version": "10.2.3",
-          "resolved": "https://registry.npmjs.org/@hapi/catbox/-/catbox-10.2.3.tgz",
-          "integrity": "sha512-kN9hXO4NYyOHW09CXiuj5qW1syc/0XeVOBsNNk0Tz89wWNQE5h21WF+VsfAw3uFR8swn/Wj3YEVBnWqo82m/JQ==",
-          "requires": {
-            "@hapi/boom": "7.x.x",
-            "@hapi/hoek": "8.x.x",
-            "@hapi/joi": "16.x.x",
-            "@hapi/podium": "3.x.x"
-          },
-          "dependencies": {
-            "@hapi/joi": {
-              "version": "16.1.8",
-              "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-16.1.8.tgz",
-              "integrity": "sha512-wAsVvTPe+FwSrsAurNt5vkg3zo+TblvC5Bb1zMVK6SJzZqw9UrJnexxR+76cpePmtUZKHAPxcQ2Bf7oVHyahhg==",
-              "requires": {
-                "@hapi/address": "^2.1.2",
-                "@hapi/formula": "^1.2.0",
-                "@hapi/hoek": "^8.2.4",
-                "@hapi/pinpoint": "^1.0.2",
-                "@hapi/topo": "^3.1.3"
-              }
-            }
-          }
-        },
-        "@hapi/catbox-memory": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/@hapi/catbox-memory/-/catbox-memory-4.1.1.tgz",
-          "integrity": "sha512-T6Hdy8DExzG0jY7C8yYWZB4XHfc0v+p1EGkwxl2HoaPYAmW7I3E59M/IvmSVpis8RPcIoBp41ZpO2aZPBpM2Ww==",
-          "requires": {
-            "@hapi/boom": "7.x.x",
-            "@hapi/hoek": "8.x.x"
-          }
-        },
         "@hapi/content": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/@hapi/content/-/content-4.1.0.tgz",
@@ -7931,87 +8226,10 @@
             "@hapi/boom": "7.x.x"
           }
         },
-        "@hapi/cryptiles": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/@hapi/cryptiles/-/cryptiles-4.2.1.tgz",
-          "integrity": "sha512-XoqgKsHK0l/VpqPs+tr6j6vE+VQ3+2bkF2stvttmc7xAOf1oSAwHcJ0tlp/6MxMysktt1IEY0Csy3khKaP9/uQ==",
-          "requires": {
-            "@hapi/boom": "7.x.x"
-          }
-        },
-        "@hapi/file": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/@hapi/file/-/file-1.0.0.tgz",
-          "integrity": "sha512-Bsfp/+1Gyf70eGtnIgmScvrH8sSypO3TcK3Zf0QdHnzn/ACnAkI6KLtGACmNRPEzzIy+W7aJX5E+1fc9GwIABQ=="
-        },
         "@hapi/formula": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/@hapi/formula/-/formula-1.2.0.tgz",
           "integrity": "sha512-UFbtbGPjstz0eWHb+ga/GM3Z9EzqKXFWIbSOFURU0A/Gku0Bky4bCk9/h//K2Xr3IrCfjFNhMm4jyZ5dbCewGA=="
-        },
-        "@hapi/hapi": {
-          "version": "18.4.0",
-          "resolved": "https://registry.npmjs.org/@hapi/hapi/-/hapi-18.4.0.tgz",
-          "integrity": "sha512-uk9zqknRLcNVQKgrPURm85DqkdroWP8eDRekh/IPoKvC4VjdZSn6EH2eUriOwyud/CldeBS3HDIJ/PtRj3VxDQ==",
-          "requires": {
-            "@hapi/accept": "3.x.x",
-            "@hapi/ammo": "3.x.x",
-            "@hapi/boom": "7.x.x",
-            "@hapi/bounce": "1.x.x",
-            "@hapi/call": "5.x.x",
-            "@hapi/catbox": "10.x.x",
-            "@hapi/catbox-memory": "4.x.x",
-            "@hapi/heavy": "6.x.x",
-            "@hapi/hoek": "8.x.x",
-            "@hapi/joi": "15.x.x",
-            "@hapi/mimos": "4.x.x",
-            "@hapi/podium": "3.x.x",
-            "@hapi/shot": "4.x.x",
-            "@hapi/somever": "2.x.x",
-            "@hapi/statehood": "6.x.x",
-            "@hapi/subtext": "6.x.x",
-            "@hapi/teamwork": "3.x.x",
-            "@hapi/topo": "3.x.x"
-          },
-          "dependencies": {
-            "@hapi/ammo": {
-              "version": "3.1.1",
-              "resolved": "https://registry.npmjs.org/@hapi/ammo/-/ammo-3.1.1.tgz",
-              "integrity": "sha512-NYFK27VSPGyQ/KmOQedpQH4PSjE7awLntepX68vrYtRvuJO21W1kX0bK2p3C+6ltUwtCQSvmNT8a4uMVAysC6Q==",
-              "requires": {
-                "@hapi/hoek": "8.x.x"
-              }
-            }
-          }
-        },
-        "@hapi/heavy": {
-          "version": "6.2.2",
-          "resolved": "https://registry.npmjs.org/@hapi/heavy/-/heavy-6.2.2.tgz",
-          "integrity": "sha512-PY1dCCO6dsze7RlafIRhTaGeyTgVe49A/lSkxbhKGjQ7x46o/OFf7hLiRqTCDh3atcEKf6362EaB3+kTUbCsVA==",
-          "requires": {
-            "@hapi/boom": "7.x.x",
-            "@hapi/hoek": "8.x.x",
-            "@hapi/joi": "16.x.x"
-          },
-          "dependencies": {
-            "@hapi/joi": {
-              "version": "16.1.8",
-              "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-16.1.8.tgz",
-              "integrity": "sha512-wAsVvTPe+FwSrsAurNt5vkg3zo+TblvC5Bb1zMVK6SJzZqw9UrJnexxR+76cpePmtUZKHAPxcQ2Bf7oVHyahhg==",
-              "requires": {
-                "@hapi/address": "^2.1.2",
-                "@hapi/formula": "^1.2.0",
-                "@hapi/hoek": "^8.2.4",
-                "@hapi/pinpoint": "^1.0.2",
-                "@hapi/topo": "^3.1.3"
-              }
-            }
-          }
-        },
-        "@hapi/hoek": {
-          "version": "8.5.0",
-          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.0.tgz",
-          "integrity": "sha512-7XYT10CZfPsH7j9F1Jmg1+d0ezOux2oM2GfArAzLwWe4mE2Dr3hVjsAL6+TFY49RRJlCdJDMw3nJsLFroTc8Kw=="
         },
         "@hapi/inert": {
           "version": "5.2.2",
@@ -8062,18 +8280,6 @@
             }
           }
         },
-        "@hapi/iron": {
-          "version": "5.1.4",
-          "resolved": "https://registry.npmjs.org/@hapi/iron/-/iron-5.1.4.tgz",
-          "integrity": "sha512-+ElC+OCiwWLjlJBmm8ZEWjlfzTMQTdgPnU/TsoU5QsktspIWmWi9IU4kU83nH+X/SSya8TP8h8P11Wr5L7dkQQ==",
-          "requires": {
-            "@hapi/b64": "4.x.x",
-            "@hapi/boom": "7.x.x",
-            "@hapi/bourne": "1.x.x",
-            "@hapi/cryptiles": "4.x.x",
-            "@hapi/hoek": "8.x.x"
-          }
-        },
         "@hapi/joi": {
           "version": "15.1.1",
           "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-15.1.1.tgz",
@@ -8085,142 +8291,10 @@
             "@hapi/topo": "3.x.x"
           }
         },
-        "@hapi/mimos": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/@hapi/mimos/-/mimos-4.1.1.tgz",
-          "integrity": "sha512-CXoi/zfcTWfKYX756eEea8rXJRIb9sR4d7VwyAH9d3BkDyNgAesZxvqIdm55npQc6S9mU3FExinMAQVlIkz0eA==",
-          "requires": {
-            "@hapi/hoek": "8.x.x",
-            "mime-db": "1.x.x"
-          }
-        },
-        "@hapi/nigel": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/@hapi/nigel/-/nigel-3.1.1.tgz",
-          "integrity": "sha512-R9YWx4S8yu0gcCBrMUDCiEFm1SQT895dMlYoeNBp8I6YhF1BFF1iYPueKA2Kkp9BvyHdjmvrxCOns7GMmpl+Fw==",
-          "requires": {
-            "@hapi/hoek": "8.x.x",
-            "@hapi/vise": "3.x.x"
-          }
-        },
-        "@hapi/pez": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/@hapi/pez/-/pez-4.1.1.tgz",
-          "integrity": "sha512-TUa2C7Xk6J69HWrm+Ad+O6dFvdVAG0BiFUYaRsmkdWjFIfwHBCaOI1dWT/juNukSb39Lj6/mDVyjN+H4nKB3xg==",
-          "requires": {
-            "@hapi/b64": "4.x.x",
-            "@hapi/boom": "7.x.x",
-            "@hapi/content": "4.x.x",
-            "@hapi/hoek": "8.x.x",
-            "@hapi/nigel": "3.x.x"
-          }
-        },
         "@hapi/pinpoint": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/@hapi/pinpoint/-/pinpoint-1.0.2.tgz",
           "integrity": "sha512-dtXC/WkZBfC5vxscazuiJ6iq4j9oNx1SHknmIr8hofarpKUZKmlUVYVIhNVzIEgK5Wrc4GMHL5lZtt1uS2flmQ=="
-        },
-        "@hapi/podium": {
-          "version": "3.4.3",
-          "resolved": "https://registry.npmjs.org/@hapi/podium/-/podium-3.4.3.tgz",
-          "integrity": "sha512-QJlnYLEYZWlKQ9fSOtuUcpANyoVGwT68GA9P0iQQCAetBK0fI+nbRBt58+aMixoifczWZUthuGkNjqKxgPh/CQ==",
-          "requires": {
-            "@hapi/hoek": "8.x.x",
-            "@hapi/joi": "16.x.x"
-          },
-          "dependencies": {
-            "@hapi/joi": {
-              "version": "16.1.8",
-              "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-16.1.8.tgz",
-              "integrity": "sha512-wAsVvTPe+FwSrsAurNt5vkg3zo+TblvC5Bb1zMVK6SJzZqw9UrJnexxR+76cpePmtUZKHAPxcQ2Bf7oVHyahhg==",
-              "requires": {
-                "@hapi/address": "^2.1.2",
-                "@hapi/formula": "^1.2.0",
-                "@hapi/hoek": "^8.2.4",
-                "@hapi/pinpoint": "^1.0.2",
-                "@hapi/topo": "^3.1.3"
-              }
-            }
-          }
-        },
-        "@hapi/shot": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/@hapi/shot/-/shot-4.1.2.tgz",
-          "integrity": "sha512-6LeHLjvsq/bQ0R+fhEyr7mqExRGguNTrxFZf5DyKe3CK6pNabiGgYO4JVFaRrLZ3JyuhkS0fo8iiRE2Ql2oA/A==",
-          "requires": {
-            "@hapi/hoek": "8.x.x",
-            "@hapi/joi": "16.x.x"
-          },
-          "dependencies": {
-            "@hapi/joi": {
-              "version": "16.1.8",
-              "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-16.1.8.tgz",
-              "integrity": "sha512-wAsVvTPe+FwSrsAurNt5vkg3zo+TblvC5Bb1zMVK6SJzZqw9UrJnexxR+76cpePmtUZKHAPxcQ2Bf7oVHyahhg==",
-              "requires": {
-                "@hapi/address": "^2.1.2",
-                "@hapi/formula": "^1.2.0",
-                "@hapi/hoek": "^8.2.4",
-                "@hapi/pinpoint": "^1.0.2",
-                "@hapi/topo": "^3.1.3"
-              }
-            }
-          }
-        },
-        "@hapi/somever": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/@hapi/somever/-/somever-2.1.1.tgz",
-          "integrity": "sha512-cic5Sto4KGd9B0oQSdKTokju+rYhCbdpzbMb0EBnrH5Oc1z048hY8PaZ1lx2vBD7I/XIfTQVQetBH57fU51XRA==",
-          "requires": {
-            "@hapi/bounce": "1.x.x",
-            "@hapi/hoek": "8.x.x"
-          }
-        },
-        "@hapi/statehood": {
-          "version": "6.1.2",
-          "resolved": "https://registry.npmjs.org/@hapi/statehood/-/statehood-6.1.2.tgz",
-          "integrity": "sha512-pYXw1x6npz/UfmtcpUhuMvdK5kuOGTKcJNfLqdNptzietK2UZH5RzNJSlv5bDHeSmordFM3kGItcuQWX2lj2nQ==",
-          "requires": {
-            "@hapi/boom": "7.x.x",
-            "@hapi/bounce": "1.x.x",
-            "@hapi/bourne": "1.x.x",
-            "@hapi/cryptiles": "4.x.x",
-            "@hapi/hoek": "8.x.x",
-            "@hapi/iron": "5.x.x",
-            "@hapi/joi": "16.x.x"
-          },
-          "dependencies": {
-            "@hapi/joi": {
-              "version": "16.1.8",
-              "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-16.1.8.tgz",
-              "integrity": "sha512-wAsVvTPe+FwSrsAurNt5vkg3zo+TblvC5Bb1zMVK6SJzZqw9UrJnexxR+76cpePmtUZKHAPxcQ2Bf7oVHyahhg==",
-              "requires": {
-                "@hapi/address": "^2.1.2",
-                "@hapi/formula": "^1.2.0",
-                "@hapi/hoek": "^8.2.4",
-                "@hapi/pinpoint": "^1.0.2",
-                "@hapi/topo": "^3.1.3"
-              }
-            }
-          }
-        },
-        "@hapi/subtext": {
-          "version": "6.1.2",
-          "resolved": "https://registry.npmjs.org/@hapi/subtext/-/subtext-6.1.2.tgz",
-          "integrity": "sha512-G1kqD1E2QdxpvpL26WieIyo3z0qCa/sAGSa2TJI/PYPWCR9rL0rqFvhWY774xPZ4uK1PV3TIaJcx8AruAvxclg==",
-          "requires": {
-            "@hapi/boom": "7.x.x",
-            "@hapi/bourne": "1.x.x",
-            "@hapi/content": "4.x.x",
-            "@hapi/file": "1.x.x",
-            "@hapi/hoek": "8.x.x",
-            "@hapi/pez": "4.x.x",
-            "@hapi/wreck": "15.x.x"
-          }
-        },
-        "@hapi/teamwork": {
-          "version": "3.3.1",
-          "resolved": "https://registry.npmjs.org/@hapi/teamwork/-/teamwork-3.3.1.tgz",
-          "integrity": "sha512-61tiqWCYvMKP7fCTXy0M4VE6uNIwA0qvgFoiDubgfj7uqJ0fdHJFQNnVPGrxhLWlwz0uBPWrQlBH7r8y9vFITQ=="
         },
         "@hapi/topo": {
           "version": "3.1.6",
@@ -8228,24 +8302,6 @@
           "integrity": "sha512-tAag0jEcjwH+P2quUfipd7liWCNX2F8NvYjQp2wtInsZxnMlypdw0FtAOLxtvvkO+GSRRbmNi8m/5y42PQJYCQ==",
           "requires": {
             "@hapi/hoek": "^8.3.0"
-          }
-        },
-        "@hapi/vise": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/@hapi/vise/-/vise-3.1.1.tgz",
-          "integrity": "sha512-OXarbiCSadvtg+bSdVPqu31Z1JoBL+FwNYz3cYoBKQ5xq1/Cr4A3IkGpAZbAuxU5y4NL5pZFZG3d2a3ZGm/dOQ==",
-          "requires": {
-            "@hapi/hoek": "8.x.x"
-          }
-        },
-        "@hapi/wreck": {
-          "version": "15.1.0",
-          "resolved": "https://registry.npmjs.org/@hapi/wreck/-/wreck-15.1.0.tgz",
-          "integrity": "sha512-tQczYRTTeYBmvhsek/D49En/5khcShaBEmzrAaDjMrFXKJRuF8xA8+tlq1ETLBFwGd6Do6g2OC74rt11kzawzg==",
-          "requires": {
-            "@hapi/boom": "7.x.x",
-            "@hapi/bourne": "1.x.x",
-            "@hapi/hoek": "8.x.x"
           }
         },
         "@marionebl/sander": {
@@ -14527,7 +14583,6 @@
           "requires": {
             "concat-stream": "1.6.2",
             "debug": "2.6.9",
-            "mkdirp": "0.5.1",
             "yauzl": "2.4.1"
           },
           "dependencies": {
@@ -19508,7 +19563,6 @@
                 "growl": "1.10.5",
                 "he": "1.1.1",
                 "minimatch": "3.0.4",
-                "mkdirp": "0.5.1",
                 "supports-color": "5.4.0"
               },
               "dependencies": {
@@ -21410,10 +21464,7 @@
         "karma-mocha": {
           "version": "1.3.0",
           "resolved": "https://registry.npmjs.org/karma-mocha/-/karma-mocha-1.3.0.tgz",
-          "integrity": "sha1-7qrH/8DiAetjxGdEDStpx883eL8=",
-          "requires": {
-            "minimist": "1.2.0"
-          }
+          "integrity": "sha1-7qrH/8DiAetjxGdEDStpx883eL8="
         },
         "karma-mocha-reporter": {
           "version": "2.2.5",
@@ -21533,9 +21584,9 @@
           }
         },
         "kind-of": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
         },
         "ky": {
           "version": "0.15.0",
@@ -24041,9 +24092,9 @@
           }
         },
         "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
         },
         "minimist-options": {
           "version": "3.0.2",
@@ -24153,17 +24204,17 @@
           }
         },
         "mkdirp": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "version": "0.5.5",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
           "requires": {
-            "minimist": "0.0.8"
+            "minimist": "^1.2.5"
           },
           "dependencies": {
             "minimist": {
-              "version": "0.0.8",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+              "version": "1.2.5",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+              "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
             }
           }
         },
@@ -24184,7 +24235,6 @@
             "js-yaml": "3.13.1",
             "log-symbols": "2.2.0",
             "minimatch": "3.0.4",
-            "mkdirp": "0.5.1",
             "ms": "2.1.1",
             "node-environment-flags": "1.0.5",
             "object.assign": "4.1.0",
@@ -31452,82 +31502,48 @@
       }
     },
     "ipfs-http-client": {
-      "version": "37.0.3",
-      "resolved": "https://registry.npmjs.org/ipfs-http-client/-/ipfs-http-client-37.0.3.tgz",
-      "integrity": "sha512-yv8lVWGUWcAX5K1K5gj0uWjIBmvbS0hIhnStC4Da+RTJL09jFj9LsBYySst8F3pmU6XfqOurwihlFmK79ZChyg==",
+      "version": "41.0.1",
+      "resolved": "https://registry.npmjs.org/ipfs-http-client/-/ipfs-http-client-41.0.1.tgz",
+      "integrity": "sha512-oyH0hXoB+jfz4NqM+SZSpk6c9wR+9uvUO+/0eQFT6B9Ludz4zR8T5MHo7bnQoVerj9Qlv0x0wO1ckSoekaSPpw==",
       "dev": true,
       "requires": {
         "abort-controller": "^3.0.0",
-        "async": "^2.6.1",
-        "async-iterator-all": "^1.0.0",
         "async-iterator-to-pull-stream": "^1.3.0",
         "bignumber.js": "^9.0.0",
-        "bl": "^3.0.0",
+        "bl": "^4.0.0",
         "bs58": "^4.0.1",
         "buffer": "^5.4.2",
+        "callbackify": "^1.1.0",
         "cids": "~0.7.1",
-        "concat-stream": "github:hugomrdias/concat-stream#feat/smaller",
         "debug": "^4.1.0",
-        "delay": "^4.3.0",
-        "detect-node": "^2.0.4",
-        "end-of-stream": "^1.4.1",
         "err-code": "^2.0.0",
         "explain-error": "^1.0.4",
-        "flatmap": "0.0.3",
-        "form-data": "^2.5.1",
-        "fs-extra": "^8.1.0",
-        "glob": "^7.1.3",
+        "form-data": "^3.0.0",
         "ipfs-block": "~0.8.1",
-        "ipfs-utils": "^0.4.0",
+        "ipfs-utils": "^0.4.2",
         "ipld-dag-cbor": "~0.15.0",
-        "ipld-dag-pb": "~0.17.3",
+        "ipld-dag-pb": "^0.18.1",
         "ipld-raw": "^4.0.0",
         "is-ipfs": "~0.6.1",
-        "is-pull-stream": "0.0.0",
-        "is-stream": "^2.0.0",
-        "iso-stream-http": "~0.1.2",
-        "iso-url": "~0.4.6",
-        "it-glob": "0.0.4",
+        "it-all": "^1.0.1",
+        "it-glob": "0.0.7",
+        "it-tar": "^1.1.1",
         "it-to-stream": "^0.1.1",
         "iterable-ndjson": "^1.1.0",
-        "just-kebab-case": "^1.1.0",
-        "just-map-keys": "^1.1.0",
-        "kind-of": "^6.0.2",
-        "ky": "^0.14.0",
+        "ky": "^0.15.0",
         "ky-universal": "^0.3.0",
-        "lru-cache": "^5.1.1",
-        "merge-options": "^1.0.1",
+        "merge-options": "^2.0.0",
         "multiaddr": "^6.0.6",
+        "multiaddr-to-uri": "^5.0.0",
         "multibase": "~0.6.0",
-        "multicodec": "~0.5.1",
+        "multicodec": "^1.0.0",
         "multihashes": "~0.4.14",
-        "ndjson": "github:hugomrdias/ndjson#feat/readable-stream3",
-        "once": "^1.4.0",
+        "parse-duration": "^0.1.1",
         "peer-id": "~0.12.3",
         "peer-info": "~0.15.1",
-        "promise-nodeify": "^3.0.1",
-        "promisify-es6": "^1.0.3",
-        "pull-defer": "~0.2.3",
-        "pull-stream": "^3.6.9",
-        "pull-stream-to-async-iterator": "^1.0.2",
-        "pull-to-stream": "~0.1.1",
-        "pump": "^3.0.0",
-        "qs": "^6.5.2",
-        "readable-stream": "^3.1.1",
-        "stream-to-pull-stream": "^1.7.2",
-        "tar-stream": "^2.0.1",
-        "through2": "^3.0.1"
+        "promise-nodeify": "^3.0.1"
       },
       "dependencies": {
-        "bl": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/bl/-/bl-3.0.0.tgz",
-          "integrity": "sha512-EUAyP5UHU5hxF8BPT0LKW8gjYLhq1DQIcneOX/pL/m2Alo+OYDQAJlHq+yseMP50Os2nHXOSic6Ss3vSQeyf4A==",
-          "dev": true,
-          "requires": {
-            "readable-stream": "^3.0.1"
-          }
-        },
         "debug": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -31542,6 +31558,17 @@
           "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.0.tgz",
           "integrity": "sha512-MsMOijQ4v0xlmrz1fc7lyPEy7jFhoNF7EVaRSP7mPzs20LaFOwG6qNjGRy3Ie85n9DARlcUnB1zbsBv5sJrIvw==",
           "dev": true
+        },
+        "form-data": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
+          "integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
+          "dev": true,
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
         },
         "fs-extra": {
           "version": "8.1.0",
@@ -31571,16 +31598,53 @@
             "kind-of": "^6.0.2",
             "pull-stream-to-async-iterator": "^1.0.2",
             "readable-stream": "^3.4.0"
+          }
+        },
+        "ipld-dag-pb": {
+          "version": "0.18.4",
+          "resolved": "https://registry.npmjs.org/ipld-dag-pb/-/ipld-dag-pb-0.18.4.tgz",
+          "integrity": "sha512-T7Fa6xDGtWqRE3uE3bU0eflKATkZrBuh7LwFByCdz0lUpES6aMRDoUdIjlOxWAvEN01oUeT7jeeX/ZWINsI1gw==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.6.0",
+            "cids": "~0.8.0",
+            "class-is": "^1.1.0",
+            "multicodec": "^1.0.1",
+            "multihashing-async": "~0.8.1",
+            "protons": "^1.0.2"
           },
           "dependencies": {
-            "it-glob": {
-              "version": "0.0.7",
-              "resolved": "https://registry.npmjs.org/it-glob/-/it-glob-0.0.7.tgz",
-              "integrity": "sha512-XfbziJs4fi0MfdEGTLkZXeqo2EorF2baFXxFn1E2dGbgYMhFTZlZ2Yn/mx5CkpuLWVJvO1DwtTOVW2mzRyVK8w==",
+            "buffer": {
+              "version": "5.6.0",
+              "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+              "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
               "dev": true,
               "requires": {
-                "fs-extra": "^8.1.0",
-                "minimatch": "^3.0.4"
+                "base64-js": "^1.0.2",
+                "ieee754": "^1.1.4"
+              }
+            },
+            "cids": {
+              "version": "0.8.0",
+              "resolved": "https://registry.npmjs.org/cids/-/cids-0.8.0.tgz",
+              "integrity": "sha512-HdKURxtSOnww3H28CJU2TauIklEBsOn+ouGl2EOnSfVCVkH6+sWTj7to2D/BmuWvwzEy2+ZIKdcIwsXHJBQVew==",
+              "dev": true,
+              "requires": {
+                "buffer": "^5.5.0",
+                "class-is": "^1.1.0",
+                "multibase": "~0.7.0",
+                "multicodec": "^1.0.1",
+                "multihashes": "~0.4.17"
+              }
+            },
+            "multibase": {
+              "version": "0.7.0",
+              "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.7.0.tgz",
+              "integrity": "sha512-TW8q03O0f6PNFTQDvh3xxH03c8CjGaaYrjkl9UQPG6rz53TQzzxJVCIWVjzcbN/Q5Y53Zd0IBQBMVktVgNx4Fg==",
+              "dev": true,
+              "requires": {
+                "base-x": "^3.0.8",
+                "buffer": "^5.5.0"
               }
             }
           }
@@ -31590,16 +31654,6 @@
           "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
           "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==",
           "dev": true
-        },
-        "it-glob": {
-          "version": "0.0.4",
-          "resolved": "https://registry.npmjs.org/it-glob/-/it-glob-0.0.4.tgz",
-          "integrity": "sha512-sTMM62VQWRqlMpgbd+x1uTviQY7a8vMLXYmw+KPiV9vmAYuyIr9Sp1QRQ5B/faybf4O9RzMGyQb7eFpqLwsBhQ==",
-          "dev": true,
-          "requires": {
-            "fs-extra": "^8.1.0",
-            "minimatch": "^3.0.4"
-          }
         },
         "jsonfile": {
           "version": "4.0.0",
@@ -31616,38 +31670,24 @@
           "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
           "dev": true
         },
-        "merge-options": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-1.0.1.tgz",
-          "integrity": "sha512-iuPV41VWKWBIOpBsjoxjDZw8/GbSfZ2mk7N1453bwMrfzdrIk7EzBd+8UVR6rkw67th7xnk9Dytl3J+lHPdxvg==",
-          "dev": true,
-          "requires": {
-            "is-plain-obj": "^1.1"
-          }
-        },
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         },
-        "multicodec": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-0.5.7.tgz",
-          "integrity": "sha512-PscoRxm3f+88fAtELwUnZxGDkduE2HD9Q6GHUOywQLjOGT/HAdhjLDYNZ1e7VR0s0TP0EwZ16LNUTFpoBGivOA==",
+        "multihashing-async": {
+          "version": "0.8.1",
+          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.8.1.tgz",
+          "integrity": "sha512-qu3eIXHebc9a4OU4n/60BdZLFpX+/dGBs3DbzXCxX1aU0rFF19KQAiGl+sRL9wvKIJdeF2+w16RRJrpyTHpkkA==",
           "dev": true,
           "requires": {
-            "varint": "^5.0.0"
-          }
-        },
-        "pump": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-          "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-          "dev": true,
-          "requires": {
-            "end-of-stream": "^1.1.0",
-            "once": "^1.3.1"
+            "blakejs": "^1.1.0",
+            "buffer": "^5.4.3",
+            "err-code": "^2.0.0",
+            "js-sha3": "~0.8.0",
+            "multihashes": "~0.4.15",
+            "murmurhash3js-revisited": "^3.0.0"
           }
         },
         "readable-stream": {
@@ -31659,15 +31699,6 @@
             "inherits": "^2.0.3",
             "string_decoder": "^1.1.1",
             "util-deprecate": "^1.0.1"
-          }
-        },
-        "through2": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.1.tgz",
-          "integrity": "sha512-M96dvTalPT3YbYLaKaCuwu+j06D/8Jfib0o/PxbVt6Amhv3dUAtW6rTV1jPgJSBG83I/e04Y6xkVdVhSRhi0ww==",
-          "dev": true,
-          "requires": {
-            "readable-stream": "2 || 3"
           }
         },
         "universalify": {
@@ -32626,6 +32657,12 @@
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
+    "iso-constants": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/iso-constants/-/iso-constants-0.1.2.tgz",
+      "integrity": "sha512-OTCM5ZCQsHBCI4Wdu4tSxvDIkmDHd5EwJDps5mKqnQnWJSKlnwMs3EDZ4n3Fh1tmkWkDlyd2vCDbEYuPbyrUNQ==",
+      "dev": true
+    },
     "iso-random-stream": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/iso-random-stream/-/iso-random-stream-1.1.1.tgz",
@@ -32686,6 +32723,21 @@
         "isarray": "1.0.0"
       }
     },
+    "it-all": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/it-all/-/it-all-1.0.1.tgz",
+      "integrity": "sha512-DQ8MQXVfwCktZOja1xvKdsuka7E/OJHpLKLR3tMBmg6Kfo8Kob+XRE6pRfpbkXNsGyET4lMYrQ0y5T3XXF/Akw==",
+      "dev": true
+    },
+    "it-concat": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/it-concat/-/it-concat-1.0.0.tgz",
+      "integrity": "sha512-mLhiCB3tW4NTYTg7bMlyYX2c782KsAacthHMR3y5kjJn9JhNFb02NcH70KZuNrSXFSTq8k6m8MiYaQWRjrDxAA==",
+      "dev": true,
+      "requires": {
+        "bl": "^4.0.0"
+      }
+    },
     "it-glob": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/it-glob/-/it-glob-0.0.7.tgz",
@@ -32722,6 +32774,29 @@
           "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
           "dev": true
         }
+      }
+    },
+    "it-reader": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/it-reader/-/it-reader-2.1.0.tgz",
+      "integrity": "sha512-hSysqWTO9Tlwc5EGjVf8JYZzw0D2FsxD/g+eNNWrez9zODxWt6QlN6JAMmycK72Mv4jHEKEXoyzUN4FYGmJaZw==",
+      "dev": true,
+      "requires": {
+        "bl": "^4.0.0"
+      }
+    },
+    "it-tar": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/it-tar/-/it-tar-1.2.2.tgz",
+      "integrity": "sha512-M8V4a9I+x/vwXTjqvixcEZbQZHjwDIb8iUQ+D4M2QbhAdNs3WKVSl+45u5/F2XFx6jYMFOGzMVlKNK/uONgNIA==",
+      "dev": true,
+      "requires": {
+        "bl": "^4.0.0",
+        "buffer": "^5.4.3",
+        "iso-constants": "^0.1.2",
+        "it-concat": "^1.0.0",
+        "it-reader": "^2.0.0",
+        "p-defer": "^3.0.0"
       }
     },
     "it-to-stream": {
@@ -32948,9 +33023,9 @@
       }
     },
     "ky": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/ky/-/ky-0.14.0.tgz",
-      "integrity": "sha512-NSjg+WCElQPdlF3BFZnjh8s5QlMIP+vIGoyukrRU+n+23VBUX87bQYOoG5h3HX5tO7kKQYXvg+QZVt8n0uWmhg==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/ky/-/ky-0.15.0.tgz",
+      "integrity": "sha512-6IlJRPFHq4ZKRRa9lyh6YqHqlmddAkfyXI9CYvZpLQtg7fQvwncPHyHrmtXAHKCqHOilINPMT88eW6FTA3HwkA==",
       "dev": true
     },
     "ky-universal": {
@@ -33835,8 +33910,7 @@
     "mime-db": {
       "version": "1.43.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.43.0.tgz",
-      "integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ==",
-      "dev": true
+      "integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ=="
     },
     "mime-types": {
       "version": "2.1.26",
@@ -34115,6 +34189,54 @@
           "dev": true,
           "requires": {
             "ip-regex": "^2.0.0"
+          }
+        }
+      }
+    },
+    "multiaddr-to-uri": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/multiaddr-to-uri/-/multiaddr-to-uri-5.1.0.tgz",
+      "integrity": "sha512-rIlMLkw3yk3RJmf2hxYYzeqPXz4Vx7C4M/hg7BVWhmksDW0rDVNMEyoVb0H1A+sh3deHOh5EAFK87XcW+mFimA==",
+      "dev": true,
+      "requires": {
+        "multiaddr": "^7.2.1"
+      },
+      "dependencies": {
+        "cids": {
+          "version": "0.8.0",
+          "resolved": "https://registry.npmjs.org/cids/-/cids-0.8.0.tgz",
+          "integrity": "sha512-HdKURxtSOnww3H28CJU2TauIklEBsOn+ouGl2EOnSfVCVkH6+sWTj7to2D/BmuWvwzEy2+ZIKdcIwsXHJBQVew==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.5.0",
+            "class-is": "^1.1.0",
+            "multibase": "~0.7.0",
+            "multicodec": "^1.0.1",
+            "multihashes": "~0.4.17"
+          }
+        },
+        "multiaddr": {
+          "version": "7.4.3",
+          "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-7.4.3.tgz",
+          "integrity": "sha512-gFjXmjcCMyrx5KF1QOohUQm6a3E2XF4kydvClS8DmRJkY3qJaDPNNe0OC7mWvVUE0nnE8HjyToQfABnpKClXRA==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.5.0",
+            "cids": "~0.8.0",
+            "class-is": "^1.1.0",
+            "is-ip": "^3.1.0",
+            "multibase": "^0.7.0",
+            "varint": "^5.0.0"
+          }
+        },
+        "multibase": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.7.0.tgz",
+          "integrity": "sha512-TW8q03O0f6PNFTQDvh3xxH03c8CjGaaYrjkl9UQPG6rz53TQzzxJVCIWVjzcbN/Q5Y53Zd0IBQBMVktVgNx4Fg==",
+          "dev": true,
+          "requires": {
+            "base-x": "^3.0.8",
+            "buffer": "^5.5.0"
           }
         }
       }
@@ -35046,6 +35168,12 @@
       "requires": {
         "author-regex": "^1.0.0"
       }
+    },
+    "parse-duration": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/parse-duration/-/parse-duration-0.1.2.tgz",
+      "integrity": "sha512-0qfMZyjOUFBeEIvJ5EayfXJqaEXxQ+Oj2b7tWJM3hvEXvXsYCk05EDVI23oYnEw2NaFYUWdABEVPBvBMh8L/pA==",
+      "dev": true
     },
     "parse-entities": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -45,9 +45,9 @@
     "cross-env": "^6.0.3",
     "datastore-level": "~0.14.0",
     "fs-extra": "^7.0.1",
-    "go-ipfs-dep": "~0.4.20",
+    "go-ipfs-dep": "~0.4.23-3",
     "ipfs": "~0.40.0",
-    "ipfs-http-client": "~37.0.1",
+    "ipfs-http-client": "~41.0.1",
     "ipfs-repo": "~0.30.1",
     "ipfsd-ctl": "~0.42.3",
     "localstorage-level-migration": "~0.1.0",
@@ -84,6 +84,9 @@
     "build:debug": "webpack --config conf/webpack.debug.config.js --sort-modules-by size && mkdirp examples/browser/lib && cpy dist/orbitdb.js examples/browser/lib && cpy dist/orbitdb.js.map examples/browser/lib",
     "build:docs/toc": "markdown-toc --no-first1 -i README.md && markdown-toc --no-first1 -i API.md && markdown-toc --no-first1 -i GUIDE.md && markdown-toc --no-first1 -i CHANGELOG.md && markdown-toc --no-first1 -i FAQ.md ",
     "build:es5": "babel src --out-dir ./dist/es5/ --presets babel-preset-env --plugins babel-plugin-transform-runtime"
+  },
+  "go-ipfs": {
+    "version": "v0.5.0-rc2"
   },
   "standard": {
     "env": "mocha",


### PR DESCRIPTION
## TL;DR

This PR ensures orbit-db remains compatible with HTTP API exposed by go-ipfs 0.5 (https://github.com/ipfs/go-ipfs/issues/7109) by switching to `ipfs-http-client@41.0.1` in tests and adding interop note in README.  

## Changes

- **added interop note to README about compatible http client version**
  - note about version limitation can be removed when #767 lands
- bumped versions of http-client and go-ipfs used in tests to ensure it works with latest go-ipfs 0.5.0-rc2

## Why?

go-ipfs 0.5  will block `GET` commands on the API port (https://github.com/ipfs/go-ipfs/pull/7097), requiring every  command (RPC) to be sent as HTTP `POST` request.



Why v41.0.1? It sends only POST requests while maintaining the old JS API 
(breaking changes that introduced support for async iterators landed in 42.x)


cc @aphelionz @stebalien @achingbrain 