### PR TITLE
Suport new base36 format, Improve unwieldy logic

### DIFF
--- a/src/orbit-db-address.js
+++ b/src/orbit-db-address.js
@@ -26,8 +26,18 @@ class OrbitDBAddress {
 
     let accessControllerHash
 
+    const validateHash = (hash) => {
+      const prefixes = ['zd', 'Qm', 'ba', 'k5']
+      for (const p of prefixes) {
+        if (hash.indexOf(p) > -1) {
+          return true
+        }
+      }
+      return false
+    }
+
     try {
-      accessControllerHash = (parts[0].indexOf('zd') > -1 || parts[0].indexOf('Qm') > -1 || parts[0].indexOf('ba') > -1)
+      accessControllerHash = validateHash(parts[0])
         ? new CID(parts[0]).toBaseEncodedString()
         : null
     } catch (e) {


### PR DESCRIPTION
The 0.6.0 version of go-ipfs introduces base36 cids, so It'd be good if we can get ahead of any issues that might occur when (if) this becomes the default and support it right out of the gate. The logic with the existing single if statement was rapidly getting out of hand and foreseeably was going to get worse over time given the amount of format changes cids are undergoing,; So it required a small refactor to make it neater & easier to add new cases.
e.g. base36 cid `k51qzi5uqu5dj16qyiq0tajolkojyl9qdkr254920wxv7ghtuwcz593tp69z9m`