### PR TITLE
fix: fs shim when running inside electron renderer process

### DIFF
--- a/src/fs-shim.js
+++ b/src/fs-shim.js
@@ -1,5 +1,4 @@
 /* eslint-disable */
-const fs = (typeof window === 'object' || typeof self === 'object') ? null
-  : eval('require("fs")')
+const fs = (typeof process !== 'object' && (typeof window === 'object' || typeof self === 'object')) ? null : eval('require("fs")')
 
 module.exports = fs


### PR DESCRIPTION
The fs shim does not work properly when used inside an [electron renderer process](https://www.electronjs.org/docs/tutorial/application-architecture#main-and-renderer-processes), where both native node modules and chromium (i.e. global `window`) are available. This is one simple way to address the issue.