### PR TITLE
Updating for js-ipfs 0.50 and go-ipfs 0.6.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ jobs:
     # To see the list of pre-built images that CircleCI provides for most common languages see
     # https://circleci.com/docs/2.0/circleci-images/
     docker:
-      - image: circleci/node:10-browsers
+      - image: circleci/node:12-browsers
     steps:
     # Machine Setup
     #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ deps:
 	npm install
 
 test: deps
-	npm run test:all
+	npm run test:all -- --exit
 	npx validate-maintainers orbit-db --match --ci
 
 build: test

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "orbit-db",
-  "version": "0.25.3",
+  "version": "0.26.0-rc4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -155,25 +155,10 @@
         "lodash": "^4.17.19"
       },
       "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
         "globals": {
           "version": "11.12.0",
           "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
           "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-          "dev": true
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         }
       }
@@ -198,53 +183,53 @@
       }
     },
     "@ethersproject/abi": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.0.4.tgz",
-      "integrity": "sha512-T8woaIQHCJMZDAQim1vSp8ycsP2h1/TlnBHzQqR9atKknoqLiT26Wxr9AkhW1aufexkWrZTHbf2837469uS6Eg==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.0.5.tgz",
+      "integrity": "sha512-FNx6UMm0LnmCMFzN3urohFwZpjbUHPvc/O60h4qkF4yiJxLJ/G7QOSPjkHQ/q/QibagR4S7OKQawRy0NcvWa9w==",
       "requires": {
-        "@ethersproject/address": "^5.0.3",
-        "@ethersproject/bignumber": "^5.0.6",
+        "@ethersproject/address": "^5.0.4",
+        "@ethersproject/bignumber": "^5.0.7",
         "@ethersproject/bytes": "^5.0.4",
-        "@ethersproject/constants": "^5.0.3",
-        "@ethersproject/hash": "^5.0.3",
+        "@ethersproject/constants": "^5.0.4",
+        "@ethersproject/hash": "^5.0.4",
         "@ethersproject/keccak256": "^5.0.3",
         "@ethersproject/logger": "^5.0.5",
         "@ethersproject/properties": "^5.0.3",
-        "@ethersproject/strings": "^5.0.3"
+        "@ethersproject/strings": "^5.0.4"
       }
     },
     "@ethersproject/abstract-provider": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.0.3.tgz",
-      "integrity": "sha512-0dVq0IcJd6/qTjT+bhJw6ooJuCJDNWTL8SKRFBnqr4OgDW7p1AXX2l7lQd7vX9RpbnDzurSM+fTBKCVWjdm3Vw==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.0.4.tgz",
+      "integrity": "sha512-EOCHUTS8jOE3WZlA1pq9b/vQwKDyDzMy4gXeAv0wZecH1kwUkD0++x8avxeSYoWI+aJn62P1FVV9B6r9pM56kQ==",
       "requires": {
-        "@ethersproject/bignumber": "^5.0.6",
+        "@ethersproject/bignumber": "^5.0.7",
         "@ethersproject/bytes": "^5.0.4",
         "@ethersproject/logger": "^5.0.5",
         "@ethersproject/networks": "^5.0.3",
         "@ethersproject/properties": "^5.0.3",
-        "@ethersproject/transactions": "^5.0.3",
-        "@ethersproject/web": "^5.0.4"
+        "@ethersproject/transactions": "^5.0.5",
+        "@ethersproject/web": "^5.0.6"
       }
     },
     "@ethersproject/abstract-signer": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.0.3.tgz",
-      "integrity": "sha512-uhHXqmcJcxWYD+hcvsp/pu8iSgqQzgSXHJtFGUYBBkWGpCp5kF95nSRlFnyVu9uAqZxwynBtOrPZBd1ACGBQBQ==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.0.4.tgz",
+      "integrity": "sha512-pQTDZwOhz2zINC27xfVah7EVv1A9qza1SShmqFjljZo4C9liYf/kSeWCLKkEbpbJNUVUHAbXBwV4N0XBv1xRYA==",
       "requires": {
-        "@ethersproject/abstract-provider": "^5.0.3",
-        "@ethersproject/bignumber": "^5.0.6",
+        "@ethersproject/abstract-provider": "^5.0.4",
+        "@ethersproject/bignumber": "^5.0.7",
         "@ethersproject/bytes": "^5.0.4",
         "@ethersproject/logger": "^5.0.5",
         "@ethersproject/properties": "^5.0.3"
       }
     },
     "@ethersproject/address": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.0.3.tgz",
-      "integrity": "sha512-LMmLxL1wTNtvwgm/eegcaxtG/W7vHXKzHGUkK9KZEI9W+SfHrpT7cGX+hBcatcUXPANjS3TmOaQ+mq5JU5sGTw==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.0.4.tgz",
+      "integrity": "sha512-CIjAeG6zNehbpJTi0sgwUvaH2ZICiAV9XkCBaFy5tjuEVFpQNeqd6f+B7RowcNO7Eut+QbhcQ5CVLkmP5zhL9A==",
       "requires": {
-        "@ethersproject/bignumber": "^5.0.6",
+        "@ethersproject/bignumber": "^5.0.7",
         "@ethersproject/bytes": "^5.0.4",
         "@ethersproject/keccak256": "^5.0.3",
         "@ethersproject/logger": "^5.0.5",
@@ -270,9 +255,9 @@
       }
     },
     "@ethersproject/bignumber": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.6.tgz",
-      "integrity": "sha512-fLilYOSH3DJXBrimx7PwrJdY/zAI5MGp229Mvhtcur76Lgt4qNWu9HTiwMGHP01Tkm3YP5gweF83GrQrA2tYUA==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.7.tgz",
+      "integrity": "sha512-wwKgDJ+KA7IpgJwc8Fc0AjKIRuDskKA2cque29/+SgII9/1K/38JpqVNPKIovkLwTC2DDofIyzHcxeaKpMFouQ==",
       "requires": {
         "@ethersproject/bytes": "^5.0.4",
         "@ethersproject/logger": "^5.0.5",
@@ -288,75 +273,75 @@
       }
     },
     "@ethersproject/constants": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.0.3.tgz",
-      "integrity": "sha512-iN7KBrA0zNFybDyrkcAPOcyU3CHXYFMd+KM2Jr07Kjg+DVB5wPpEXsOdd/K1KWFsFtGfNdPZ7QP8siLtCePXrQ==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.0.4.tgz",
+      "integrity": "sha512-Df32lcXDHPgZRPgp1dgmByNbNe4Ki1QoXR+wU61on5nggQGTqWR1Bb7pp9VtI5Go9kyE/JflFc4Te6o9MvYt8A==",
       "requires": {
-        "@ethersproject/bignumber": "^5.0.6"
+        "@ethersproject/bignumber": "^5.0.7"
       }
     },
     "@ethersproject/contracts": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.0.3.tgz",
-      "integrity": "sha512-60H7UJx6qsp3JP5q3jFjzVNGUygRfz+XzfRwx/VeCKjHBUpFxPEIO2S30SMjYKPqw6JsgxbOjxFFZgOfQiNesw==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.0.4.tgz",
+      "integrity": "sha512-gfOZNgLiO9e1D/hmQ4sEyqoolw6jDFVfqirGJv3zyFKNyX+lAXLN7YAZnnWVmp4GU1jiMtSqQKjpWp7r6ihs3Q==",
       "requires": {
-        "@ethersproject/abi": "^5.0.3",
-        "@ethersproject/abstract-provider": "^5.0.3",
-        "@ethersproject/abstract-signer": "^5.0.3",
-        "@ethersproject/address": "^5.0.3",
-        "@ethersproject/bignumber": "^5.0.6",
+        "@ethersproject/abi": "^5.0.5",
+        "@ethersproject/abstract-provider": "^5.0.4",
+        "@ethersproject/abstract-signer": "^5.0.4",
+        "@ethersproject/address": "^5.0.4",
+        "@ethersproject/bignumber": "^5.0.7",
         "@ethersproject/bytes": "^5.0.4",
-        "@ethersproject/constants": "^5.0.3",
+        "@ethersproject/constants": "^5.0.4",
         "@ethersproject/logger": "^5.0.5",
         "@ethersproject/properties": "^5.0.3"
       }
     },
     "@ethersproject/hash": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.0.3.tgz",
-      "integrity": "sha512-KSnJyL0G9lxbOK0UPrUcaYTc/RidrX8c+kn7xnEpTmSGxqlndw4BzvQcRgYt31bOIwuFtwlWvOo6AN2tJgdQtA==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.0.4.tgz",
+      "integrity": "sha512-VCs/bFBU8AQFhHcT1cQH6x7a4zjulR6fJmAOcPxUgrN7bxOQ7QkpBKF+YCDJhFtkLdaljIsr/r831TuWU4Ysfg==",
       "requires": {
         "@ethersproject/bytes": "^5.0.4",
         "@ethersproject/keccak256": "^5.0.3",
         "@ethersproject/logger": "^5.0.5",
-        "@ethersproject/strings": "^5.0.3"
+        "@ethersproject/strings": "^5.0.4"
       }
     },
     "@ethersproject/hdnode": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.0.3.tgz",
-      "integrity": "sha512-+VQj0gRxfwRPHH7J32fTU8Ouk9CBFBIqvl937I0swO5PghNXBy/1U+o8gZMOitLIId1P3Wr6QcaDHkusi7OQXw==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.0.4.tgz",
+      "integrity": "sha512-eHmpNLvasfB4xbmQUvKXOsGF4ekjIKJH/eZm7fc6nIdMci9u5ERooSSRLjs9Dsa5QuJf6YD4DbqeJsT71n47iw==",
       "requires": {
-        "@ethersproject/abstract-signer": "^5.0.3",
+        "@ethersproject/abstract-signer": "^5.0.4",
         "@ethersproject/basex": "^5.0.3",
-        "@ethersproject/bignumber": "^5.0.6",
+        "@ethersproject/bignumber": "^5.0.7",
         "@ethersproject/bytes": "^5.0.4",
         "@ethersproject/logger": "^5.0.5",
         "@ethersproject/pbkdf2": "^5.0.3",
         "@ethersproject/properties": "^5.0.3",
         "@ethersproject/sha2": "^5.0.3",
         "@ethersproject/signing-key": "^5.0.4",
-        "@ethersproject/strings": "^5.0.3",
-        "@ethersproject/transactions": "^5.0.3",
-        "@ethersproject/wordlists": "^5.0.3"
+        "@ethersproject/strings": "^5.0.4",
+        "@ethersproject/transactions": "^5.0.5",
+        "@ethersproject/wordlists": "^5.0.4"
       }
     },
     "@ethersproject/json-wallets": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.0.5.tgz",
-      "integrity": "sha512-g2kdOY5l+TDE5rIE9BLK+S7fiQMIIsM+KTxxVu4H2COROFwCSMeEb5uMCkccXc3iDX1sOBF653h8kTXCaFY03Q==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.0.6.tgz",
+      "integrity": "sha512-BPCfyGdwOUSp6+xA59IaZ/2pUWrUOL5Z9HuCh8YLsJzkuyBJQN0j+z/PmhIiZ7X8ilhuE+pRUwXb42U/R39fig==",
       "requires": {
-        "@ethersproject/abstract-signer": "^5.0.3",
-        "@ethersproject/address": "^5.0.3",
+        "@ethersproject/abstract-signer": "^5.0.4",
+        "@ethersproject/address": "^5.0.4",
         "@ethersproject/bytes": "^5.0.4",
-        "@ethersproject/hdnode": "^5.0.3",
+        "@ethersproject/hdnode": "^5.0.4",
         "@ethersproject/keccak256": "^5.0.3",
         "@ethersproject/logger": "^5.0.5",
         "@ethersproject/pbkdf2": "^5.0.3",
         "@ethersproject/properties": "^5.0.3",
         "@ethersproject/random": "^5.0.3",
-        "@ethersproject/strings": "^5.0.3",
-        "@ethersproject/transactions": "^5.0.3",
+        "@ethersproject/strings": "^5.0.4",
+        "@ethersproject/transactions": "^5.0.5",
         "aes-js": "3.0.0",
         "scrypt-js": "3.0.1"
       }
@@ -408,27 +393,27 @@
       }
     },
     "@ethersproject/providers": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.0.7.tgz",
-      "integrity": "sha512-lT+w/w2PKX9oyddX0DTBYl2CVHJTJONZP5HLJ3MzVvSA5dTOdiJ9Sx5rpqR7Tw+mxVA9xPjanoNCaPPIT7cykQ==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.0.8.tgz",
+      "integrity": "sha512-nSObVCmcbw0Cbuhg75cCAZtvfaWWx2mcFqqS+9M5G/OAQbcNtqXA7z5hGSBSfapAtLFwzoUiJ8oW7iRTXtT3yQ==",
       "requires": {
-        "@ethersproject/abstract-provider": "^5.0.3",
-        "@ethersproject/abstract-signer": "^5.0.3",
-        "@ethersproject/address": "^5.0.3",
+        "@ethersproject/abstract-provider": "^5.0.4",
+        "@ethersproject/abstract-signer": "^5.0.4",
+        "@ethersproject/address": "^5.0.4",
         "@ethersproject/basex": "^5.0.3",
-        "@ethersproject/bignumber": "^5.0.6",
+        "@ethersproject/bignumber": "^5.0.7",
         "@ethersproject/bytes": "^5.0.4",
-        "@ethersproject/constants": "^5.0.3",
-        "@ethersproject/hash": "^5.0.3",
+        "@ethersproject/constants": "^5.0.4",
+        "@ethersproject/hash": "^5.0.4",
         "@ethersproject/logger": "^5.0.5",
         "@ethersproject/networks": "^5.0.3",
         "@ethersproject/properties": "^5.0.3",
         "@ethersproject/random": "^5.0.3",
         "@ethersproject/rlp": "^5.0.3",
         "@ethersproject/sha2": "^5.0.3",
-        "@ethersproject/strings": "^5.0.3",
-        "@ethersproject/transactions": "^5.0.3",
-        "@ethersproject/web": "^5.0.4",
+        "@ethersproject/strings": "^5.0.4",
+        "@ethersproject/transactions": "^5.0.5",
+        "@ethersproject/web": "^5.0.6",
         "bech32": "1.1.4",
         "ws": "7.2.3"
       }
@@ -484,36 +469,36 @@
       }
     },
     "@ethersproject/solidity": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.0.3.tgz",
-      "integrity": "sha512-a6ni4OIj1e+JrvDiuLVqygYmAh53Ljk5iErkjzPgFBY8dz9xQfDxhpASjOZY0lzCf+N125yeK9N7Vm3HI7OLzQ==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.0.4.tgz",
+      "integrity": "sha512-cUq1l8A+AgRkIItRoztC98Qx7b0bMNMzKX817fszDuGNsT2POAyP5knvuEt4Fx4IBcJREXoOjsGYFfjyK5Sa+w==",
       "requires": {
-        "@ethersproject/bignumber": "^5.0.6",
+        "@ethersproject/bignumber": "^5.0.7",
         "@ethersproject/bytes": "^5.0.4",
         "@ethersproject/keccak256": "^5.0.3",
         "@ethersproject/sha2": "^5.0.3",
-        "@ethersproject/strings": "^5.0.3"
+        "@ethersproject/strings": "^5.0.4"
       }
     },
     "@ethersproject/strings": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.0.3.tgz",
-      "integrity": "sha512-8kEx3+Z6cMn581yh093qnaSa8H7XzmLn6g8YFDHUpzXM7+bvXvnL2ciHrJ+EbvaMQZpej6nNtl0nm7XF4PmQHA==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.0.4.tgz",
+      "integrity": "sha512-azXFHaNkDXzefhr4LVVzzDMFwj3kH9EOKlATu51HjxabQafuUyVLPFgmxRFmCynnAi0Bmmp7nr+qK1pVDgRDLQ==",
       "requires": {
         "@ethersproject/bytes": "^5.0.4",
-        "@ethersproject/constants": "^5.0.3",
+        "@ethersproject/constants": "^5.0.4",
         "@ethersproject/logger": "^5.0.5"
       }
     },
     "@ethersproject/transactions": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.0.4.tgz",
-      "integrity": "sha512-QvS5CzxmL46D9Y3OlddurYgEIi5mb0eAgrKm5pM074Uz/1qxCYr+Ah12I4hpaciZtCq4Fe12YWZqUFb1vGcH6Q==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.0.5.tgz",
+      "integrity": "sha512-1Ga/QmbcB74DItggP8/DK1tggu4ErEvwTkIwIlUXUcvIAuRNXXE7kgQhlp+w1xA/SAQFhv56SqCoyqPiiLCvVA==",
       "requires": {
-        "@ethersproject/address": "^5.0.3",
-        "@ethersproject/bignumber": "^5.0.6",
+        "@ethersproject/address": "^5.0.4",
+        "@ethersproject/bignumber": "^5.0.7",
         "@ethersproject/bytes": "^5.0.4",
-        "@ethersproject/constants": "^5.0.3",
+        "@ethersproject/constants": "^5.0.4",
         "@ethersproject/keccak256": "^5.0.3",
         "@ethersproject/logger": "^5.0.5",
         "@ethersproject/properties": "^5.0.3",
@@ -522,466 +507,368 @@
       }
     },
     "@ethersproject/units": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.0.3.tgz",
-      "integrity": "sha512-PyQ066mFczUy0CSJJrc/VK+1ATh1bsI8EkzAVT7GQ0IPJlNDcXnGNtlH5EQGHzuXA3GDQNV23poB0Cy/WDb2zg==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.0.4.tgz",
+      "integrity": "sha512-80d6skjDgiHLdbKOA9FVpzyMEPwbif40PbGd970JvcecVf48VjB09fUu37d6duG8DhRVyefRdX8nuVQLzcGGPw==",
       "requires": {
-        "@ethersproject/bignumber": "^5.0.6",
-        "@ethersproject/constants": "^5.0.3",
+        "@ethersproject/bignumber": "^5.0.7",
+        "@ethersproject/constants": "^5.0.4",
         "@ethersproject/logger": "^5.0.5"
       }
     },
     "@ethersproject/wallet": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.0.3.tgz",
-      "integrity": "sha512-Nouwfh1HlpxaeRRi4+UDVsfrd9fitBHUvw35bTMSwJLFsZTb9xPd0LGWdX4llwVlAP/CXb6qDc0zwYy6uLp7Lw==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.0.4.tgz",
+      "integrity": "sha512-h/3mdy6HZVketHbs6ZP/WjHDz+rtTIE3qZrko2MVeafjgDcYWaHcVmhsPq4LGqxginhr191a4dkJDNeQrQZWOw==",
       "requires": {
-        "@ethersproject/abstract-provider": "^5.0.3",
-        "@ethersproject/abstract-signer": "^5.0.3",
-        "@ethersproject/address": "^5.0.3",
-        "@ethersproject/bignumber": "^5.0.6",
+        "@ethersproject/abstract-provider": "^5.0.4",
+        "@ethersproject/abstract-signer": "^5.0.4",
+        "@ethersproject/address": "^5.0.4",
+        "@ethersproject/bignumber": "^5.0.7",
         "@ethersproject/bytes": "^5.0.4",
-        "@ethersproject/hash": "^5.0.3",
-        "@ethersproject/hdnode": "^5.0.3",
-        "@ethersproject/json-wallets": "^5.0.5",
+        "@ethersproject/hash": "^5.0.4",
+        "@ethersproject/hdnode": "^5.0.4",
+        "@ethersproject/json-wallets": "^5.0.6",
         "@ethersproject/keccak256": "^5.0.3",
         "@ethersproject/logger": "^5.0.5",
         "@ethersproject/properties": "^5.0.3",
         "@ethersproject/random": "^5.0.3",
         "@ethersproject/signing-key": "^5.0.4",
-        "@ethersproject/transactions": "^5.0.3",
-        "@ethersproject/wordlists": "^5.0.3"
+        "@ethersproject/transactions": "^5.0.5",
+        "@ethersproject/wordlists": "^5.0.4"
       }
     },
     "@ethersproject/web": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.0.5.tgz",
-      "integrity": "sha512-3lffVNOKv/ypW42eY0xhc+UXF+lFUgP1QfIZhWDTJ4xSY6tuNayXKXYq+AqjLXwxwIHzD0TOpe4j46IXJx2NXA==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.0.6.tgz",
+      "integrity": "sha512-EpiF/4YYmHq1VSSKWKkvCfbzIZ3bbYETT+eUC4SB936gZQQE5FJVhL9UJOSJ2l7fvNR+z240+8BknwWQKUdvVA==",
       "requires": {
         "@ethersproject/base64": "^5.0.3",
         "@ethersproject/bytes": "^5.0.4",
         "@ethersproject/logger": "^5.0.5",
         "@ethersproject/properties": "^5.0.3",
-        "@ethersproject/strings": "^5.0.3"
+        "@ethersproject/strings": "^5.0.4"
       }
     },
     "@ethersproject/wordlists": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.0.3.tgz",
-      "integrity": "sha512-Asro9CcBJqxtMnmKrsg79GMmH02p0JmdOwhEdRHRbr51UMRqAfV5RjiidYk21aMsTflv4VY3HgFs6q6FtRJs+w==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.0.4.tgz",
+      "integrity": "sha512-z/NsGqdYFvpeG6vPLxuD0pYNR5lLhQAy+oLVqg6G0o1c/OoL5J/a0iDOAFvnacQphc3lMP52d1LEX3YGoy2oBQ==",
       "requires": {
         "@ethersproject/bytes": "^5.0.4",
-        "@ethersproject/hash": "^5.0.3",
+        "@ethersproject/hash": "^5.0.4",
         "@ethersproject/logger": "^5.0.5",
         "@ethersproject/properties": "^5.0.3",
-        "@ethersproject/strings": "^5.0.3"
+        "@ethersproject/strings": "^5.0.4"
       }
     },
     "@hapi/accept": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@hapi/accept/-/accept-3.2.4.tgz",
-      "integrity": "sha512-soThGB+QMgfxlh0Vzhzlf3ZOEOPk5biEwcOXhkF0Eedqx8VnhGiggL9UYHrIsOb1rUg3Be3K8kp0iDL2wbVSOQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/accept/-/accept-5.0.1.tgz",
+      "integrity": "sha512-fMr4d7zLzsAXo28PRRQPXR1o2Wmu+6z+VY1UzDp0iFo13Twj8WePakwXBiqn3E1aAlTpSNzCXdnnQXFhst8h8Q==",
       "dev": true,
       "requires": {
-        "@hapi/boom": "7.x.x",
-        "@hapi/hoek": "8.x.x"
+        "@hapi/boom": "9.x.x",
+        "@hapi/hoek": "9.x.x"
       }
     },
     "@hapi/address": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.1.4.tgz",
-      "integrity": "sha512-QD1PhQk+s31P1ixsX0H0Suoupp3VMXzIVMSwobR3F3MSUO2YCV0B7xqLcUw/Bh8yuvd3LhpyqLQWTNcRmp6IdQ==",
-      "dev": true
-    },
-    "@hapi/ammo": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@hapi/ammo/-/ammo-3.1.2.tgz",
-      "integrity": "sha512-ej9OtFmiZv1qr45g1bxEZNGyaR4jRpyMxU6VhbxjaYThymvOwsyIsUKMZnP5Qw2tfYFuwqCJuIBHGpeIbdX9gQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/address/-/address-4.1.0.tgz",
+      "integrity": "sha512-SkszZf13HVgGmChdHo/PxchnSaCJ6cetVqLzyciudzZRT0jcOouIF/Q93mgjw8cce+D+4F4C1Z/WrfFN+O3VHQ==",
       "dev": true,
       "requires": {
-        "@hapi/hoek": "8.x.x"
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
+    "@hapi/ammo": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/ammo/-/ammo-5.0.1.tgz",
+      "integrity": "sha512-FbCNwcTbnQP4VYYhLNGZmA76xb2aHg9AMPiy18NZyWMG310P5KdFGyA9v2rm5ujrIny77dEEIkMOwl0Xv+fSSA==",
+      "dev": true,
+      "requires": {
+        "@hapi/hoek": "9.x.x"
       }
     },
     "@hapi/b64": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@hapi/b64/-/b64-4.2.1.tgz",
-      "integrity": "sha512-zqHpQuH5CBMw6hADzKfU/IGNrxq1Q+/wTYV+OiZRQN9F3tMyk+9BUMeBvFRMamduuqL8iSp62QAnJ+7ATiYLWA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/b64/-/b64-5.0.0.tgz",
+      "integrity": "sha512-ngu0tSEmrezoiIaNGG6rRvKOUkUuDdf4XTPnONHGYfSGRmDqPZX5oJL6HAdKTo1UQHECbdB4OzhWrfgVppjHUw==",
       "dev": true,
       "requires": {
-        "@hapi/hoek": "8.x.x"
+        "@hapi/hoek": "9.x.x"
       }
     },
     "@hapi/boom": {
-      "version": "7.4.11",
-      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-7.4.11.tgz",
-      "integrity": "sha512-VSU/Cnj1DXouukYxxkes4nNJonCnlogHvIff1v1RVoN4xzkKhMXX+GRmb3NyH1iar10I9WFPDv2JPwfH3GaV0A==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-9.1.0.tgz",
+      "integrity": "sha512-4nZmpp4tXbm162LaZT45P7F7sgiem8dwAh2vHWT6XX24dozNjGMg6BvKCRvtCUcmcXqeMIUqWN8Rc5X8yKuROQ==",
       "dev": true,
       "requires": {
-        "@hapi/hoek": "8.x.x"
+        "@hapi/hoek": "9.x.x"
       }
     },
     "@hapi/bounce": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@hapi/bounce/-/bounce-1.3.2.tgz",
-      "integrity": "sha512-3bnb1AlcEByFZnpDIidxQyw1Gds81z/1rSqlx4bIEE+wUN0ATj0D49B5cE1wGocy90Rp/de4tv7GjsKd5RQeew==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/bounce/-/bounce-2.0.0.tgz",
+      "integrity": "sha512-JesW92uyzOOyuzJKjoLHM1ThiOvHPOLDHw01YV8yh5nCso7sDwJho1h0Ad2N+E62bZyz46TG3xhAi/78Gsct6A==",
       "dev": true,
       "requires": {
-        "@hapi/boom": "7.x.x",
-        "@hapi/hoek": "^8.3.1"
+        "@hapi/boom": "9.x.x",
+        "@hapi/hoek": "9.x.x"
       }
     },
     "@hapi/bourne": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-1.3.2.tgz",
-      "integrity": "sha512-1dVNHT76Uu5N3eJNTYcvxee+jzX4Z9lfciqRRHCU27ihbUcYi+iSc2iml5Ke1LXe1SyJCLA0+14Jh4tXJgOppA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-2.0.0.tgz",
+      "integrity": "sha512-WEezM1FWztfbzqIUbsDzFRVMxSoLy3HugVcux6KDDtTqzPsLE8NDRHfXvev66aH1i2oOKKar3/XDjbvh/OUBdg==",
       "dev": true
     },
     "@hapi/call": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@hapi/call/-/call-5.1.3.tgz",
-      "integrity": "sha512-5DfWpMk7qZiYhvBhM5oUiT4GQ/O8a2rFR121/PdwA/eZ2C1EsuD547ZggMKAR5bZ+FtxOf0fdM20zzcXzq2mZA==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/call/-/call-8.0.1.tgz",
+      "integrity": "sha512-bOff6GTdOnoe5b8oXRV3lwkQSb/LAWylvDMae6RgEWWntd0SHtkYbQukDHKlfaYtVnSAgIavJ0kqszF/AIBb6g==",
       "dev": true,
       "requires": {
-        "@hapi/boom": "7.x.x",
-        "@hapi/hoek": "8.x.x"
+        "@hapi/boom": "9.x.x",
+        "@hapi/hoek": "9.x.x"
       }
     },
     "@hapi/catbox": {
-      "version": "10.2.3",
-      "resolved": "https://registry.npmjs.org/@hapi/catbox/-/catbox-10.2.3.tgz",
-      "integrity": "sha512-kN9hXO4NYyOHW09CXiuj5qW1syc/0XeVOBsNNk0Tz89wWNQE5h21WF+VsfAw3uFR8swn/Wj3YEVBnWqo82m/JQ==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/catbox/-/catbox-11.1.1.tgz",
+      "integrity": "sha512-u/8HvB7dD/6X8hsZIpskSDo4yMKpHxFd7NluoylhGrL6cUfYxdQPnvUp9YU2C6F9hsyBVLGulBd9vBN1ebfXOQ==",
       "dev": true,
       "requires": {
-        "@hapi/boom": "7.x.x",
-        "@hapi/hoek": "8.x.x",
-        "@hapi/joi": "16.x.x",
-        "@hapi/podium": "3.x.x"
-      },
-      "dependencies": {
-        "@hapi/joi": {
-          "version": "16.1.8",
-          "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-16.1.8.tgz",
-          "integrity": "sha512-wAsVvTPe+FwSrsAurNt5vkg3zo+TblvC5Bb1zMVK6SJzZqw9UrJnexxR+76cpePmtUZKHAPxcQ2Bf7oVHyahhg==",
-          "dev": true,
-          "requires": {
-            "@hapi/address": "^2.1.2",
-            "@hapi/formula": "^1.2.0",
-            "@hapi/hoek": "^8.2.4",
-            "@hapi/pinpoint": "^1.0.2",
-            "@hapi/topo": "^3.1.3"
-          }
-        }
+        "@hapi/boom": "9.x.x",
+        "@hapi/hoek": "9.x.x",
+        "@hapi/podium": "4.x.x",
+        "@hapi/validate": "1.x.x"
       }
     },
     "@hapi/catbox-memory": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@hapi/catbox-memory/-/catbox-memory-4.1.1.tgz",
-      "integrity": "sha512-T6Hdy8DExzG0jY7C8yYWZB4XHfc0v+p1EGkwxl2HoaPYAmW7I3E59M/IvmSVpis8RPcIoBp41ZpO2aZPBpM2Ww==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/catbox-memory/-/catbox-memory-5.0.0.tgz",
+      "integrity": "sha512-ByuxVJPHNaXwLzbBv4GdTr6ccpe1nG+AfYt+8ftDWEJY7EWBWzD+Klhy5oPTDGzU26pNUh1e7fcYI1ILZRxAXQ==",
       "dev": true,
       "requires": {
-        "@hapi/boom": "7.x.x",
-        "@hapi/hoek": "8.x.x"
+        "@hapi/boom": "9.x.x",
+        "@hapi/hoek": "9.x.x"
       }
     },
     "@hapi/content": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@hapi/content/-/content-4.1.1.tgz",
-      "integrity": "sha512-3TWvmwpVPxFSF3KBjKZ8yDqIKKZZIm7VurDSweYpXYENZrJH3C1hd1+qEQW9wQaUaI76pPBLGrXl6I3B7i3ipA==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/content/-/content-5.0.2.tgz",
+      "integrity": "sha512-mre4dl1ygd4ZyOH3tiYBrOUBzV7Pu/EOs8VLGf58vtOEECWed8Uuw6B4iR9AN/8uQt42tB04qpVaMyoMQh0oMw==",
       "dev": true,
       "requires": {
-        "@hapi/boom": "7.x.x"
+        "@hapi/boom": "9.x.x"
       }
     },
     "@hapi/cryptiles": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@hapi/cryptiles/-/cryptiles-4.2.1.tgz",
-      "integrity": "sha512-XoqgKsHK0l/VpqPs+tr6j6vE+VQ3+2bkF2stvttmc7xAOf1oSAwHcJ0tlp/6MxMysktt1IEY0Csy3khKaP9/uQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/cryptiles/-/cryptiles-5.1.0.tgz",
+      "integrity": "sha512-fo9+d1Ba5/FIoMySfMqPBR/7Pa29J2RsiPrl7bkwo5W5o+AN1dAYQRi4SPrPwwVxVGKjgLOEWrsvt1BonJSfLA==",
       "dev": true,
       "requires": {
-        "@hapi/boom": "7.x.x"
+        "@hapi/boom": "9.x.x"
       }
     },
     "@hapi/file": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/file/-/file-1.0.0.tgz",
-      "integrity": "sha512-Bsfp/+1Gyf70eGtnIgmScvrH8sSypO3TcK3Zf0QdHnzn/ACnAkI6KLtGACmNRPEzzIy+W7aJX5E+1fc9GwIABQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/file/-/file-2.0.0.tgz",
+      "integrity": "sha512-WSrlgpvEqgPWkI18kkGELEZfXr0bYLtr16iIN4Krh9sRnzBZN6nnWxHFxtsnP684wueEySBbXPDg/WfA9xJdBQ==",
       "dev": true
     },
     "@hapi/formula": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@hapi/formula/-/formula-1.2.0.tgz",
-      "integrity": "sha512-UFbtbGPjstz0eWHb+ga/GM3Z9EzqKXFWIbSOFURU0A/Gku0Bky4bCk9/h//K2Xr3IrCfjFNhMm4jyZ5dbCewGA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/formula/-/formula-2.0.0.tgz",
+      "integrity": "sha512-V87P8fv7PI0LH7LiVi8Lkf3x+KCO7pQozXRssAHNXXL9L1K+uyu4XypLXwxqVDKgyQai6qj3/KteNlrqDx4W5A==",
       "dev": true
     },
     "@hapi/hapi": {
-      "version": "18.4.1",
-      "resolved": "https://registry.npmjs.org/@hapi/hapi/-/hapi-18.4.1.tgz",
-      "integrity": "sha512-9HjVGa0Z4Qv9jk9AVoUdJMQLA+KuZ+liKWyEEkVBx3e3H1F0JM6aGbPkY9jRfwsITBWGBU2iXazn65SFKSi/tg==",
+      "version": "20.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/hapi/-/hapi-20.0.0.tgz",
+      "integrity": "sha512-Wh0tIDFsl7nemU2JQYW4zZVr9XkpuZ1eM3yaX8tzaYdaYXon8QeB5NzrTNQY3R1/+fO7amQUrOoLLNPRwIZfgw==",
       "dev": true,
       "requires": {
-        "@hapi/accept": "^3.2.4",
-        "@hapi/ammo": "^3.1.2",
-        "@hapi/boom": "7.x.x",
-        "@hapi/bounce": "1.x.x",
-        "@hapi/call": "^5.1.3",
-        "@hapi/catbox": "10.x.x",
-        "@hapi/catbox-memory": "4.x.x",
-        "@hapi/heavy": "6.x.x",
-        "@hapi/hoek": "8.x.x",
-        "@hapi/joi": "15.x.x",
-        "@hapi/mimos": "4.x.x",
-        "@hapi/podium": "3.x.x",
-        "@hapi/shot": "4.x.x",
-        "@hapi/somever": "2.x.x",
-        "@hapi/statehood": "6.x.x",
-        "@hapi/subtext": "^6.1.3",
-        "@hapi/teamwork": "3.x.x",
-        "@hapi/topo": "3.x.x"
+        "@hapi/accept": "^5.0.1",
+        "@hapi/ammo": "^5.0.1",
+        "@hapi/boom": "9.x.x",
+        "@hapi/bounce": "2.x.x",
+        "@hapi/call": "8.x.x",
+        "@hapi/catbox": "^11.1.1",
+        "@hapi/catbox-memory": "5.x.x",
+        "@hapi/heavy": "^7.0.1",
+        "@hapi/hoek": "9.x.x",
+        "@hapi/mimos": "5.x.x",
+        "@hapi/podium": "^4.1.1",
+        "@hapi/shot": "^5.0.1",
+        "@hapi/somever": "3.x.x",
+        "@hapi/statehood": "^7.0.3",
+        "@hapi/subtext": "^7.0.3",
+        "@hapi/teamwork": "5.x.x",
+        "@hapi/topo": "5.x.x",
+        "@hapi/validate": "^1.1.0"
       }
     },
     "@hapi/heavy": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/@hapi/heavy/-/heavy-6.2.2.tgz",
-      "integrity": "sha512-PY1dCCO6dsze7RlafIRhTaGeyTgVe49A/lSkxbhKGjQ7x46o/OFf7hLiRqTCDh3atcEKf6362EaB3+kTUbCsVA==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/heavy/-/heavy-7.0.1.tgz",
+      "integrity": "sha512-vJ/vzRQ13MtRzz6Qd4zRHWS3FaUc/5uivV2TIuExGTM9Qk+7Zzqj0e2G7EpE6KztO9SalTbiIkTh7qFKj/33cA==",
       "dev": true,
       "requires": {
-        "@hapi/boom": "7.x.x",
-        "@hapi/hoek": "8.x.x",
-        "@hapi/joi": "16.x.x"
-      },
-      "dependencies": {
-        "@hapi/joi": {
-          "version": "16.1.8",
-          "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-16.1.8.tgz",
-          "integrity": "sha512-wAsVvTPe+FwSrsAurNt5vkg3zo+TblvC5Bb1zMVK6SJzZqw9UrJnexxR+76cpePmtUZKHAPxcQ2Bf7oVHyahhg==",
-          "dev": true,
-          "requires": {
-            "@hapi/address": "^2.1.2",
-            "@hapi/formula": "^1.2.0",
-            "@hapi/hoek": "^8.2.4",
-            "@hapi/pinpoint": "^1.0.2",
-            "@hapi/topo": "^3.1.3"
-          }
-        }
+        "@hapi/boom": "9.x.x",
+        "@hapi/hoek": "9.x.x",
+        "@hapi/validate": "1.x.x"
       }
     },
     "@hapi/hoek": {
-      "version": "8.5.1",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.1.tgz",
-      "integrity": "sha512-yN7kbciD87WzLGc5539Tn0sApjyiGHAJgKvG9W8C7O+6c7qmoQMfVs0W4bX17eqz6C78QJqqFrtgdK5EWf6Qow==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.1.0.tgz",
+      "integrity": "sha512-i9YbZPN3QgfighY/1X1Pu118VUz2Fmmhd6b2n0/O8YVgGGfw0FbUYoA97k7FkpGJ+pLCFEDLUmAPPV4D1kpeFw==",
       "dev": true
     },
     "@hapi/inert": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@hapi/inert/-/inert-5.2.2.tgz",
-      "integrity": "sha512-8IaGfAEF8SwZtpdaTq0G3aDPG35ZTfWKjnMNniG2N3kE+qioMsBuImIGxna8TNQ+sYMXYK78aqmvzbQHno8qSQ==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/inert/-/inert-6.0.2.tgz",
+      "integrity": "sha512-cq0a8jstkLW1+oJaw4jp52PZBEkVbX9d0YDy5aOs3rOKYSjpzs2nQBahnCHEMchOrOSUffLpE+IDoivYHcx8uA==",
       "dev": true,
       "requires": {
-        "@hapi/ammo": "3.x.x",
-        "@hapi/boom": "7.x.x",
-        "@hapi/bounce": "1.x.x",
-        "@hapi/hoek": "8.x.x",
-        "@hapi/joi": "16.x.x",
-        "lru-cache": "4.1.x"
-      },
-      "dependencies": {
-        "@hapi/joi": {
-          "version": "16.1.8",
-          "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-16.1.8.tgz",
-          "integrity": "sha512-wAsVvTPe+FwSrsAurNt5vkg3zo+TblvC5Bb1zMVK6SJzZqw9UrJnexxR+76cpePmtUZKHAPxcQ2Bf7oVHyahhg==",
-          "dev": true,
-          "requires": {
-            "@hapi/address": "^2.1.2",
-            "@hapi/formula": "^1.2.0",
-            "@hapi/hoek": "^8.2.4",
-            "@hapi/pinpoint": "^1.0.2",
-            "@hapi/topo": "^3.1.3"
-          }
-        }
+        "@hapi/ammo": "5.x.x",
+        "@hapi/boom": "9.x.x",
+        "@hapi/bounce": "2.x.x",
+        "@hapi/hoek": "9.x.x",
+        "@hapi/validate": "1.x.x",
+        "lru-cache": "5.x.x"
       }
     },
     "@hapi/iron": {
-      "version": "5.1.4",
-      "resolved": "https://registry.npmjs.org/@hapi/iron/-/iron-5.1.4.tgz",
-      "integrity": "sha512-+ElC+OCiwWLjlJBmm8ZEWjlfzTMQTdgPnU/TsoU5QsktspIWmWi9IU4kU83nH+X/SSya8TP8h8P11Wr5L7dkQQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/iron/-/iron-6.0.0.tgz",
+      "integrity": "sha512-zvGvWDufiTGpTJPG1Y/McN8UqWBu0k/xs/7l++HVU535NLHXsHhy54cfEMdW7EjwKfbBfM9Xy25FmTiobb7Hvw==",
       "dev": true,
       "requires": {
-        "@hapi/b64": "4.x.x",
-        "@hapi/boom": "7.x.x",
-        "@hapi/bourne": "1.x.x",
-        "@hapi/cryptiles": "4.x.x",
-        "@hapi/hoek": "8.x.x"
-      }
-    },
-    "@hapi/joi": {
-      "version": "15.1.1",
-      "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-15.1.1.tgz",
-      "integrity": "sha512-entf8ZMOK8sc+8YfeOlM8pCfg3b5+WZIKBfUaaJT8UsjAAPjartzxIYm3TIbjvA4u+u++KbcXD38k682nVHDAQ==",
-      "dev": true,
-      "requires": {
-        "@hapi/address": "2.x.x",
-        "@hapi/bourne": "1.x.x",
-        "@hapi/hoek": "8.x.x",
-        "@hapi/topo": "3.x.x"
+        "@hapi/b64": "5.x.x",
+        "@hapi/boom": "9.x.x",
+        "@hapi/bourne": "2.x.x",
+        "@hapi/cryptiles": "5.x.x",
+        "@hapi/hoek": "9.x.x"
       }
     },
     "@hapi/mimos": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@hapi/mimos/-/mimos-4.1.1.tgz",
-      "integrity": "sha512-CXoi/zfcTWfKYX756eEea8rXJRIb9sR4d7VwyAH9d3BkDyNgAesZxvqIdm55npQc6S9mU3FExinMAQVlIkz0eA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/mimos/-/mimos-5.0.0.tgz",
+      "integrity": "sha512-EVS6wJYeE73InTlPWt+2e3Izn319iIvffDreci3qDNT+t3lA5ylJ0/SoTaID8e0TPNUkHUSsgJZXEmLHvoYzrA==",
       "dev": true,
       "requires": {
-        "@hapi/hoek": "8.x.x",
+        "@hapi/hoek": "9.x.x",
         "mime-db": "1.x.x"
       }
     },
     "@hapi/nigel": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@hapi/nigel/-/nigel-3.1.1.tgz",
-      "integrity": "sha512-R9YWx4S8yu0gcCBrMUDCiEFm1SQT895dMlYoeNBp8I6YhF1BFF1iYPueKA2Kkp9BvyHdjmvrxCOns7GMmpl+Fw==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/nigel/-/nigel-4.0.2.tgz",
+      "integrity": "sha512-ht2KoEsDW22BxQOEkLEJaqfpoKPXxi7tvabXy7B/77eFtOyG5ZEstfZwxHQcqAiZhp58Ae5vkhEqI03kawkYNw==",
       "dev": true,
       "requires": {
-        "@hapi/hoek": "8.x.x",
-        "@hapi/vise": "3.x.x"
+        "@hapi/hoek": "^9.0.4",
+        "@hapi/vise": "^4.0.0"
       }
     },
     "@hapi/pez": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@hapi/pez/-/pez-4.1.2.tgz",
-      "integrity": "sha512-8zSdJ8cZrJLFldTgwjU9Fb1JebID+aBCrCsycgqKYe0OZtM2r3Yv3aAwW5z97VsZWCROC1Vx6Mdn4rujh5Ktcg==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@hapi/pez/-/pez-5.0.3.tgz",
+      "integrity": "sha512-mpikYRJjtrbJgdDHG/H9ySqYqwJ+QU/D7FXsYciS9P7NYBXE2ayKDAy3H0ou6CohOCaxPuTV4SZ0D936+VomHA==",
       "dev": true,
       "requires": {
-        "@hapi/b64": "4.x.x",
-        "@hapi/boom": "7.x.x",
-        "@hapi/content": "^4.1.1",
-        "@hapi/hoek": "8.x.x",
-        "@hapi/nigel": "3.x.x"
+        "@hapi/b64": "5.x.x",
+        "@hapi/boom": "9.x.x",
+        "@hapi/content": "^5.0.2",
+        "@hapi/hoek": "9.x.x",
+        "@hapi/nigel": "4.x.x"
       }
     },
     "@hapi/pinpoint": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@hapi/pinpoint/-/pinpoint-1.0.2.tgz",
-      "integrity": "sha512-dtXC/WkZBfC5vxscazuiJ6iq4j9oNx1SHknmIr8hofarpKUZKmlUVYVIhNVzIEgK5Wrc4GMHL5lZtt1uS2flmQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/pinpoint/-/pinpoint-2.0.0.tgz",
+      "integrity": "sha512-vzXR5MY7n4XeIvLpfl3HtE3coZYO4raKXW766R6DZw/6aLqR26iuZ109K7a0NtF2Db0jxqh7xz2AxkUwpUFybw==",
       "dev": true
     },
     "@hapi/podium": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/@hapi/podium/-/podium-3.4.3.tgz",
-      "integrity": "sha512-QJlnYLEYZWlKQ9fSOtuUcpANyoVGwT68GA9P0iQQCAetBK0fI+nbRBt58+aMixoifczWZUthuGkNjqKxgPh/CQ==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/podium/-/podium-4.1.1.tgz",
+      "integrity": "sha512-jh7a6+5Z4FUWzx8fgmxjaAa1DTBu+Qfg+NbVdo0f++rE5DgsVidUYrLDp3db65+QjDLleA2MfKQXkpT8ylBDXA==",
       "dev": true,
       "requires": {
-        "@hapi/hoek": "8.x.x",
-        "@hapi/joi": "16.x.x"
-      },
-      "dependencies": {
-        "@hapi/joi": {
-          "version": "16.1.8",
-          "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-16.1.8.tgz",
-          "integrity": "sha512-wAsVvTPe+FwSrsAurNt5vkg3zo+TblvC5Bb1zMVK6SJzZqw9UrJnexxR+76cpePmtUZKHAPxcQ2Bf7oVHyahhg==",
-          "dev": true,
-          "requires": {
-            "@hapi/address": "^2.1.2",
-            "@hapi/formula": "^1.2.0",
-            "@hapi/hoek": "^8.2.4",
-            "@hapi/pinpoint": "^1.0.2",
-            "@hapi/topo": "^3.1.3"
-          }
-        }
+        "@hapi/hoek": "9.x.x",
+        "@hapi/teamwork": "5.x.x",
+        "@hapi/validate": "1.x.x"
       }
     },
     "@hapi/shot": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@hapi/shot/-/shot-4.1.2.tgz",
-      "integrity": "sha512-6LeHLjvsq/bQ0R+fhEyr7mqExRGguNTrxFZf5DyKe3CK6pNabiGgYO4JVFaRrLZ3JyuhkS0fo8iiRE2Ql2oA/A==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@hapi/shot/-/shot-5.0.4.tgz",
+      "integrity": "sha512-PcEz0WJgFDA3xNSMeONgQmothFr7jhbbRRSAKaDh7chN7zOXBlhl13bvKZW6CMb2xVfJUmt34CW3e/oExMgBhQ==",
       "dev": true,
       "requires": {
-        "@hapi/hoek": "8.x.x",
-        "@hapi/joi": "16.x.x"
-      },
-      "dependencies": {
-        "@hapi/joi": {
-          "version": "16.1.8",
-          "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-16.1.8.tgz",
-          "integrity": "sha512-wAsVvTPe+FwSrsAurNt5vkg3zo+TblvC5Bb1zMVK6SJzZqw9UrJnexxR+76cpePmtUZKHAPxcQ2Bf7oVHyahhg==",
-          "dev": true,
-          "requires": {
-            "@hapi/address": "^2.1.2",
-            "@hapi/formula": "^1.2.0",
-            "@hapi/hoek": "^8.2.4",
-            "@hapi/pinpoint": "^1.0.2",
-            "@hapi/topo": "^3.1.3"
-          }
-        }
+        "@hapi/hoek": "9.x.x",
+        "@hapi/validate": "1.x.x"
       }
     },
     "@hapi/somever": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@hapi/somever/-/somever-2.1.1.tgz",
-      "integrity": "sha512-cic5Sto4KGd9B0oQSdKTokju+rYhCbdpzbMb0EBnrH5Oc1z048hY8PaZ1lx2vBD7I/XIfTQVQetBH57fU51XRA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/somever/-/somever-3.0.0.tgz",
+      "integrity": "sha512-Upw/kmKotC9iEmK4y047HMYe4LDKsE5NWfjgX41XNKmFvxsQL7OiaCWVhuyyhU0ShDGBfIAnCH8jZr49z/JzZA==",
       "dev": true,
       "requires": {
-        "@hapi/bounce": "1.x.x",
-        "@hapi/hoek": "8.x.x"
+        "@hapi/bounce": "2.x.x",
+        "@hapi/hoek": "9.x.x"
       }
     },
     "@hapi/statehood": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/@hapi/statehood/-/statehood-6.1.2.tgz",
-      "integrity": "sha512-pYXw1x6npz/UfmtcpUhuMvdK5kuOGTKcJNfLqdNptzietK2UZH5RzNJSlv5bDHeSmordFM3kGItcuQWX2lj2nQ==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@hapi/statehood/-/statehood-7.0.3.tgz",
+      "integrity": "sha512-pYB+pyCHkf2Amh67QAXz7e/DN9jcMplIL7Z6N8h0K+ZTy0b404JKPEYkbWHSnDtxLjJB/OtgElxocr2fMH4G7w==",
       "dev": true,
       "requires": {
-        "@hapi/boom": "7.x.x",
-        "@hapi/bounce": "1.x.x",
-        "@hapi/bourne": "1.x.x",
-        "@hapi/cryptiles": "4.x.x",
-        "@hapi/hoek": "8.x.x",
-        "@hapi/iron": "5.x.x",
-        "@hapi/joi": "16.x.x"
-      },
-      "dependencies": {
-        "@hapi/joi": {
-          "version": "16.1.8",
-          "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-16.1.8.tgz",
-          "integrity": "sha512-wAsVvTPe+FwSrsAurNt5vkg3zo+TblvC5Bb1zMVK6SJzZqw9UrJnexxR+76cpePmtUZKHAPxcQ2Bf7oVHyahhg==",
-          "dev": true,
-          "requires": {
-            "@hapi/address": "^2.1.2",
-            "@hapi/formula": "^1.2.0",
-            "@hapi/hoek": "^8.2.4",
-            "@hapi/pinpoint": "^1.0.2",
-            "@hapi/topo": "^3.1.3"
-          }
-        }
+        "@hapi/boom": "9.x.x",
+        "@hapi/bounce": "2.x.x",
+        "@hapi/bourne": "2.x.x",
+        "@hapi/cryptiles": "5.x.x",
+        "@hapi/hoek": "9.x.x",
+        "@hapi/iron": "6.x.x",
+        "@hapi/validate": "1.x.x"
       }
     },
     "@hapi/subtext": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/@hapi/subtext/-/subtext-6.1.3.tgz",
-      "integrity": "sha512-qWN6NbiHNzohVcJMeAlpku/vzbyH4zIpnnMPMPioQMwIxbPFKeNViDCNI6fVBbMPBiw/xB4FjqiJkRG5P9eWWg==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@hapi/subtext/-/subtext-7.0.3.tgz",
+      "integrity": "sha512-CekDizZkDGERJ01C0+TzHlKtqdXZxzSWTOaH6THBrbOHnsr3GY+yiMZC+AfNCypfE17RaIakGIAbpL2Tk1z2+A==",
       "dev": true,
       "requires": {
-        "@hapi/boom": "7.x.x",
-        "@hapi/bourne": "1.x.x",
-        "@hapi/content": "^4.1.1",
-        "@hapi/file": "1.x.x",
-        "@hapi/hoek": "8.x.x",
-        "@hapi/pez": "^4.1.2",
-        "@hapi/wreck": "15.x.x"
+        "@hapi/boom": "9.x.x",
+        "@hapi/bourne": "2.x.x",
+        "@hapi/content": "^5.0.2",
+        "@hapi/file": "2.x.x",
+        "@hapi/hoek": "9.x.x",
+        "@hapi/pez": "^5.0.1",
+        "@hapi/wreck": "17.x.x"
       }
     },
     "@hapi/teamwork": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@hapi/teamwork/-/teamwork-3.3.1.tgz",
-      "integrity": "sha512-61tiqWCYvMKP7fCTXy0M4VE6uNIwA0qvgFoiDubgfj7uqJ0fdHJFQNnVPGrxhLWlwz0uBPWrQlBH7r8y9vFITQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/teamwork/-/teamwork-5.1.0.tgz",
+      "integrity": "sha512-llqoQTrAJDTXxG3c4Kz/uzhBS1TsmSBa/XG5SPcVXgmffHE1nFtyLIK0hNJHCB3EuBKT84adzd1hZNY9GJLWtg==",
       "dev": true
     },
     "@hapi/topo": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-3.1.6.tgz",
-      "integrity": "sha512-tAag0jEcjwH+P2quUfipd7liWCNX2F8NvYjQp2wtInsZxnMlypdw0FtAOLxtvvkO+GSRRbmNi8m/5y42PQJYCQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.0.0.tgz",
+      "integrity": "sha512-tFJlT47db0kMqVm3H4nQYgn6Pwg10GTZHb1pwmSiv1K4ks6drQOtfEF5ZnPjkvC+y4/bUPHK+bc87QvLcL+WMw==",
       "dev": true,
       "requires": {
-        "@hapi/hoek": "^8.3.0"
+        "@hapi/hoek": "^9.0.0"
       }
     },
     "@hapi/validate": {
@@ -992,43 +879,26 @@
       "requires": {
         "@hapi/hoek": "^9.0.0",
         "@hapi/topo": "^5.0.0"
-      },
-      "dependencies": {
-        "@hapi/hoek": {
-          "version": "9.1.0",
-          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.1.0.tgz",
-          "integrity": "sha512-i9YbZPN3QgfighY/1X1Pu118VUz2Fmmhd6b2n0/O8YVgGGfw0FbUYoA97k7FkpGJ+pLCFEDLUmAPPV4D1kpeFw==",
-          "dev": true
-        },
-        "@hapi/topo": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.0.0.tgz",
-          "integrity": "sha512-tFJlT47db0kMqVm3H4nQYgn6Pwg10GTZHb1pwmSiv1K4ks6drQOtfEF5ZnPjkvC+y4/bUPHK+bc87QvLcL+WMw==",
-          "dev": true,
-          "requires": {
-            "@hapi/hoek": "^9.0.0"
-          }
-        }
       }
     },
     "@hapi/vise": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@hapi/vise/-/vise-3.1.1.tgz",
-      "integrity": "sha512-OXarbiCSadvtg+bSdVPqu31Z1JoBL+FwNYz3cYoBKQ5xq1/Cr4A3IkGpAZbAuxU5y4NL5pZFZG3d2a3ZGm/dOQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/vise/-/vise-4.0.0.tgz",
+      "integrity": "sha512-eYyLkuUiFZTer59h+SGy7hUm+qE9p+UemePTHLlIWppEd+wExn3Df5jO04bFQTm7nleF5V8CtuYQYb+VFpZ6Sg==",
       "dev": true,
       "requires": {
-        "@hapi/hoek": "8.x.x"
+        "@hapi/hoek": "9.x.x"
       }
     },
     "@hapi/wreck": {
-      "version": "15.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/wreck/-/wreck-15.1.0.tgz",
-      "integrity": "sha512-tQczYRTTeYBmvhsek/D49En/5khcShaBEmzrAaDjMrFXKJRuF8xA8+tlq1ETLBFwGd6Do6g2OC74rt11kzawzg==",
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/wreck/-/wreck-17.0.0.tgz",
+      "integrity": "sha512-d8lqCinbKyDByn7GzJDRDbitddhIEydNm44UcAMejfhEH3o4IYvKYq6K8cAqXbilXPuvZc0ErlUOg9SDdgRtMw==",
       "dev": true,
       "requires": {
-        "@hapi/boom": "7.x.x",
-        "@hapi/bourne": "1.x.x",
-        "@hapi/hoek": "8.x.x"
+        "@hapi/boom": "9.x.x",
+        "@hapi/bourne": "2.x.x",
+        "@hapi/hoek": "9.x.x"
       }
     },
     "@mrmlnc/readdir-enhanced": {
@@ -1129,9 +999,9 @@
       }
     },
     "@octokit/request": {
-      "version": "5.4.8",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.4.8.tgz",
-      "integrity": "sha512-mWbxjsARJzAq5xp+ZrQfotc+MHFz3/Am2qATJwflv4PZ1TjhgIJnr60PCVdZT9Z/tl+uPXooaVgeviy1KkDlLQ==",
+      "version": "5.4.9",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.4.9.tgz",
+      "integrity": "sha512-CzwVvRyimIM1h2n9pLVYfTDmX9m+KHSgCpqPsY8F1NdEK8IaWqXhSBXsdjOBFZSpEcxNEeg4p0UO9cQ8EnOCLA==",
       "dev": true,
       "requires": {
         "@octokit/endpoint": "^6.0.1",
@@ -1139,7 +1009,7 @@
         "@octokit/types": "^5.0.0",
         "deprecation": "^2.0.0",
         "is-plain-object": "^5.0.0",
-        "node-fetch": "^2.3.0",
+        "node-fetch": "^2.6.1",
         "once": "^1.4.0",
         "universal-user-agent": "^6.0.0"
       },
@@ -1216,9 +1086,9 @@
       }
     },
     "@octokit/types": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-5.4.1.tgz",
-      "integrity": "sha512-OlMlSySBJoJ6uozkr/i03nO5dlYQyE05vmQNZhAh9MyO4DPBP88QlwsDVLmVjIMFssvIZB6WO0ctIGMRG+xsJQ==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-5.5.0.tgz",
+      "integrity": "sha512-UZ1pErDue6bZNjYOotCNveTXArOMZQFG6hKJfOnGnulVCMcVVi7YIIuuR4WfBhjo7zgpmzn/BkPDnUXtNx+PcQ==",
       "dev": true,
       "requires": {
         "@types/node": ">= 8"
@@ -1418,9 +1288,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "14.10.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.10.1.tgz",
-      "integrity": "sha512-aYNbO+FZ/3KGeQCEkNhHFRIzBOUgc7QvcVNKXbfnhDkSfwUv91JsQQa10rDgKSTSLkXZ1UIyPe4FJJNVgw1xWQ==",
+      "version": "14.10.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.10.3.tgz",
+      "integrity": "sha512-zdN0hor7TLkjAdKTnYW+Y22oIhUUpil5ZD1V1OFq0CR0CLKw+NdR6dkziTfkWRLo6sKzisayoj/GNpNbe4LY9Q==",
       "dev": true
     },
     "@types/normalize-package-data": {
@@ -1666,7 +1536,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
       "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-      "dev": true,
       "requires": {
         "event-target-shim": "^5.0.0"
       }
@@ -1689,9 +1558,9 @@
       }
     },
     "abstract-logging": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/abstract-logging/-/abstract-logging-1.0.0.tgz",
-      "integrity": "sha1-i33q/TEFWbwo93ck3RuzAXcnjBs=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/abstract-logging/-/abstract-logging-2.0.0.tgz",
+      "integrity": "sha512-/oA9z7JszpIioo6J6dB79LVUgJ3eD3cxkAmdCkvWWS+Y9tPtALs1rLqOekLUXUbYqM2fB9TTK0ibAyZJJOP/CA==",
       "dev": true
     },
     "accepts": {
@@ -1749,23 +1618,6 @@
       "dev": true,
       "requires": {
         "debug": "4"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        }
       }
     },
     "aggregate-error": {
@@ -1778,9 +1630,9 @@
       }
     },
     "ajv": {
-      "version": "6.12.4",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.4.tgz",
-      "integrity": "sha512-eienB2c9qVQs2KWexhkrdMLVDoIQCz5KSeLxwg9Lzk4DOfBtIK9PQwwufcsn1jjGuf9WZmqPMbGxOzfcuphJCQ==",
+      "version": "6.12.5",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.5.tgz",
+      "integrity": "sha512-lRF8RORchjpKG50/WFf8xmg7sgCLFiYNNnqdKflk63whMQcWR5ngGjiSXkL9bjxy6B2npOK2HSMN49jEBMSkag==",
       "dev": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
@@ -1898,7 +1750,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/any-signal/-/any-signal-1.2.0.tgz",
       "integrity": "sha512-Cl08k4xItix3jvu4cxO/dt2rQ6iUAjO66pTyRMub+WL1VXeAyZydCpD8GqWTPKfdL28U0R0UucmQVsUsBnvCmQ==",
-      "dev": true,
       "requires": {
         "abort-controller": "^3.0.0"
       }
@@ -2236,41 +2087,15 @@
       "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
       "dev": true
     },
-    "async.nexttick": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/async.nexttick/-/async.nexttick-0.5.2.tgz",
-      "integrity": "sha1-Wi6qemLO/dn1HfykgFibwkIY+Z4=",
-      "dev": true,
-      "requires": {
-        "async.util.nexttick": "0.5.2"
-      }
-    },
-    "async.util.nexttick": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/async.util.nexttick/-/async.util.nexttick-0.5.2.tgz",
-      "integrity": "sha1-UbmyNhHoC9iaGoGIcrv2h3ls35U=",
-      "dev": true,
-      "requires": {
-        "async.util.setimmediate": "0.5.2"
-      }
-    },
-    "async.util.setimmediate": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/async.util.setimmediate/-/async.util.setimmediate-0.5.2.tgz",
-      "integrity": "sha1-KBLrq/KlgCd1jUvHeT0cz68QJV8=",
-      "dev": true
-    },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-      "dev": true
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "at-least-node": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
-      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
-      "dev": true
+      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg=="
     },
     "atob": {
       "version": "2.1.2",
@@ -2378,6 +2203,23 @@
         "private": "^0.1.8",
         "slash": "^1.0.0",
         "source-map": "^0.5.7"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
       }
     },
     "babel-generator": {
@@ -3004,6 +2846,23 @@
         "globals": "^9.18.0",
         "invariant": "^2.2.2",
         "lodash": "^4.17.4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
       }
     },
     "babel-types": {
@@ -3039,8 +2898,7 @@
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "dev": true
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "base": {
       "version": "0.11.2",
@@ -3166,13 +3024,13 @@
       }
     },
     "bcrypto": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/bcrypto/-/bcrypto-5.1.0.tgz",
-      "integrity": "sha512-WEs5g7WHdEdLLcsvhE7Z1AXv0G+hb+bJhSUYM7samFNrH051XhcFVWxAbAZDmIU1HWjpjhmQ+HqBar7UC/qrzQ==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/bcrypto/-/bcrypto-5.3.0.tgz",
+      "integrity": "sha512-SP48cpoc4BkEPNOErdsZ1VjbtdXY/C0f5wAywWniLne/Fd/5oOBqLbC6ZavngLvk4oik76g4I7PO5KduJoqECQ==",
       "dev": true,
       "requires": {
-        "bufio": "~1.0.6",
-        "loady": "~0.0.1"
+        "bufio": "~1.0.7",
+        "loady": "~0.0.5"
       }
     },
     "bech32": {
@@ -3204,8 +3062,7 @@
     "bignumber.js": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.0.tgz",
-      "integrity": "sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A==",
-      "dev": true
+      "integrity": "sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A=="
     },
     "binary": {
       "version": "0.3.0",
@@ -3308,7 +3165,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.3.tgz",
       "integrity": "sha512-fs4G6/Hu4/EE+F75J8DuN/0IpQqNjAdC7aEQv7Qt8MHGUH7Ckv2MwTEEeN9QehD0pfIDkMI1bkHYkKy7xHyKIg==",
-      "dev": true,
       "requires": {
         "buffer": "^5.5.0",
         "inherits": "^2.0.4",
@@ -3327,12 +3183,11 @@
       "dev": true
     },
     "blob-to-it": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/blob-to-it/-/blob-to-it-0.0.1.tgz",
-      "integrity": "sha512-gvOVIs0YUpKHAwvhoJcRs81LJrOb+kwOol0/NnF/JgD0a5i9SJ/Es/njJo3NgFzb+x/FDPh4cD4D1KnrBeUWuw==",
-      "dev": true,
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/blob-to-it/-/blob-to-it-0.0.2.tgz",
+      "integrity": "sha512-3/NRr0mUWQTkS71MYEC1teLbT5BTs7RZ6VMPXDV6qApjw3B4TAZspQuvDkYfHuD/XzL5p/RO91x5XRPeJvcCqg==",
       "requires": {
-        "browser-readablestream-to-it": "^0.0.1"
+        "browser-readablestream-to-it": "^0.0.2"
       }
     },
     "block-stream": {
@@ -3360,7 +3215,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/borc/-/borc-2.1.2.tgz",
       "integrity": "sha512-Sy9eoUi4OiKzq7VovMn246iTo17kzuyHJKomCfpWMlI6RpfN1gk95w7d7gH264nApVLg0HZfcpz62/g4VH1Y4w==",
-      "dev": true,
       "requires": {
         "bignumber.js": "^9.0.0",
         "buffer": "^5.5.0",
@@ -3487,7 +3341,6 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -3511,10 +3364,9 @@
       "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
     },
     "browser-readablestream-to-it": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/browser-readablestream-to-it/-/browser-readablestream-to-it-0.0.1.tgz",
-      "integrity": "sha512-leRiI4bLRr7K8znNmQZ3frgL8A7aX4LI4g7444YEtT3alaxqem+XPGsJmOlFRRdRqjFpvf2wW4dXKcgBLxypVg==",
-      "dev": true
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/browser-readablestream-to-it/-/browser-readablestream-to-it-0.0.2.tgz",
+      "integrity": "sha512-bbiTccngeAbPmpTUJcUyr6JhivADKV9xkNJVLdA91vjdzXyFBZ6fgrzElQsV3k1UNGQACRTl3p4y+cEGG9U48A=="
     },
     "browser-stdout": {
       "version": "1.3.1",
@@ -3733,15 +3585,6 @@
           "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
           "dev": true
         },
-        "lru-cache": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-          "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-          "dev": true,
-          "requires": {
-            "yallist": "^3.0.2"
-          }
-        },
         "mkdirp": {
           "version": "0.5.5",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
@@ -3759,12 +3602,6 @@
           "requires": {
             "glob": "^7.1.3"
           }
-        },
-        "yallist": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-          "dev": true
         }
       }
     },
@@ -3877,9 +3714,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001125",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001125.tgz",
-      "integrity": "sha512-9f+r7BW8Qli917mU3j0fUaTweT3f3vnX/Lcs+1C73V+RADmFme+Ih0Br8vONQi3X0lseOe6ZHfsZLCA8MSjxUA==",
+      "version": "1.0.30001131",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001131.tgz",
+      "integrity": "sha512-4QYi6Mal4MMfQMSqGIRPGbKIbZygeN83QsWq1ixpUwvtfgAZot5BrCKzGygvZaV+CnELdTwD0S4cqUNozq7/Cw==",
       "dev": true
     },
     "caseless": {
@@ -4023,16 +3860,17 @@
       "dev": true
     },
     "cid-tool": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/cid-tool/-/cid-tool-0.4.1.tgz",
-      "integrity": "sha512-nASd+T8H9hY1Z3Z9ylvWlUUCFZ1msFaGAx7Y9+peqJEbrnSLErJXT8YJFRyUtkkP8+0NYE9g8JRUhC5+pj8SJw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/cid-tool/-/cid-tool-1.0.0.tgz",
+      "integrity": "sha512-K7NGZBo1P6N2ogUmBtJWwMNfqXxU3ROiCHs+YKDDwBecsZ46J+9vJ6pOEJzds1JzqRnYRxxZBPfgBEYQebMXJg==",
       "dev": true,
       "requires": {
-        "cids": "~0.8.0",
+        "cids": "^1.0.0",
         "explain-error": "^1.0.4",
-        "multibase": "~0.7.0",
-        "multihashes": "~0.4.14",
+        "multibase": "^3.0.0",
+        "multihashes": "^3.0.1",
         "split2": "^3.1.1",
+        "uint8arrays": "^1.1.0",
         "yargs": "^15.0.2"
       },
       "dependencies": {
@@ -4050,42 +3888,6 @@
           "requires": {
             "@types/color-name": "^1.1.1",
             "color-convert": "^2.0.1"
-          }
-        },
-        "cids": {
-          "version": "0.8.3",
-          "resolved": "https://registry.npmjs.org/cids/-/cids-0.8.3.tgz",
-          "integrity": "sha512-yoXTbV3llpm+EBGWKeL9xKtksPE/s6DPoDSY4fn8I8TEW1zehWXPSB0pwAXVDlLaOlrw+sNynj995uD9abmPhA==",
-          "dev": true,
-          "requires": {
-            "buffer": "^5.6.0",
-            "class-is": "^1.1.0",
-            "multibase": "^1.0.0",
-            "multicodec": "^1.0.1",
-            "multihashes": "^1.0.1"
-          },
-          "dependencies": {
-            "multibase": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
-              "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
-              "dev": true,
-              "requires": {
-                "base-x": "^3.0.8",
-                "buffer": "^5.5.0"
-              }
-            },
-            "multihashes": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
-              "integrity": "sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==",
-              "dev": true,
-              "requires": {
-                "buffer": "^5.6.0",
-                "multibase": "^1.0.1",
-                "varint": "^5.0.0"
-              }
-            }
           }
         },
         "cliui": {
@@ -4143,37 +3945,6 @@
           "dev": true,
           "requires": {
             "p-locate": "^4.1.0"
-          }
-        },
-        "multibase": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.7.0.tgz",
-          "integrity": "sha512-TW8q03O0f6PNFTQDvh3xxH03c8CjGaaYrjkl9UQPG6rz53TQzzxJVCIWVjzcbN/Q5Y53Zd0IBQBMVktVgNx4Fg==",
-          "dev": true,
-          "requires": {
-            "base-x": "^3.0.8",
-            "buffer": "^5.5.0"
-          }
-        },
-        "multicodec": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-1.0.4.tgz",
-          "integrity": "sha512-NDd7FeS3QamVtbgfvu5h7fd1IlbaC4EQ0/pgU4zqE2vdHCmBGsUa0TiM8/TdSeG6BMPC92OOCf8F1ocE/Wkrrg==",
-          "dev": true,
-          "requires": {
-            "buffer": "^5.6.0",
-            "varint": "^5.0.0"
-          }
-        },
-        "multihashes": {
-          "version": "0.4.21",
-          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-0.4.21.tgz",
-          "integrity": "sha512-uVSvmeCWf36pU2nB4/1kzYZjsXD9vofZKpgudqkceYY5g2aZZXJ5r9lxuzoRLl1OAp28XljXsEJ/X/85ZsKmKw==",
-          "dev": true,
-          "requires": {
-            "buffer": "^5.5.0",
-            "multibase": "^0.7.0",
-            "varint": "^5.0.0"
           }
         },
         "p-locate": {
@@ -4419,7 +4190,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -4427,8 +4197,7 @@
     "commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
     },
     "commondir": {
       "version": "1.0.1",
@@ -4457,8 +4226,7 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "concat-stream": {
       "version": "1.6.2",
@@ -4848,59 +4616,13 @@
       "integrity": "sha1-QAKofoUMv8n52XBrYPymE6MzbpA="
     },
     "dag-cbor-links": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/dag-cbor-links/-/dag-cbor-links-1.3.6.tgz",
-      "integrity": "sha512-UeslQGj1cF5FLDLUlutDdeWKOnN3QVrqzIFOwOq4kQud+2aOxQjmlFnsU/uNdkJaz6H66RvbPGivueQB0fL5Iw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dag-cbor-links/-/dag-cbor-links-2.0.0.tgz",
+      "integrity": "sha512-ra3oaFkrl57zcZf0l5F/L9l8QTdqdO9XZLpbXsNT0EX4NPL34RDN4r6Uuk6LI1WQLFfM0prSCbAEdOWxzUJo3A==",
       "dev": true,
       "requires": {
-        "cids": "^0.8.0",
-        "ipld-dag-cbor": "^0.16.0"
-      },
-      "dependencies": {
-        "cids": {
-          "version": "0.8.3",
-          "resolved": "https://registry.npmjs.org/cids/-/cids-0.8.3.tgz",
-          "integrity": "sha512-yoXTbV3llpm+EBGWKeL9xKtksPE/s6DPoDSY4fn8I8TEW1zehWXPSB0pwAXVDlLaOlrw+sNynj995uD9abmPhA==",
-          "dev": true,
-          "requires": {
-            "buffer": "^5.6.0",
-            "class-is": "^1.1.0",
-            "multibase": "^1.0.0",
-            "multicodec": "^1.0.1",
-            "multihashes": "^1.0.1"
-          }
-        },
-        "multibase": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
-          "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
-          "dev": true,
-          "requires": {
-            "base-x": "^3.0.8",
-            "buffer": "^5.5.0"
-          }
-        },
-        "multicodec": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-1.0.4.tgz",
-          "integrity": "sha512-NDd7FeS3QamVtbgfvu5h7fd1IlbaC4EQ0/pgU4zqE2vdHCmBGsUa0TiM8/TdSeG6BMPC92OOCf8F1ocE/Wkrrg==",
-          "dev": true,
-          "requires": {
-            "buffer": "^5.6.0",
-            "varint": "^5.0.0"
-          }
-        },
-        "multihashes": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
-          "integrity": "sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==",
-          "dev": true,
-          "requires": {
-            "buffer": "^5.6.0",
-            "multibase": "^1.0.1",
-            "varint": "^5.0.0"
-          }
-        }
+        "cids": "^1.0.0",
+        "ipld-dag-cbor": "^0.17.0"
       }
     },
     "dashdash": {
@@ -4924,78 +4646,40 @@
         "ipfs-utils": "^2.3.1"
       },
       "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+        "ipfs-utils": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-2.4.0.tgz",
+          "integrity": "sha512-0RH8rMIEhrXyrbh87V8SQC6E6/5EJs+YionqZGAXnVoTzkpFhxC3x3FlsxwZ9s72yaieGP1Mx1tRYgfCFM/mJg==",
           "dev": true,
           "requires": {
-            "ms": "^2.1.1"
+            "abort-controller": "^3.0.0",
+            "any-signal": "^1.1.0",
+            "buffer": "^5.6.0",
+            "err-code": "^2.0.0",
+            "fs-extra": "^9.0.1",
+            "is-electron": "^2.2.0",
+            "iso-url": "^0.4.7",
+            "it-glob": "0.0.8",
+            "it-to-stream": "^0.1.2",
+            "merge-options": "^2.0.0",
+            "nanoid": "^3.1.3",
+            "node-fetch": "^2.6.0",
+            "stream-to-it": "^0.2.0"
           }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
         }
       }
     },
     "datastore-fs": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/datastore-fs/-/datastore-fs-1.1.0.tgz",
-      "integrity": "sha512-z/lsSMxi7omrPwCgGjZ1OrPN0cq35sFMWhTHnnF1ekvD3fxntB1gNqEi9ioMMJNX8OQap7JvYT40LdtZZx7mTg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/datastore-fs/-/datastore-fs-2.0.1.tgz",
+      "integrity": "sha512-W0qOEJDHVmzSfCXMBcgnHI7n0SROQ7vpD24v9AicVWE/DPju4CUWl/1NHSQO3RR3ooaFdG31c1J2OjDKJO6+Fg==",
       "dev": true,
       "requires": {
-        "datastore-core": "^1.1.0",
+        "datastore-core": "^2.0.0",
         "fast-write-atomic": "^0.2.0",
-        "glob": "^7.1.3",
-        "interface-datastore": "^1.0.2",
+        "interface-datastore": "^2.0.0",
+        "it-glob": "0.0.8",
         "mkdirp": "^1.0.4"
-      },
-      "dependencies": {
-        "datastore-core": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/datastore-core/-/datastore-core-1.1.0.tgz",
-          "integrity": "sha512-tn42Qy6t1V5otG4R3hq7yW4vpNaKc8/GXEYnLv8oeGNSQfEWPnfz1x5Sto080N7IsluzOUWK/W+a4m4Er8DnAA==",
-          "dev": true,
-          "requires": {
-            "buffer": "^5.5.0",
-            "debug": "^4.1.1",
-            "interface-datastore": "^1.0.2"
-          }
-        },
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "interface-datastore": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-1.0.4.tgz",
-          "integrity": "sha512-nIOP/mVwDUc7OenayUyFQB3D6c3SxDG5opTPeSrhA0jS5q0XWkf8Nz2GtNBm3wkeSKUM6iXt6LwIOCH/+jFXIQ==",
-          "dev": true,
-          "requires": {
-            "buffer": "^5.5.0",
-            "class-is": "^1.1.0",
-            "err-code": "^2.0.1",
-            "ipfs-utils": "^2.2.2",
-            "iso-random-stream": "^1.1.1",
-            "it-all": "^1.0.2",
-            "it-drain": "^1.0.1",
-            "nanoid": "^3.0.2"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        }
       }
     },
     "datastore-level": {
@@ -5010,59 +4694,15 @@
       }
     },
     "datastore-pubsub": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/datastore-pubsub/-/datastore-pubsub-0.3.3.tgz",
-      "integrity": "sha512-QMGKZpOnwMO4UK14aU1GfsiyXv77F//7jj8mjTmbdma+iVBSLW1aNq6koZtw46DM7K9LfhlfLHyvyAl4JJp7fA==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/datastore-pubsub/-/datastore-pubsub-0.4.1.tgz",
+      "integrity": "sha512-OVKIlSqILBSFApJ5FPmiWaSA71l53sX52sV0JgyGBaghzqbFTTB1HQikB8npSyGMEJfmpCVhKue9rkTHF+WoXg==",
       "dev": true,
       "requires": {
-        "buffer": "^5.6.0",
         "debug": "^4.1.1",
         "err-code": "^2.0.3",
-        "interface-datastore": "^1.0.4",
-        "multibase": "^0.7.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "interface-datastore": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-1.0.4.tgz",
-          "integrity": "sha512-nIOP/mVwDUc7OenayUyFQB3D6c3SxDG5opTPeSrhA0jS5q0XWkf8Nz2GtNBm3wkeSKUM6iXt6LwIOCH/+jFXIQ==",
-          "dev": true,
-          "requires": {
-            "buffer": "^5.5.0",
-            "class-is": "^1.1.0",
-            "err-code": "^2.0.1",
-            "ipfs-utils": "^2.2.2",
-            "iso-random-stream": "^1.1.1",
-            "it-all": "^1.0.2",
-            "it-drain": "^1.0.1",
-            "nanoid": "^3.0.2"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        },
-        "multibase": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.7.0.tgz",
-          "integrity": "sha512-TW8q03O0f6PNFTQDvh3xxH03c8CjGaaYrjkl9UQPG6rz53TQzzxJVCIWVjzcbN/Q5Y53Zd0IBQBMVktVgNx4Fg==",
-          "dev": true,
-          "requires": {
-            "base-x": "^3.0.8",
-            "buffer": "^5.5.0"
-          }
-        }
+        "interface-datastore": "^2.0.0",
+        "uint8arrays": "^1.1.0"
       }
     },
     "dateformat": {
@@ -5072,12 +4712,11 @@
       "dev": true
     },
     "debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
       "requires": {
-        "ms": "2.0.0"
+        "ms": "^2.1.1"
       }
     },
     "debug-log": {
@@ -5282,8 +4921,7 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "delegates": {
       "version": "1.0.0",
@@ -5294,8 +4932,7 @@
     "delimit-stream": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/delimit-stream/-/delimit-stream-0.1.0.tgz",
-      "integrity": "sha1-m4MZR3wOX4rrPONXrjBfwl6hzSs=",
-      "dev": true
+      "integrity": "sha1-m4MZR3wOX4rrPONXrjBfwl6hzSs="
     },
     "denque": {
       "version": "1.4.1",
@@ -5529,9 +5166,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.566",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.566.tgz",
-      "integrity": "sha512-V0fANdGN7waOE0tvCDhjf1vqPRevG3eo0asYm42c4t1qmZSunlnUuWQDxglUi9wDpbKQlGIttMJ+2DYpRwvYRA==",
+      "version": "1.3.570",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.570.tgz",
+      "integrity": "sha512-Y6OCoVQgFQBP5py6A/06+yWxUZHDlNr/gNDGatjH8AZqXl8X0tE4LfjLJsXGz/JmWJz8a6K7bR1k+QzZ+k//fg==",
       "dev": true
     },
     "elliptic": {
@@ -5611,23 +5248,6 @@
         "debug": "~4.1.0",
         "engine.io-parser": "~2.2.0",
         "ws": "^7.1.2"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        }
       }
     },
     "engine.io-client": {
@@ -5649,21 +5269,6 @@
         "yeast": "0.1.2"
       },
       "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        },
         "ws": {
           "version": "6.1.4",
           "resolved": "https://registry.npmjs.org/ws/-/ws-6.1.4.tgz",
@@ -5951,15 +5556,6 @@
             }
           }
         },
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
         "glob-parent": {
           "version": "5.1.1",
           "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
@@ -6001,12 +5597,6 @@
           "requires": {
             "minimist": "^1.2.5"
           }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
         },
         "path-key": {
           "version": "2.0.1",
@@ -6090,6 +5680,23 @@
       "requires": {
         "debug": "^2.6.9",
         "resolve": "^1.13.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
       }
     },
     "eslint-module-utils": {
@@ -6102,6 +5709,15 @@
         "pkg-dir": "^2.0.0"
       },
       "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
         "find-up": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
@@ -6120,6 +5736,12 @@
             "p-locate": "^2.0.0",
             "path-exists": "^3.0.0"
           }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
         },
         "p-limit": {
           "version": "1.3.0",
@@ -6193,6 +5815,15 @@
         "resolve": "^1.11.0"
       },
       "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
         "doctrine": {
           "version": "1.5.0",
           "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
@@ -6233,6 +5864,12 @@
             "p-locate": "^2.0.0",
             "path-exists": "^3.0.0"
           }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
         },
         "p-limit": {
           "version": "1.3.0",
@@ -6374,12 +6011,12 @@
       "dev": true
     },
     "eslint-scope": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.0.tgz",
-      "integrity": "sha512-iiGRvtxWqgtx5m8EyQUJihBloE4EnYeGE/bz1wSPwJE6tZuJUtHlhqDM4Xj2ukE8Dyy1+HCZ4hE0fzIVMzb58w==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
       "dev": true,
       "requires": {
-        "esrecurse": "^4.1.0",
+        "esrecurse": "^4.3.0",
         "estraverse": "^4.1.1"
       }
     },
@@ -6767,40 +6404,40 @@
       }
     },
     "ethers": {
-      "version": "5.0.12",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.0.12.tgz",
-      "integrity": "sha512-mgF1ZLd1y5r+hS1IPATKwKx5k/PCSqz4PEQjMR+er+Hhu6IefVVcoYATUMjmK4FG+3PAkorRMA9rJ4Y/fdW0UA==",
+      "version": "5.0.13",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.0.13.tgz",
+      "integrity": "sha512-xtSVE6r3ltLZ2EHtzA0rd1s2TQaLTC11qhSG+iYhOgno+lhyIXffBC8CzLkQEp51+GlRTn9/xCjly6JCn5qwMA==",
       "requires": {
-        "@ethersproject/abi": "^5.0.3",
-        "@ethersproject/abstract-provider": "^5.0.3",
-        "@ethersproject/abstract-signer": "^5.0.3",
-        "@ethersproject/address": "^5.0.3",
+        "@ethersproject/abi": "^5.0.5",
+        "@ethersproject/abstract-provider": "^5.0.4",
+        "@ethersproject/abstract-signer": "^5.0.4",
+        "@ethersproject/address": "^5.0.4",
         "@ethersproject/base64": "^5.0.3",
         "@ethersproject/basex": "^5.0.3",
-        "@ethersproject/bignumber": "^5.0.6",
+        "@ethersproject/bignumber": "^5.0.7",
         "@ethersproject/bytes": "^5.0.4",
-        "@ethersproject/constants": "^5.0.3",
-        "@ethersproject/contracts": "^5.0.3",
-        "@ethersproject/hash": "^5.0.3",
-        "@ethersproject/hdnode": "^5.0.3",
-        "@ethersproject/json-wallets": "^5.0.5",
+        "@ethersproject/constants": "^5.0.4",
+        "@ethersproject/contracts": "^5.0.4",
+        "@ethersproject/hash": "^5.0.4",
+        "@ethersproject/hdnode": "^5.0.4",
+        "@ethersproject/json-wallets": "^5.0.6",
         "@ethersproject/keccak256": "^5.0.3",
         "@ethersproject/logger": "^5.0.5",
         "@ethersproject/networks": "^5.0.3",
         "@ethersproject/pbkdf2": "^5.0.3",
         "@ethersproject/properties": "^5.0.3",
-        "@ethersproject/providers": "^5.0.6",
+        "@ethersproject/providers": "^5.0.8",
         "@ethersproject/random": "^5.0.3",
         "@ethersproject/rlp": "^5.0.3",
         "@ethersproject/sha2": "^5.0.3",
         "@ethersproject/signing-key": "^5.0.4",
-        "@ethersproject/solidity": "^5.0.3",
-        "@ethersproject/strings": "^5.0.3",
-        "@ethersproject/transactions": "^5.0.3",
-        "@ethersproject/units": "^5.0.3",
-        "@ethersproject/wallet": "^5.0.3",
-        "@ethersproject/web": "^5.0.4",
-        "@ethersproject/wordlists": "^5.0.3"
+        "@ethersproject/solidity": "^5.0.4",
+        "@ethersproject/strings": "^5.0.4",
+        "@ethersproject/transactions": "^5.0.5",
+        "@ethersproject/units": "^5.0.4",
+        "@ethersproject/wallet": "^5.0.4",
+        "@ethersproject/web": "^5.0.6",
+        "@ethersproject/wordlists": "^5.0.4"
       }
     },
     "ethjs-util": {
@@ -6822,8 +6459,7 @@
     "event-target-shim": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
-      "dev": true
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
     },
     "eventemitter3": {
       "version": "4.0.7",
@@ -6965,23 +6601,6 @@
         "debug": "^4.1.1",
         "get-stream": "^5.1.0",
         "yauzl": "^2.10.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        }
       }
     },
     "extsprintf": {
@@ -7055,6 +6674,15 @@
                 "is-extendable": "^0.1.0"
               }
             }
+          }
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
           }
         },
         "expand-brackets": {
@@ -7325,6 +6953,12 @@
             "snapdragon": "^0.8.1",
             "to-regex": "^3.0.2"
           }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
         }
       }
     },
@@ -7425,9 +7059,9 @@
       "optional": true
     },
     "filesize": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/filesize/-/filesize-3.6.1.tgz",
-      "integrity": "sha512-7KjR1vv6qnicaPMi1iiTcI85CyYwRO/PSFCu6SvqL8jN2Wjt/NIYQTFtFs7fSDCYOstUkEWIQGFUg5YZQfjlcg==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/filesize/-/filesize-6.1.0.tgz",
+      "integrity": "sha512-LpCHtPQ3sFx67z+uh2HnSyWSLLu5Jxo21795uRDuar/EOuYWXib5EmPaGIBuSnRqH2IODiKA2k5re/K9OnN/Yg==",
       "dev": true
     },
     "fill-range": {
@@ -7648,6 +7282,16 @@
             "which": "^1.2.9"
           }
         },
+        "lru-cache": {
+          "version": "4.1.5",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+          "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+          "dev": true,
+          "requires": {
+            "pseudomap": "^1.0.2",
+            "yallist": "^2.1.2"
+          }
+        },
         "which": {
           "version": "1.3.1",
           "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
@@ -7656,6 +7300,12 @@
           "requires": {
             "isexe": "^2.0.0"
           }
+        },
+        "yallist": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+          "dev": true
         }
       }
     },
@@ -7670,7 +7320,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
       "integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
-      "dev": true,
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -7757,7 +7406,6 @@
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.1.tgz",
       "integrity": "sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==",
-      "dev": true,
       "requires": {
         "at-least-node": "^1.0.0",
         "graceful-fs": "^4.2.0",
@@ -8816,8 +8464,7 @@
     "graceful-fs": {
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
-      "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
-      "dev": true
+      "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
     },
     "gray-matter": {
       "version": "2.1.1",
@@ -8884,15 +8531,15 @@
       }
     },
     "hapi-pino": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/hapi-pino/-/hapi-pino-6.5.0.tgz",
-      "integrity": "sha512-262F+AJpNHCCGIPpqugPtVWU2plXyCcjeXkbcrD60LRg/tcobLAHuzR6usNcKCansJbrcCy+/kBXYcKQGae7+g==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/hapi-pino/-/hapi-pino-8.3.0.tgz",
+      "integrity": "sha512-8Cm1WIs6jp8B9ZzYqPFbCWNKt6F6jNCfLmCIHmPsm35sTOvT/r5+d9KpYR2vigWQRLS23VBXzOqUVESpP7r+jA==",
       "dev": true,
       "requires": {
-        "@hapi/hoek": "^8.3.0",
-        "abstract-logging": "^1.0.0",
-        "pino": "^5.13.5",
-        "pino-pretty": "^3.2.2"
+        "@hapi/hoek": "^9.0.0",
+        "abstract-logging": "^2.0.0",
+        "pino": "^6.0.0",
+        "pino-pretty": "^4.0.0"
       }
     },
     "har-schema": {
@@ -9208,23 +8855,6 @@
       "requires": {
         "agent-base": "6",
         "debug": "4"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        }
       }
     },
     "human-signals": {
@@ -9484,6 +9114,29 @@
         "it-all": "^1.0.2",
         "it-drain": "^1.0.1",
         "nanoid": "^3.0.2"
+      },
+      "dependencies": {
+        "ipfs-utils": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-2.4.0.tgz",
+          "integrity": "sha512-0RH8rMIEhrXyrbh87V8SQC6E6/5EJs+YionqZGAXnVoTzkpFhxC3x3FlsxwZ9s72yaieGP1Mx1tRYgfCFM/mJg==",
+          "dev": true,
+          "requires": {
+            "abort-controller": "^3.0.0",
+            "any-signal": "^1.1.0",
+            "buffer": "^5.6.0",
+            "err-code": "^2.0.0",
+            "fs-extra": "^9.0.1",
+            "is-electron": "^2.2.0",
+            "iso-url": "^0.4.7",
+            "it-glob": "0.0.8",
+            "it-to-stream": "^0.1.2",
+            "merge-options": "^2.0.0",
+            "nanoid": "^3.1.3",
+            "node-fetch": "^2.6.0",
+            "stream-to-it": "^0.2.0"
+          }
+        }
       }
     },
     "interpret": {
@@ -9508,9 +9161,9 @@
       "dev": true
     },
     "ip-address": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-6.3.0.tgz",
-      "integrity": "sha512-tYN6DnF82jBRA6ZT3C+k4LBtVUKu0Taq7GZN4yldhz6nFKVh3EDg/zRIABsu4fAT2N0iFW9D482Aqkiah1NxTg==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-6.4.0.tgz",
+      "integrity": "sha512-c5uxc2WUTuRBVHT/6r4m7HIr/DfV0bF6DvLH3iZGSK8wp8iMwwZSgIq2do0asFf8q9ECug0SE+6+1ACMe4sorA==",
       "dev": true,
       "requires": {
         "jsbn": "1.1.0",
@@ -9533,34 +9186,31 @@
     "ip-regex": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.1.0.tgz",
-      "integrity": "sha512-pKnZpbgCTfH/1NLIlOduP/V+WRXzC2MOz3Qo8xmxk8C5GudJLgK5QyLVXOSWy3ParAH7Eemurl3xjv/WXYFvMA==",
-      "dev": true
+      "integrity": "sha512-pKnZpbgCTfH/1NLIlOduP/V+WRXzC2MOz3Qo8xmxk8C5GudJLgK5QyLVXOSWy3ParAH7Eemurl3xjv/WXYFvMA=="
     },
     "ipfs": {
-      "version": "0.49.1",
-      "resolved": "https://registry.npmjs.org/ipfs/-/ipfs-0.49.1.tgz",
-      "integrity": "sha512-pVTs9/IXrW/nQ4loj8uOsEOLcRvdgp9vRotw0g+ZGEUVMKgRLTvSacvY6ZBALThn6LtrZRJcFRXkpdvLCB6Utg==",
+      "version": "0.50.2",
+      "resolved": "https://registry.npmjs.org/ipfs/-/ipfs-0.50.2.tgz",
+      "integrity": "sha512-mgXab5fxyUwQpy/NNfOCplql+Em2DhyWLYjTOgIaaCrWTssejeZyRETBYZazAwIk1xNsIDX3IgOfXlzWw850bw==",
       "dev": true,
       "requires": {
-        "@hapi/ammo": "^3.1.2",
-        "@hapi/boom": "^7.4.3",
-        "@hapi/content": "^4.1.0",
-        "@hapi/hapi": "^18.4.0",
-        "@hapi/joi": "^15.1.0",
+        "@hapi/ammo": "^5.0.1",
+        "@hapi/boom": "^9.1.0",
+        "@hapi/content": "^5.0.2",
+        "@hapi/hapi": "^20.0.0",
         "abort-controller": "^3.0.0",
         "any-signal": "^1.1.0",
         "array-shuffle": "^1.0.1",
         "bignumber.js": "^9.0.0",
         "bl": "^4.0.2",
-        "bs58": "^4.0.1",
-        "buffer": "^5.6.0",
         "byteman": "^1.3.5",
-        "cid-tool": "^0.4.0",
-        "cids": "^0.8.3",
+        "cbor": "^5.0.1",
+        "cid-tool": "^1.0.0",
+        "cids": "^1.0.0",
         "class-is": "^1.1.0",
-        "dag-cbor-links": "^1.3.3",
-        "datastore-core": "^1.1.0",
-        "datastore-pubsub": "^0.3.2",
+        "dag-cbor-links": "^2.0.0",
+        "datastore-core": "^2.0.0",
+        "datastore-pubsub": "^0.4.0",
         "debug": "^4.1.0",
         "dlv": "^1.1.3",
         "err-code": "^2.0.0",
@@ -9569,86 +9219,88 @@
         "fnv1a": "^1.0.1",
         "get-folder-size": "^2.0.0",
         "hamt-sharding": "^1.0.0",
-        "hapi-pino": "^6.1.0",
+        "hapi-pino": "^8.2.0",
         "hashlru": "^2.3.0",
-        "interface-datastore": "^1.0.2",
-        "ipfs-bitswap": "^2.0.1",
-        "ipfs-block-service": "^0.17.1",
-        "ipfs-core-utils": "^0.3.2",
-        "ipfs-http-client": "^46.0.1",
-        "ipfs-http-response": "^0.5.0",
-        "ipfs-repo": "^4.0.0",
-        "ipfs-unixfs": "^1.0.3",
-        "ipfs-unixfs-exporter": "^2.0.2",
-        "ipfs-unixfs-importer": "^2.0.2",
+        "interface-datastore": "^2.0.0",
+        "ipfs-bitswap": "^3.0.0",
+        "ipfs-block-service": "^0.18.0",
+        "ipfs-core-utils": "^0.4.0",
+        "ipfs-http-client": "^47.0.1",
+        "ipfs-http-response": "^0.6.0",
+        "ipfs-repo": "^6.0.3",
+        "ipfs-unixfs": "^2.0.2",
+        "ipfs-unixfs-exporter": "^3.0.2",
+        "ipfs-unixfs-importer": "^3.0.2",
         "ipfs-utils": "^3.0.0",
-        "ipld": "^0.26.2",
-        "ipld-bitcoin": "^0.3.0",
-        "ipld-block": "^0.9.2",
-        "ipld-dag-cbor": "^0.16.0",
-        "ipld-dag-pb": "^0.19.0",
-        "ipld-ethereum": "^4.0.0",
-        "ipld-git": "^0.5.0",
-        "ipld-raw": "^5.0.0",
-        "ipld-zcash": "^0.4.0",
-        "ipns": "^0.7.1",
+        "ipld": "^0.27.1",
+        "ipld-bitcoin": "^0.4.0",
+        "ipld-block": "^0.10.0",
+        "ipld-dag-cbor": "^0.17.0",
+        "ipld-dag-pb": "^0.20.0",
+        "ipld-ethereum": "^5.0.1",
+        "ipld-git": "^0.6.1",
+        "ipld-raw": "^6.0.0",
+        "ipld-zcash": "^0.5.0",
+        "ipns": "^0.8.0",
         "is-domain-name": "^1.0.1",
-        "is-ipfs": "^1.0.3",
+        "is-ipfs": "^2.0.0",
         "iso-url": "^0.4.7",
         "it-all": "^1.0.1",
         "it-concat": "^1.0.0",
         "it-drain": "^1.0.1",
         "it-first": "^1.0.1",
         "it-glob": "0.0.8",
-        "it-last": "^1.0.1",
-        "it-map": "^1.0.0",
+        "it-last": "^1.0.2",
+        "it-map": "^1.0.2",
         "it-multipart": "^1.0.1",
         "it-pipe": "^1.1.0",
         "it-tar": "^1.2.2",
         "it-to-stream": "^0.1.1",
         "iterable-ndjson": "^1.1.0",
+        "joi": "^17.2.1",
         "jsondiffpatch": "^0.4.1",
         "just-safe-set": "^2.1.0",
-        "libp2p": "^0.28.10",
-        "libp2p-bootstrap": "^0.11.0",
-        "libp2p-crypto": "^0.17.9",
-        "libp2p-delegated-content-routing": "^0.5.0",
-        "libp2p-delegated-peer-routing": "^0.5.0",
-        "libp2p-floodsub": "^0.21.0",
-        "libp2p-gossipsub": "^0.4.0",
-        "libp2p-kad-dht": "^0.19.9",
-        "libp2p-mdns": "^0.14.1",
-        "libp2p-mplex": "^0.9.5",
-        "libp2p-noise": "^1.1.1",
-        "libp2p-record": "^0.7.3",
-        "libp2p-secio": "^0.12.6",
-        "libp2p-tcp": "^0.14.5",
-        "libp2p-webrtc-star": "^0.18.0",
-        "libp2p-websockets": "^0.13.3",
-        "mafmt": "^7.0.0",
+        "libp2p": "^0.29.0",
+        "libp2p-bootstrap": "^0.12.0",
+        "libp2p-crypto": "^0.18.0",
+        "libp2p-delegated-content-routing": "^0.7.0",
+        "libp2p-delegated-peer-routing": "^0.7.0",
+        "libp2p-floodsub": "^0.23.0",
+        "libp2p-gossipsub": "^0.6.0",
+        "libp2p-kad-dht": "^0.20.0",
+        "libp2p-mdns": "^0.15.0",
+        "libp2p-mplex": "^0.10.0",
+        "libp2p-noise": "^2.0.0",
+        "libp2p-record": "^0.9.0",
+        "libp2p-secio": "^0.13.0",
+        "libp2p-tcp": "^0.15.0",
+        "libp2p-webrtc-star": "^0.20.0",
+        "libp2p-websockets": "^0.14.0",
+        "mafmt": "^8.0.0",
         "merge-options": "^2.0.0",
         "mortice": "^2.0.0",
-        "multiaddr": "^7.4.3",
-        "multiaddr-to-uri": "^5.1.0",
-        "multibase": "^1.0.1",
-        "multicodec": "^1.0.0",
-        "multihashing-async": "^1.0.0",
+        "multiaddr": "^8.0.0",
+        "multiaddr-to-uri": "^6.0.0",
+        "multibase": "^3.0.0",
+        "multicodec": "^2.0.0",
+        "multihashing-async": "^2.0.1",
         "p-defer": "^3.0.0",
         "p-queue": "^6.1.0",
         "parse-duration": "^0.4.4",
-        "peer-id": "^0.13.12",
+        "peer-id": "^0.14.0",
         "pretty-bytes": "^5.3.0",
         "progress": "^2.0.1",
         "prom-client": "^12.0.0",
         "prometheus-gc-stats": "^0.6.0",
-        "protons": "^1.2.1",
+        "protons": "^2.0.0",
         "semver": "^7.3.2",
         "stream-to-it": "^0.2.1",
         "streaming-iterables": "^5.0.0",
         "temp": "^0.9.0",
         "timeout-abort-controller": "^1.1.0",
+        "uint8arrays": "^1.1.0",
         "update-notifier": "^4.0.0",
-        "uri-to-multiaddr": "^3.0.2",
+        "uri-to-multiaddr": "^4.0.0",
         "varint": "^5.0.0",
         "yargs": "^15.1.0",
         "yargs-promise": "^1.1.0"
@@ -9668,19 +9320,6 @@
           "requires": {
             "@types/color-name": "^1.1.1",
             "color-convert": "^2.0.1"
-          }
-        },
-        "cids": {
-          "version": "0.8.3",
-          "resolved": "https://registry.npmjs.org/cids/-/cids-0.8.3.tgz",
-          "integrity": "sha512-yoXTbV3llpm+EBGWKeL9xKtksPE/s6DPoDSY4fn8I8TEW1zehWXPSB0pwAXVDlLaOlrw+sNynj995uD9abmPhA==",
-          "dev": true,
-          "requires": {
-            "buffer": "^5.6.0",
-            "class-is": "^1.1.0",
-            "multibase": "^1.0.0",
-            "multicodec": "^1.0.1",
-            "multihashes": "^1.0.1"
           }
         },
         "cliui": {
@@ -9709,37 +9348,6 @@
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
         },
-        "datastore-core": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/datastore-core/-/datastore-core-1.1.0.tgz",
-          "integrity": "sha512-tn42Qy6t1V5otG4R3hq7yW4vpNaKc8/GXEYnLv8oeGNSQfEWPnfz1x5Sto080N7IsluzOUWK/W+a4m4Er8DnAA==",
-          "dev": true,
-          "requires": {
-            "buffer": "^5.5.0",
-            "debug": "^4.1.1",
-            "interface-datastore": "^1.0.2"
-          }
-        },
-        "datastore-level": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/datastore-level/-/datastore-level-1.1.0.tgz",
-          "integrity": "sha512-XEuXC3mq2BTUdhOvx7vwD93GN1O8SJf1HL/EOlmVcxLt3EHtDpX5pqZmiDdrXIAfe4uiEuSfFu2tKycuz1PMZA==",
-          "dev": true,
-          "requires": {
-            "datastore-core": "^1.1.0",
-            "interface-datastore": "^1.0.2",
-            "level": "^5.0.1"
-          }
-        },
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
         "emoji-regex": {
           "version": "8.0.0",
           "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -9756,132 +9364,6 @@
             "path-exists": "^4.0.0"
           }
         },
-        "interface-datastore": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-1.0.4.tgz",
-          "integrity": "sha512-nIOP/mVwDUc7OenayUyFQB3D6c3SxDG5opTPeSrhA0jS5q0XWkf8Nz2GtNBm3wkeSKUM6iXt6LwIOCH/+jFXIQ==",
-          "dev": true,
-          "requires": {
-            "buffer": "^5.5.0",
-            "class-is": "^1.1.0",
-            "err-code": "^2.0.1",
-            "ipfs-utils": "^2.2.2",
-            "iso-random-stream": "^1.1.1",
-            "it-all": "^1.0.2",
-            "it-drain": "^1.0.1",
-            "nanoid": "^3.0.2"
-          },
-          "dependencies": {
-            "ipfs-utils": {
-              "version": "2.4.0",
-              "resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-2.4.0.tgz",
-              "integrity": "sha512-0RH8rMIEhrXyrbh87V8SQC6E6/5EJs+YionqZGAXnVoTzkpFhxC3x3FlsxwZ9s72yaieGP1Mx1tRYgfCFM/mJg==",
-              "dev": true,
-              "requires": {
-                "abort-controller": "^3.0.0",
-                "any-signal": "^1.1.0",
-                "buffer": "^5.6.0",
-                "err-code": "^2.0.0",
-                "fs-extra": "^9.0.1",
-                "is-electron": "^2.2.0",
-                "iso-url": "^0.4.7",
-                "it-glob": "0.0.8",
-                "it-to-stream": "^0.1.2",
-                "merge-options": "^2.0.0",
-                "nanoid": "^3.1.3",
-                "node-fetch": "^2.6.0",
-                "stream-to-it": "^0.2.0"
-              }
-            }
-          }
-        },
-        "ipfs-repo": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/ipfs-repo/-/ipfs-repo-4.0.0.tgz",
-          "integrity": "sha512-rhmRjO3ekS4/RzgNB1EQOudKCCYK23Lb2/E6eD3So5r0bX1PvDdybbzfpDj05HBoNmvDy9pYDJzdtdH7a4gP3w==",
-          "dev": true,
-          "requires": {
-            "bignumber.js": "^9.0.0",
-            "buffer": "^5.6.0",
-            "bytes": "^3.1.0",
-            "cids": "^0.8.0",
-            "datastore-core": "^1.1.0",
-            "datastore-fs": "^1.1.0",
-            "datastore-level": "^1.1.0",
-            "debug": "^4.1.0",
-            "err-code": "^2.0.0",
-            "interface-datastore": "^1.0.2",
-            "ipfs-repo-migrations": "^1.0.0",
-            "ipfs-utils": "^2.2.0",
-            "ipld-block": "^0.9.1",
-            "it-map": "^1.0.2",
-            "it-pushable": "^1.4.0",
-            "just-safe-get": "^2.0.0",
-            "just-safe-set": "^2.1.0",
-            "multibase": "^1.0.1",
-            "p-queue": "^6.0.0",
-            "proper-lockfile": "^4.0.0",
-            "sort-keys": "^4.0.0"
-          },
-          "dependencies": {
-            "ipfs-utils": {
-              "version": "2.4.0",
-              "resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-2.4.0.tgz",
-              "integrity": "sha512-0RH8rMIEhrXyrbh87V8SQC6E6/5EJs+YionqZGAXnVoTzkpFhxC3x3FlsxwZ9s72yaieGP1Mx1tRYgfCFM/mJg==",
-              "dev": true,
-              "requires": {
-                "abort-controller": "^3.0.0",
-                "any-signal": "^1.1.0",
-                "buffer": "^5.6.0",
-                "err-code": "^2.0.0",
-                "fs-extra": "^9.0.1",
-                "is-electron": "^2.2.0",
-                "iso-url": "^0.4.7",
-                "it-glob": "0.0.8",
-                "it-to-stream": "^0.1.2",
-                "merge-options": "^2.0.0",
-                "nanoid": "^3.1.3",
-                "node-fetch": "^2.6.0",
-                "stream-to-it": "^0.2.0"
-              }
-            }
-          }
-        },
-        "ipfs-utils": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-3.0.0.tgz",
-          "integrity": "sha512-qahDc+fghrM57sbySr2TeWjaVR/RH/YEB/hvdAjiTbjESeD87qZawrXwj+19Q2LtGmFGusKNLo5wExeuI5ZfDQ==",
-          "dev": true,
-          "requires": {
-            "abort-controller": "^3.0.0",
-            "any-signal": "^1.1.0",
-            "buffer": "^5.6.0",
-            "err-code": "^2.0.0",
-            "fs-extra": "^9.0.1",
-            "is-electron": "^2.2.0",
-            "iso-url": "^0.4.7",
-            "it-glob": "0.0.8",
-            "merge-options": "^2.0.0",
-            "nanoid": "^3.1.3",
-            "node-fetch": "^2.6.0",
-            "stream-to-it": "^0.2.0"
-          }
-        },
-        "ipld-dag-pb": {
-          "version": "0.19.0",
-          "resolved": "https://registry.npmjs.org/ipld-dag-pb/-/ipld-dag-pb-0.19.0.tgz",
-          "integrity": "sha512-qwuJM2Ev74HLKxgfmH7Qw/ob/Iwo4Te6ADZas8OqV2FCY+I4H+KJujLvaBs+By2g3h0aagv0ei3aUgqE8XzDfw==",
-          "dev": true,
-          "requires": {
-            "buffer": "^5.6.0",
-            "cids": "~0.8.3",
-            "class-is": "^1.1.0",
-            "multicodec": "^1.0.3",
-            "multihashing-async": "^1.0.0",
-            "protons": "^1.2.1",
-            "stable": "^0.1.8"
-          }
-        },
         "is-fullwidth-code-point": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -9889,41 +9371,24 @@
           "dev": true
         },
         "libp2p-crypto": {
-          "version": "0.17.9",
-          "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.17.9.tgz",
-          "integrity": "sha512-nH3vTfQ4UqhZ1SORTP7HOsmFdJBs604Qy0Xi3IFFtU6ofYt+rFAZ2QNgo4MH1ZTT38/LEM374N9K7yzj1IQm0g==",
+          "version": "0.18.0",
+          "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.18.0.tgz",
+          "integrity": "sha512-zNMHDwf2J4t1LRjrBPMiSa4+14u0SfZRu66FyIVZtOnBGo3V/8imbJsOp8RPT8IgeHRN7EVIUt9lp8dcgXHMOw==",
           "dev": true,
           "requires": {
-            "buffer": "^5.5.0",
             "err-code": "^2.0.0",
             "is-typedarray": "^1.0.0",
             "iso-random-stream": "^1.1.0",
             "keypair": "^1.0.1",
-            "multibase": "^1.0.1",
-            "multicodec": "^1.0.4",
-            "multihashing-async": "^0.8.1",
+            "multibase": "^3.0.0",
+            "multicodec": "^2.0.0",
+            "multihashing-async": "^2.0.1",
             "node-forge": "^0.9.1",
             "pem-jwk": "^2.0.0",
-            "protons": "^1.2.1",
+            "protons": "^2.0.0",
             "secp256k1": "^4.0.0",
-            "uint8arrays": "^1.0.0",
+            "uint8arrays": "^1.1.0",
             "ursa-optional": "^0.10.1"
-          },
-          "dependencies": {
-            "multihashing-async": {
-              "version": "0.8.2",
-              "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.8.2.tgz",
-              "integrity": "sha512-2lKa1autuCy8x7KIEj9aVNbAb3aIMRFYIwN7mq/zD4pxgNIVgGlm+f6GKY4880EOF2Y3GktHYssRy7TAJQ2DyQ==",
-              "dev": true,
-              "requires": {
-                "blakejs": "^1.1.0",
-                "buffer": "^5.4.3",
-                "err-code": "^2.0.0",
-                "js-sha3": "^0.8.0",
-                "multihashes": "^1.0.1",
-                "murmurhash3js-revisited": "^3.0.0"
-              }
-            }
           }
         },
         "locate-path": {
@@ -9933,57 +9398,6 @@
           "dev": true,
           "requires": {
             "p-locate": "^4.1.0"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        },
-        "multibase": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
-          "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
-          "dev": true,
-          "requires": {
-            "base-x": "^3.0.8",
-            "buffer": "^5.5.0"
-          }
-        },
-        "multicodec": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-1.0.4.tgz",
-          "integrity": "sha512-NDd7FeS3QamVtbgfvu5h7fd1IlbaC4EQ0/pgU4zqE2vdHCmBGsUa0TiM8/TdSeG6BMPC92OOCf8F1ocE/Wkrrg==",
-          "dev": true,
-          "requires": {
-            "buffer": "^5.6.0",
-            "varint": "^5.0.0"
-          }
-        },
-        "multihashes": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
-          "integrity": "sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==",
-          "dev": true,
-          "requires": {
-            "buffer": "^5.6.0",
-            "multibase": "^1.0.1",
-            "varint": "^5.0.0"
-          }
-        },
-        "multihashing-async": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-1.0.0.tgz",
-          "integrity": "sha512-gRtHjJuULvo2dd9ybIsF+aUEamraAwet/ib3YapWdaP7QWkI8JtN/6EZBhdoqlzSVU7POrC3/rp13Or7zY7x1A==",
-          "dev": true,
-          "requires": {
-            "blakejs": "^1.1.0",
-            "buffer": "^5.4.3",
-            "err-code": "^2.0.0",
-            "js-sha3": "^0.8.0",
-            "multihashes": "^1.0.1",
-            "murmurhash3js-revisited": "^3.0.0"
           }
         },
         "node-gyp-build": {
@@ -10077,513 +9491,140 @@
       }
     },
     "ipfs-bitswap": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/ipfs-bitswap/-/ipfs-bitswap-2.0.1.tgz",
-      "integrity": "sha512-kZauF0XwatrMe0SfdKs4abrarcVNRzdfWFaz+kodGl1Uq7aryf/DZmSutw3NFkJDVnYWAQ7l55VsDRxC4kD6dg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ipfs-bitswap/-/ipfs-bitswap-3.0.0.tgz",
+      "integrity": "sha512-9rX9vMUEegk61O4OoUWBUcU/WLLwALhyzHQdJzqW1DCn+nNnZVbRrzIWY1v5PnlywMtcUvd/ennpegVKCPuiUA==",
       "dev": true,
       "requires": {
         "abort-controller": "^3.0.0",
         "any-signal": "^1.1.0",
         "bignumber.js": "^9.0.0",
-        "cids": "^0.8.3",
+        "cids": "^1.0.0",
         "debug": "^4.1.0",
-        "ipld-block": "^0.9.1",
+        "ipld-block": "^0.10.0",
         "it-length-prefixed": "^3.0.0",
         "it-pipe": "^1.1.0",
         "just-debounce-it": "^1.1.0",
-        "libp2p-interfaces": "^0.3.0",
+        "libp2p-interfaces": "^0.4.1",
         "moving-average": "^1.0.0",
-        "multicodec": "^1.0.3",
-        "multihashing-async": "^1.0.0",
-        "protons": "^1.0.1",
+        "multicodec": "^2.0.0",
+        "multihashing-async": "^2.0.1",
+        "protons": "^2.0.0",
         "streaming-iterables": "^5.0.2",
-        "varint-decoder": "^0.4.0"
-      },
-      "dependencies": {
-        "cids": {
-          "version": "0.8.3",
-          "resolved": "https://registry.npmjs.org/cids/-/cids-0.8.3.tgz",
-          "integrity": "sha512-yoXTbV3llpm+EBGWKeL9xKtksPE/s6DPoDSY4fn8I8TEW1zehWXPSB0pwAXVDlLaOlrw+sNynj995uD9abmPhA==",
-          "dev": true,
-          "requires": {
-            "buffer": "^5.6.0",
-            "class-is": "^1.1.0",
-            "multibase": "^1.0.0",
-            "multicodec": "^1.0.1",
-            "multihashes": "^1.0.1"
-          }
-        },
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        },
-        "multibase": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
-          "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
-          "dev": true,
-          "requires": {
-            "base-x": "^3.0.8",
-            "buffer": "^5.5.0"
-          }
-        },
-        "multicodec": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-1.0.4.tgz",
-          "integrity": "sha512-NDd7FeS3QamVtbgfvu5h7fd1IlbaC4EQ0/pgU4zqE2vdHCmBGsUa0TiM8/TdSeG6BMPC92OOCf8F1ocE/Wkrrg==",
-          "dev": true,
-          "requires": {
-            "buffer": "^5.6.0",
-            "varint": "^5.0.0"
-          }
-        },
-        "multihashes": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
-          "integrity": "sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==",
-          "dev": true,
-          "requires": {
-            "buffer": "^5.6.0",
-            "multibase": "^1.0.1",
-            "varint": "^5.0.0"
-          }
-        },
-        "multihashing-async": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-1.0.0.tgz",
-          "integrity": "sha512-gRtHjJuULvo2dd9ybIsF+aUEamraAwet/ib3YapWdaP7QWkI8JtN/6EZBhdoqlzSVU7POrC3/rp13Or7zY7x1A==",
-          "dev": true,
-          "requires": {
-            "blakejs": "^1.1.0",
-            "buffer": "^5.4.3",
-            "err-code": "^2.0.0",
-            "js-sha3": "^0.8.0",
-            "multihashes": "^1.0.1",
-            "murmurhash3js-revisited": "^3.0.0"
-          }
-        }
+        "uint8arrays": "^1.1.0",
+        "varint-decoder": "^1.0.0"
       }
     },
     "ipfs-block-service": {
-      "version": "0.17.1",
-      "resolved": "https://registry.npmjs.org/ipfs-block-service/-/ipfs-block-service-0.17.1.tgz",
-      "integrity": "sha512-I12f6nXCJfkv9IoxZTRbHcIAa/bptSGAMDawAm2GUqD8lNPs3w2KuLpxBX6doZomhJ07C5VtaiW0pmWY5L52WA==",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/ipfs-block-service/-/ipfs-block-service-0.18.0.tgz",
+      "integrity": "sha512-tye5Uxbf3bYlfcGkV3CspP2JNcM2Ggm/5Kxph0jGKtAZtgfFxUq3NeSmvS6nGtZZBaFP4nwRF2yq7dQMALWzVg==",
       "dev": true,
       "requires": {
         "err-code": "^2.0.0",
-        "streaming-iterables": "^4.1.0"
-      },
-      "dependencies": {
-        "streaming-iterables": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/streaming-iterables/-/streaming-iterables-4.1.2.tgz",
-          "integrity": "sha512-IzhmKnQ2thkNMUcaGsjedrxdAoXPhtIFn8hUlmSqSqafa2p0QmZudu6ImG7ckvPNfazpMfr6Ef8cxUWyIyxpxA==",
-          "dev": true
-        }
+        "streaming-iterables": "^5.0.2"
       }
     },
     "ipfs-core-utils": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/ipfs-core-utils/-/ipfs-core-utils-0.3.2.tgz",
-      "integrity": "sha512-4kn6qbhYsyn48HeH7qAKPG07CxwEr1EsgRccGQOUy/5OjcfqIjw4HnBwYmsRU6QuWsNR7nOAhwrVc6Y3glVvnQ==",
-      "dev": true,
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/ipfs-core-utils/-/ipfs-core-utils-0.4.0.tgz",
+      "integrity": "sha512-IBPFvYjWPfVFpCeYUL/0gCUOabdBhh7aO5i4tU//UlF2gVCXPH4PRYlbBH9WM83zE2+o4vDi+dBXsdAI6nLPAg==",
       "requires": {
-        "blob-to-it": "0.0.1",
-        "browser-readablestream-to-it": "0.0.1",
-        "buffer": "^5.6.0",
-        "cids": "^0.8.3",
+        "blob-to-it": "0.0.2",
+        "browser-readablestream-to-it": "0.0.2",
+        "cids": "^1.0.0",
         "err-code": "^2.0.0",
         "ipfs-utils": "^3.0.0",
         "it-all": "^1.0.1",
-        "it-map": "^1.0.0",
-        "it-peekable": "0.0.1"
-      },
-      "dependencies": {
-        "cids": {
-          "version": "0.8.3",
-          "resolved": "https://registry.npmjs.org/cids/-/cids-0.8.3.tgz",
-          "integrity": "sha512-yoXTbV3llpm+EBGWKeL9xKtksPE/s6DPoDSY4fn8I8TEW1zehWXPSB0pwAXVDlLaOlrw+sNynj995uD9abmPhA==",
-          "dev": true,
-          "requires": {
-            "buffer": "^5.6.0",
-            "class-is": "^1.1.0",
-            "multibase": "^1.0.0",
-            "multicodec": "^1.0.1",
-            "multihashes": "^1.0.1"
-          }
-        },
-        "ipfs-utils": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-3.0.0.tgz",
-          "integrity": "sha512-qahDc+fghrM57sbySr2TeWjaVR/RH/YEB/hvdAjiTbjESeD87qZawrXwj+19Q2LtGmFGusKNLo5wExeuI5ZfDQ==",
-          "dev": true,
-          "requires": {
-            "abort-controller": "^3.0.0",
-            "any-signal": "^1.1.0",
-            "buffer": "^5.6.0",
-            "err-code": "^2.0.0",
-            "fs-extra": "^9.0.1",
-            "is-electron": "^2.2.0",
-            "iso-url": "^0.4.7",
-            "it-glob": "0.0.8",
-            "merge-options": "^2.0.0",
-            "nanoid": "^3.1.3",
-            "node-fetch": "^2.6.0",
-            "stream-to-it": "^0.2.0"
-          }
-        },
-        "multibase": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
-          "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
-          "dev": true,
-          "requires": {
-            "base-x": "^3.0.8",
-            "buffer": "^5.5.0"
-          }
-        },
-        "multicodec": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-1.0.4.tgz",
-          "integrity": "sha512-NDd7FeS3QamVtbgfvu5h7fd1IlbaC4EQ0/pgU4zqE2vdHCmBGsUa0TiM8/TdSeG6BMPC92OOCf8F1ocE/Wkrrg==",
-          "dev": true,
-          "requires": {
-            "buffer": "^5.6.0",
-            "varint": "^5.0.0"
-          }
-        },
-        "multihashes": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
-          "integrity": "sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==",
-          "dev": true,
-          "requires": {
-            "buffer": "^5.6.0",
-            "multibase": "^1.0.1",
-            "varint": "^5.0.0"
-          }
-        }
+        "it-map": "^1.0.2",
+        "it-peekable": "0.0.1",
+        "uint8arrays": "^1.1.0"
       }
     },
     "ipfs-http-client": {
-      "version": "46.0.1",
-      "resolved": "https://registry.npmjs.org/ipfs-http-client/-/ipfs-http-client-46.0.1.tgz",
-      "integrity": "sha512-/AK3lpeoxzyagmuAix1BNmDH/R5PpB+VdFtjV6mC57XE6/OoYl5FCmgxOtz/gusfnTLLjm87i9I5+4IbuzVhFg==",
-      "dev": true,
+      "version": "47.0.1",
+      "resolved": "https://registry.npmjs.org/ipfs-http-client/-/ipfs-http-client-47.0.1.tgz",
+      "integrity": "sha512-IAQf+uTLvXw5QFOzbyhu/5lH3rn7jEwwwdCGaNKVhoPI7yfyOV0wRse3hVWejjP1Id0P9mKuMKG8rhcY7pVAdQ==",
       "requires": {
         "abort-controller": "^3.0.0",
         "any-signal": "^1.1.0",
         "bignumber.js": "^9.0.0",
-        "buffer": "^5.6.0",
-        "cids": "^0.8.3",
+        "cids": "^1.0.0",
         "debug": "^4.1.0",
         "form-data": "^3.0.0",
-        "ipfs-core-utils": "^0.3.2",
+        "ipfs-core-utils": "^0.4.0",
         "ipfs-utils": "^3.0.0",
-        "ipld-block": "^0.9.2",
-        "ipld-dag-cbor": "^0.16.0",
-        "ipld-dag-pb": "^0.19.0",
-        "ipld-raw": "^5.0.0",
+        "ipld-block": "^0.10.0",
+        "ipld-dag-cbor": "^0.17.0",
+        "ipld-dag-pb": "^0.20.0",
+        "ipld-raw": "^6.0.0",
         "iso-url": "^0.4.7",
-        "it-last": "^1.0.1",
+        "it-last": "^1.0.2",
+        "it-map": "^1.0.2",
         "it-tar": "^1.2.2",
         "it-to-buffer": "^1.0.0",
         "it-to-stream": "^0.1.1",
         "merge-options": "^2.0.0",
-        "multiaddr": "^7.4.3",
-        "multiaddr-to-uri": "^5.1.0",
-        "multibase": "^1.0.1",
-        "multicodec": "^1.0.0",
-        "multihashes": "^1.0.1",
+        "multiaddr": "^8.0.0",
+        "multiaddr-to-uri": "^6.0.0",
+        "multibase": "^3.0.0",
+        "multicodec": "^2.0.0",
+        "multihashes": "^3.0.1",
         "nanoid": "^3.0.2",
         "node-fetch": "^2.6.0",
         "parse-duration": "^0.4.4",
-        "stream-to-it": "^0.2.1"
-      },
-      "dependencies": {
-        "cids": {
-          "version": "0.8.3",
-          "resolved": "https://registry.npmjs.org/cids/-/cids-0.8.3.tgz",
-          "integrity": "sha512-yoXTbV3llpm+EBGWKeL9xKtksPE/s6DPoDSY4fn8I8TEW1zehWXPSB0pwAXVDlLaOlrw+sNynj995uD9abmPhA==",
-          "dev": true,
-          "requires": {
-            "buffer": "^5.6.0",
-            "class-is": "^1.1.0",
-            "multibase": "^1.0.0",
-            "multicodec": "^1.0.1",
-            "multihashes": "^1.0.1"
-          }
-        },
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ipfs-utils": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-3.0.0.tgz",
-          "integrity": "sha512-qahDc+fghrM57sbySr2TeWjaVR/RH/YEB/hvdAjiTbjESeD87qZawrXwj+19Q2LtGmFGusKNLo5wExeuI5ZfDQ==",
-          "dev": true,
-          "requires": {
-            "abort-controller": "^3.0.0",
-            "any-signal": "^1.1.0",
-            "buffer": "^5.6.0",
-            "err-code": "^2.0.0",
-            "fs-extra": "^9.0.1",
-            "is-electron": "^2.2.0",
-            "iso-url": "^0.4.7",
-            "it-glob": "0.0.8",
-            "merge-options": "^2.0.0",
-            "nanoid": "^3.1.3",
-            "node-fetch": "^2.6.0",
-            "stream-to-it": "^0.2.0"
-          }
-        },
-        "ipld-dag-pb": {
-          "version": "0.19.0",
-          "resolved": "https://registry.npmjs.org/ipld-dag-pb/-/ipld-dag-pb-0.19.0.tgz",
-          "integrity": "sha512-qwuJM2Ev74HLKxgfmH7Qw/ob/Iwo4Te6ADZas8OqV2FCY+I4H+KJujLvaBs+By2g3h0aagv0ei3aUgqE8XzDfw==",
-          "dev": true,
-          "requires": {
-            "buffer": "^5.6.0",
-            "cids": "~0.8.3",
-            "class-is": "^1.1.0",
-            "multicodec": "^1.0.3",
-            "multihashing-async": "^1.0.0",
-            "protons": "^1.2.1",
-            "stable": "^0.1.8"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        },
-        "multibase": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
-          "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
-          "dev": true,
-          "requires": {
-            "base-x": "^3.0.8",
-            "buffer": "^5.5.0"
-          }
-        },
-        "multicodec": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-1.0.4.tgz",
-          "integrity": "sha512-NDd7FeS3QamVtbgfvu5h7fd1IlbaC4EQ0/pgU4zqE2vdHCmBGsUa0TiM8/TdSeG6BMPC92OOCf8F1ocE/Wkrrg==",
-          "dev": true,
-          "requires": {
-            "buffer": "^5.6.0",
-            "varint": "^5.0.0"
-          }
-        },
-        "multihashes": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
-          "integrity": "sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==",
-          "dev": true,
-          "requires": {
-            "buffer": "^5.6.0",
-            "multibase": "^1.0.1",
-            "varint": "^5.0.0"
-          }
-        },
-        "multihashing-async": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-1.0.0.tgz",
-          "integrity": "sha512-gRtHjJuULvo2dd9ybIsF+aUEamraAwet/ib3YapWdaP7QWkI8JtN/6EZBhdoqlzSVU7POrC3/rp13Or7zY7x1A==",
-          "dev": true,
-          "requires": {
-            "blakejs": "^1.1.0",
-            "buffer": "^5.4.3",
-            "err-code": "^2.0.0",
-            "js-sha3": "^0.8.0",
-            "multihashes": "^1.0.1",
-            "murmurhash3js-revisited": "^3.0.0"
-          }
-        }
+        "stream-to-it": "^0.2.1",
+        "uint8arrays": "^1.1.0"
       }
     },
     "ipfs-http-response": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/ipfs-http-response/-/ipfs-http-response-0.5.1.tgz",
-      "integrity": "sha512-Mu7LWkCCE2C8H0he2jJKY7KtmmjuSaft+wSzAZedT1WRvsgv/05JI4XXlGc2Z37eB9q0nQPFKIE83I7gJRNEaw==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/ipfs-http-response/-/ipfs-http-response-0.6.0.tgz",
+      "integrity": "sha512-x1x4ZGvR0azgasT2ql6qKjiH+aPVjra9rJbNq89KzQVxrQLf9zlEHfLzfL7p8m0iYY4MiD+fW+QZF8xA18Xh2g==",
       "dev": true,
       "requires": {
-        "cids": "~0.8.1",
         "debug": "^4.1.1",
-        "file-type": "^8.0.0",
-        "filesize": "^3.6.1",
+        "file-type": "^14.7.1",
+        "filesize": "^6.1.0",
         "it-buffer": "^0.1.1",
         "it-concat": "^1.0.0",
         "it-reader": "^2.1.0",
         "it-to-stream": "^0.1.1",
         "mime-types": "^2.1.27",
-        "multihashes": "~0.4.19",
+        "multihashes": "^3.0.1",
         "p-try-each": "^1.0.1"
-      },
-      "dependencies": {
-        "cids": {
-          "version": "0.8.3",
-          "resolved": "https://registry.npmjs.org/cids/-/cids-0.8.3.tgz",
-          "integrity": "sha512-yoXTbV3llpm+EBGWKeL9xKtksPE/s6DPoDSY4fn8I8TEW1zehWXPSB0pwAXVDlLaOlrw+sNynj995uD9abmPhA==",
-          "dev": true,
-          "requires": {
-            "buffer": "^5.6.0",
-            "class-is": "^1.1.0",
-            "multibase": "^1.0.0",
-            "multicodec": "^1.0.1",
-            "multihashes": "^1.0.1"
-          },
-          "dependencies": {
-            "multihashes": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
-              "integrity": "sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==",
-              "dev": true,
-              "requires": {
-                "buffer": "^5.6.0",
-                "multibase": "^1.0.1",
-                "varint": "^5.0.0"
-              }
-            }
-          }
-        },
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "file-type": {
-          "version": "8.1.0",
-          "resolved": "https://registry.npmjs.org/file-type/-/file-type-8.1.0.tgz",
-          "integrity": "sha512-qyQ0pzAy78gVoJsmYeNgl8uH8yKhr1lVhW7JbzJmnlRi0I4R2eEDEJZVKG8agpDnLpacwNbDhLNG/LMdxHD2YQ==",
-          "dev": true
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        },
-        "multibase": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
-          "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
-          "dev": true,
-          "requires": {
-            "base-x": "^3.0.8",
-            "buffer": "^5.5.0"
-          }
-        },
-        "multicodec": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-1.0.4.tgz",
-          "integrity": "sha512-NDd7FeS3QamVtbgfvu5h7fd1IlbaC4EQ0/pgU4zqE2vdHCmBGsUa0TiM8/TdSeG6BMPC92OOCf8F1ocE/Wkrrg==",
-          "dev": true,
-          "requires": {
-            "buffer": "^5.6.0",
-            "varint": "^5.0.0"
-          }
-        },
-        "multihashes": {
-          "version": "0.4.21",
-          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-0.4.21.tgz",
-          "integrity": "sha512-uVSvmeCWf36pU2nB4/1kzYZjsXD9vofZKpgudqkceYY5g2aZZXJ5r9lxuzoRLl1OAp28XljXsEJ/X/85ZsKmKw==",
-          "dev": true,
-          "requires": {
-            "buffer": "^5.5.0",
-            "multibase": "^0.7.0",
-            "varint": "^5.0.0"
-          },
-          "dependencies": {
-            "multibase": {
-              "version": "0.7.0",
-              "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.7.0.tgz",
-              "integrity": "sha512-TW8q03O0f6PNFTQDvh3xxH03c8CjGaaYrjkl9UQPG6rz53TQzzxJVCIWVjzcbN/Q5Y53Zd0IBQBMVktVgNx4Fg==",
-              "dev": true,
-              "requires": {
-                "base-x": "^3.0.8",
-                "buffer": "^5.5.0"
-              }
-            }
-          }
-        }
       }
     },
     "ipfs-log": {
-      "version": "4.6.5",
-      "resolved": "https://registry.npmjs.org/ipfs-log/-/ipfs-log-4.6.5.tgz",
-      "integrity": "sha512-FJN5yd1LCbVvG3+fVkqfB42TOMtvbTqSYvkd4LWj4tFtF16uh2T76LkRJud6CXJChPynRqS6zsjAvLNAZKwp6g==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ipfs-log/-/ipfs-log-5.0.0.tgz",
+      "integrity": "sha512-I8ow4Y42fODdQAX0vtc4xWO5daNTzAQzrWWGd1p6tIdr/OI0IFpC3ifpEWPW3qgWXPg30E9TXYmtxRp0fkOSbA==",
       "requires": {
+        "ipfs-http-client": "^47.0.1",
         "json-stringify-deterministic": "^1.0.1",
         "multihashing-async": "^2.0.1",
         "orbit-db-identity-provider": "~0.3.1",
-        "orbit-db-io": "~0.2.0",
+        "orbit-db-io": "~0.3.0",
         "p-do-whilst": "^1.1.0",
         "p-each-series": "^2.1.0",
         "p-map": "^4.0.0",
         "p-whilst": "^2.1.0"
-      },
-      "dependencies": {
-        "multihashing-async": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-2.0.1.tgz",
-          "integrity": "sha512-LZcH8PqW4iEKymaJ3RpsgpSJhXF29kAvO02ccqbysiXkQhZpVce8rrg+vzRKWO89hhyIBnQHI2e/ZoRVxmiJ2Q==",
-          "requires": {
-            "blakejs": "^1.1.0",
-            "err-code": "^2.0.0",
-            "js-sha3": "^0.8.0",
-            "multihashes": "^3.0.1",
-            "murmurhash3js-revisited": "^3.0.0",
-            "uint8arrays": "^1.0.0"
-          }
-        }
       }
     },
     "ipfs-pubsub-1on1": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/ipfs-pubsub-1on1/-/ipfs-pubsub-1on1-0.0.6.tgz",
-      "integrity": "sha512-Sr44DX7mdhk6znR1+DlfUIB1qiu07T5SeOMJ9Okr62U+9MGl4YQaP8vOGrmLysIEKBryZQrku2vjfNj0nxBd1g==",
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/ipfs-pubsub-1on1/-/ipfs-pubsub-1on1-0.0.7.tgz",
+      "integrity": "sha512-j+3XefZ3xF7LlUo0cBm71aBEhVIvpwqNrtxhitkSWMkMwHUB6PfV8VSJuqUJ5lKg0t/Jo4IMDO5fdDInpUkU/Q==",
       "requires": {
-        "safe-buffer": "~5.1.2"
-      },
-      "dependencies": {
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-        }
+        "safe-buffer": "~5.2.1"
       }
     },
     "ipfs-pubsub-peer-monitor": {
-      "version": "0.0.9",
-      "resolved": "https://registry.npmjs.org/ipfs-pubsub-peer-monitor/-/ipfs-pubsub-peer-monitor-0.0.9.tgz",
-      "integrity": "sha512-EJpfNzM9HnS95qnoi0WajNT3i8AoLIkItSdQabNfopuiL/8Ky81MRy17S1wCIRrZEq2EpogG2DfZMJdvcp2I8g==",
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/ipfs-pubsub-peer-monitor/-/ipfs-pubsub-peer-monitor-0.0.10.tgz",
+      "integrity": "sha512-9bwI02MRruP0BDR8Mn4ujboLJhJ+6nm8X6JdGHdM9P1zlfy1MSJQNOXGhk2e1FInEZvFseFLYiCFuSS1BL7BnA==",
       "requires": {
-        "p-forever": "^1.0.1"
+        "p-forever": "^2.1.0"
       }
     },
     "ipfs-repo": {
@@ -10615,325 +9656,103 @@
         "uint8arrays": "^1.0.0"
       },
       "dependencies": {
-        "datastore-fs": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/datastore-fs/-/datastore-fs-2.0.1.tgz",
-          "integrity": "sha512-W0qOEJDHVmzSfCXMBcgnHI7n0SROQ7vpD24v9AicVWE/DPju4CUWl/1NHSQO3RR3ooaFdG31c1J2OjDKJO6+Fg==",
+        "ipfs-utils": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-2.4.0.tgz",
+          "integrity": "sha512-0RH8rMIEhrXyrbh87V8SQC6E6/5EJs+YionqZGAXnVoTzkpFhxC3x3FlsxwZ9s72yaieGP1Mx1tRYgfCFM/mJg==",
           "dev": true,
           "requires": {
-            "datastore-core": "^2.0.0",
-            "fast-write-atomic": "^0.2.0",
-            "interface-datastore": "^2.0.0",
-            "it-glob": "0.0.8",
-            "mkdirp": "^1.0.4"
-          }
-        },
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ipfs-repo-migrations": {
-          "version": "5.0.5",
-          "resolved": "https://registry.npmjs.org/ipfs-repo-migrations/-/ipfs-repo-migrations-5.0.5.tgz",
-          "integrity": "sha512-dbg9LY+f1MhKLCUTQ28z+TmS7+fC6dgZPJhsWpNXSSwicEgMjUssGMoaft9AjoOuOTISeF3WWVVKRqFpOvCxQg==",
-          "dev": true,
-          "requires": {
-            "cbor": "^5.0.2",
-            "cids": "^1.0.0",
-            "datastore-core": "^2.0.0",
-            "debug": "^4.1.0",
-            "fnv1a": "^1.0.1",
-            "interface-datastore": "^2.0.0",
-            "ipld-dag-pb": "^0.20.0",
-            "it-length": "0.0.2",
-            "multibase": "^3.0.0",
-            "multicodec": "^2.0.0",
-            "multihashing-async": "^2.0.0",
-            "proper-lockfile": "^4.1.1",
-            "protons": "^2.0.0",
-            "uint8arrays": "^1.0.0",
-            "varint": "^5.0.0"
-          }
-        },
-        "ipld-block": {
-          "version": "0.10.1",
-          "resolved": "https://registry.npmjs.org/ipld-block/-/ipld-block-0.10.1.tgz",
-          "integrity": "sha512-lPMfW9tA2hVZw9hdO/YSppTxFmA0+5zxcefBOlCTOn+12RLyy+pdepKMbQw8u0KESFu3pYVmabNRWuFGcgHLLw==",
-          "dev": true,
-          "requires": {
-            "cids": "^1.0.0",
-            "class-is": "^1.1.0"
-          }
-        },
-        "ipld-dag-pb": {
-          "version": "0.20.0",
-          "resolved": "https://registry.npmjs.org/ipld-dag-pb/-/ipld-dag-pb-0.20.0.tgz",
-          "integrity": "sha512-zfM0EdaolqNjAxIrtpuGKvXxWk5YtH9jKinBuQGTcngOsWFQhyybGCTJHGNGGtRjHNJi2hz5Udy/8pzv4kcKyg==",
-          "dev": true,
-          "requires": {
-            "cids": "^1.0.0",
-            "class-is": "^1.1.0",
-            "multicodec": "^2.0.0",
-            "multihashing-async": "^2.0.0",
-            "protons": "^2.0.0",
-            "reset": "^0.1.0",
-            "run": "^1.4.0",
-            "stable": "^0.1.8",
-            "uint8arrays": "^1.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        },
-        "multihashing-async": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-2.0.1.tgz",
-          "integrity": "sha512-LZcH8PqW4iEKymaJ3RpsgpSJhXF29kAvO02ccqbysiXkQhZpVce8rrg+vzRKWO89hhyIBnQHI2e/ZoRVxmiJ2Q==",
-          "dev": true,
-          "requires": {
-            "blakejs": "^1.1.0",
+            "abort-controller": "^3.0.0",
+            "any-signal": "^1.1.0",
+            "buffer": "^5.6.0",
             "err-code": "^2.0.0",
-            "js-sha3": "^0.8.0",
-            "multihashes": "^3.0.1",
-            "murmurhash3js-revisited": "^3.0.0",
-            "uint8arrays": "^1.0.0"
-          }
-        },
-        "protons": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/protons/-/protons-2.0.0.tgz",
-          "integrity": "sha512-BTrE9D6/d1NGis+0D8TqAO1THdn4evHQhfjapA0NUaRH4+ecJJcbqaF7TE/DKv5czE9VB/TeOllBOmCyJhHnhg==",
-          "dev": true,
-          "requires": {
-            "protocol-buffers-schema": "^3.3.1",
-            "signed-varint": "^2.0.1",
-            "uint8arrays": "^1.0.0",
-            "varint": "^5.0.0"
+            "fs-extra": "^9.0.1",
+            "is-electron": "^2.2.0",
+            "iso-url": "^0.4.7",
+            "it-glob": "0.0.8",
+            "it-to-stream": "^0.1.2",
+            "merge-options": "^2.0.0",
+            "nanoid": "^3.1.3",
+            "node-fetch": "^2.6.0",
+            "stream-to-it": "^0.2.0"
           }
         }
       }
     },
     "ipfs-repo-migrations": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/ipfs-repo-migrations/-/ipfs-repo-migrations-1.0.1.tgz",
-      "integrity": "sha512-yPVm9hyhZxc3ZB7+5YJ1W1MOzXN+9Oyp/4xdmNyjsI9lTtf5s0PP2NqXcpxgDP09epNlMMt3LJEt4QP3qHrL/A==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/ipfs-repo-migrations/-/ipfs-repo-migrations-5.0.5.tgz",
+      "integrity": "sha512-dbg9LY+f1MhKLCUTQ28z+TmS7+fC6dgZPJhsWpNXSSwicEgMjUssGMoaft9AjoOuOTISeF3WWVVKRqFpOvCxQg==",
       "dev": true,
       "requires": {
-        "buffer": "^5.6.0",
-        "cids": "^0.8.3",
-        "datastore-core": "^1.1.0",
-        "datastore-fs": "^1.0.0",
-        "datastore-level": "^1.1.0",
+        "cbor": "^5.0.2",
+        "cids": "^1.0.0",
+        "datastore-core": "^2.0.0",
         "debug": "^4.1.0",
-        "interface-datastore": "^1.0.2",
-        "multibase": "^1.0.1",
-        "proper-lockfile": "^4.1.1"
-      },
-      "dependencies": {
-        "cids": {
-          "version": "0.8.3",
-          "resolved": "https://registry.npmjs.org/cids/-/cids-0.8.3.tgz",
-          "integrity": "sha512-yoXTbV3llpm+EBGWKeL9xKtksPE/s6DPoDSY4fn8I8TEW1zehWXPSB0pwAXVDlLaOlrw+sNynj995uD9abmPhA==",
-          "dev": true,
-          "requires": {
-            "buffer": "^5.6.0",
-            "class-is": "^1.1.0",
-            "multibase": "^1.0.0",
-            "multicodec": "^1.0.1",
-            "multihashes": "^1.0.1"
-          }
-        },
-        "datastore-core": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/datastore-core/-/datastore-core-1.1.0.tgz",
-          "integrity": "sha512-tn42Qy6t1V5otG4R3hq7yW4vpNaKc8/GXEYnLv8oeGNSQfEWPnfz1x5Sto080N7IsluzOUWK/W+a4m4Er8DnAA==",
-          "dev": true,
-          "requires": {
-            "buffer": "^5.5.0",
-            "debug": "^4.1.1",
-            "interface-datastore": "^1.0.2"
-          }
-        },
-        "datastore-level": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/datastore-level/-/datastore-level-1.1.0.tgz",
-          "integrity": "sha512-XEuXC3mq2BTUdhOvx7vwD93GN1O8SJf1HL/EOlmVcxLt3EHtDpX5pqZmiDdrXIAfe4uiEuSfFu2tKycuz1PMZA==",
-          "dev": true,
-          "requires": {
-            "datastore-core": "^1.1.0",
-            "interface-datastore": "^1.0.2",
-            "level": "^5.0.1"
-          }
-        },
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "interface-datastore": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-1.0.4.tgz",
-          "integrity": "sha512-nIOP/mVwDUc7OenayUyFQB3D6c3SxDG5opTPeSrhA0jS5q0XWkf8Nz2GtNBm3wkeSKUM6iXt6LwIOCH/+jFXIQ==",
-          "dev": true,
-          "requires": {
-            "buffer": "^5.5.0",
-            "class-is": "^1.1.0",
-            "err-code": "^2.0.1",
-            "ipfs-utils": "^2.2.2",
-            "iso-random-stream": "^1.1.1",
-            "it-all": "^1.0.2",
-            "it-drain": "^1.0.1",
-            "nanoid": "^3.0.2"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        },
-        "multibase": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
-          "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
-          "dev": true,
-          "requires": {
-            "base-x": "^3.0.8",
-            "buffer": "^5.5.0"
-          }
-        },
-        "multicodec": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-1.0.4.tgz",
-          "integrity": "sha512-NDd7FeS3QamVtbgfvu5h7fd1IlbaC4EQ0/pgU4zqE2vdHCmBGsUa0TiM8/TdSeG6BMPC92OOCf8F1ocE/Wkrrg==",
-          "dev": true,
-          "requires": {
-            "buffer": "^5.6.0",
-            "varint": "^5.0.0"
-          }
-        },
-        "multihashes": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
-          "integrity": "sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==",
-          "dev": true,
-          "requires": {
-            "buffer": "^5.6.0",
-            "multibase": "^1.0.1",
-            "varint": "^5.0.0"
-          }
-        }
+        "fnv1a": "^1.0.1",
+        "interface-datastore": "^2.0.0",
+        "ipld-dag-pb": "^0.20.0",
+        "it-length": "0.0.2",
+        "multibase": "^3.0.0",
+        "multicodec": "^2.0.0",
+        "multihashing-async": "^2.0.0",
+        "proper-lockfile": "^4.1.1",
+        "protons": "^2.0.0",
+        "uint8arrays": "^1.0.0",
+        "varint": "^5.0.0"
       }
     },
     "ipfs-unixfs": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/ipfs-unixfs/-/ipfs-unixfs-1.0.3.tgz",
-      "integrity": "sha512-fCwC0vIuQrPSNDWzVKwf31T1tA3vLwlPTC5UgAD8ZrrDgOdeJlhyeqEsMX0fxtuxR3SAKscZr43Lgjrbd5qh0Q==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/ipfs-unixfs/-/ipfs-unixfs-2.0.3.tgz",
+      "integrity": "sha512-WpzG/VTqWBPh1cYW3CXk2naElYO3xU0rJnL3SBHbviZ6ZeHRadxR5k0v3/yxPuygs2AwBhaLqBNlV6uB6OCiQw==",
       "dev": true,
       "requires": {
         "err-code": "^2.0.0",
-        "protons": "^1.2.0"
+        "protons": "^2.0.0"
       }
     },
     "ipfs-unixfs-exporter": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/ipfs-unixfs-exporter/-/ipfs-unixfs-exporter-2.0.2.tgz",
-      "integrity": "sha512-O4PknoOXzQKyAPFSZ+DCaPcSMmUnjPn2kxzhMGlWbXlUXkgGSs1cf3vcy16c/czF7DzVbQruhwURiR1IpUcYQA==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/ipfs-unixfs-exporter/-/ipfs-unixfs-exporter-3.0.4.tgz",
+      "integrity": "sha512-e5rA97JeLaaCBOsuG62MJ2UJZQ3xgd8MoJpNotO37VDXRuE/X0/ny6N8AIxikZ8kHkNmCbclW+B5yQHcmqtRvA==",
       "dev": true,
       "requires": {
-        "buffer": "^5.6.0",
-        "cids": "^0.8.0",
+        "cids": "^1.0.0",
         "err-code": "^2.0.0",
         "hamt-sharding": "^1.0.0",
-        "ipfs-unixfs": "^1.0.3",
+        "ipfs-unixfs": "^2.0.3",
+        "ipfs-utils": "^3.0.0",
         "it-last": "^1.0.1",
-        "multihashing-async": "^0.8.0"
-      },
-      "dependencies": {
-        "cids": {
-          "version": "0.8.3",
-          "resolved": "https://registry.npmjs.org/cids/-/cids-0.8.3.tgz",
-          "integrity": "sha512-yoXTbV3llpm+EBGWKeL9xKtksPE/s6DPoDSY4fn8I8TEW1zehWXPSB0pwAXVDlLaOlrw+sNynj995uD9abmPhA==",
-          "dev": true,
-          "requires": {
-            "buffer": "^5.6.0",
-            "class-is": "^1.1.0",
-            "multibase": "^1.0.0",
-            "multicodec": "^1.0.1",
-            "multihashes": "^1.0.1"
-          }
-        },
-        "multibase": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
-          "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
-          "dev": true,
-          "requires": {
-            "base-x": "^3.0.8",
-            "buffer": "^5.5.0"
-          }
-        },
-        "multicodec": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-1.0.4.tgz",
-          "integrity": "sha512-NDd7FeS3QamVtbgfvu5h7fd1IlbaC4EQ0/pgU4zqE2vdHCmBGsUa0TiM8/TdSeG6BMPC92OOCf8F1ocE/Wkrrg==",
-          "dev": true,
-          "requires": {
-            "buffer": "^5.6.0",
-            "varint": "^5.0.0"
-          }
-        },
-        "multihashes": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
-          "integrity": "sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==",
-          "dev": true,
-          "requires": {
-            "buffer": "^5.6.0",
-            "multibase": "^1.0.1",
-            "varint": "^5.0.0"
-          }
-        }
+        "multihashing-async": "^2.0.0"
       }
     },
     "ipfs-unixfs-importer": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/ipfs-unixfs-importer/-/ipfs-unixfs-importer-2.0.2.tgz",
-      "integrity": "sha512-VPi3zfNtTZZ22xECD2eY9c90tvzsan21z+8p+mG5U4inzUm+yBeWU8QCk9gzkHfrxAXaJO3VS8KOriFK+o0RGQ==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/ipfs-unixfs-importer/-/ipfs-unixfs-importer-3.0.4.tgz",
+      "integrity": "sha512-2Lz1WSrmmMxBZzk99Uh1o76OZMWzkzgvSpcZcG8AdzpBDdjtsGWWED9FBuU31INT2dZk9Yszm8qxX3a8iYcXJg==",
       "dev": true,
       "requires": {
         "bl": "^4.0.0",
-        "buffer": "^5.6.0",
         "err-code": "^2.0.0",
         "hamt-sharding": "^1.0.0",
-        "ipfs-unixfs": "^1.0.3",
-        "ipld-dag-pb": "^0.18.5",
+        "ipfs-unixfs": "^2.0.3",
+        "ipfs-utils": "^3.0.0",
+        "ipld-dag-pb": "^0.20.0",
         "it-all": "^1.0.1",
         "it-batch": "^1.0.3",
         "it-first": "^1.0.1",
         "it-parallel-batch": "^1.0.3",
         "merge-options": "^2.0.0",
-        "multihashing-async": "^0.8.0",
-        "rabin-wasm": "^0.1.1"
+        "multihashing-async": "^2.0.0",
+        "rabin-wasm": "^0.1.1",
+        "uint8arrays": "^1.1.0"
       }
     },
     "ipfs-utils": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-2.4.0.tgz",
-      "integrity": "sha512-0RH8rMIEhrXyrbh87V8SQC6E6/5EJs+YionqZGAXnVoTzkpFhxC3x3FlsxwZ9s72yaieGP1Mx1tRYgfCFM/mJg==",
-      "dev": true,
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-3.0.0.tgz",
+      "integrity": "sha512-qahDc+fghrM57sbySr2TeWjaVR/RH/YEB/hvdAjiTbjESeD87qZawrXwj+19Q2LtGmFGusKNLo5wExeuI5ZfDQ==",
       "requires": {
         "abort-controller": "^3.0.0",
         "any-signal": "^1.1.0",
@@ -10943,7 +9762,6 @@
         "is-electron": "^2.2.0",
         "iso-url": "^0.4.7",
         "it-glob": "0.0.8",
-        "it-to-stream": "^0.1.2",
         "merge-options": "^2.0.0",
         "nanoid": "^3.1.3",
         "node-fetch": "^2.6.0",
@@ -10969,1104 +9787,180 @@
         "temp-write": "^4.0.0"
       },
       "dependencies": {
-        "@hapi/accept": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/@hapi/accept/-/accept-5.0.1.tgz",
-          "integrity": "sha512-fMr4d7zLzsAXo28PRRQPXR1o2Wmu+6z+VY1UzDp0iFo13Twj8WePakwXBiqn3E1aAlTpSNzCXdnnQXFhst8h8Q==",
-          "dev": true,
-          "requires": {
-            "@hapi/boom": "9.x.x",
-            "@hapi/hoek": "9.x.x"
-          }
-        },
-        "@hapi/ammo": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/@hapi/ammo/-/ammo-5.0.1.tgz",
-          "integrity": "sha512-FbCNwcTbnQP4VYYhLNGZmA76xb2aHg9AMPiy18NZyWMG310P5KdFGyA9v2rm5ujrIny77dEEIkMOwl0Xv+fSSA==",
-          "dev": true,
-          "requires": {
-            "@hapi/hoek": "9.x.x"
-          }
-        },
-        "@hapi/b64": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/@hapi/b64/-/b64-5.0.0.tgz",
-          "integrity": "sha512-ngu0tSEmrezoiIaNGG6rRvKOUkUuDdf4XTPnONHGYfSGRmDqPZX5oJL6HAdKTo1UQHECbdB4OzhWrfgVppjHUw==",
-          "dev": true,
-          "requires": {
-            "@hapi/hoek": "9.x.x"
-          }
-        },
-        "@hapi/boom": {
-          "version": "9.1.0",
-          "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-9.1.0.tgz",
-          "integrity": "sha512-4nZmpp4tXbm162LaZT45P7F7sgiem8dwAh2vHWT6XX24dozNjGMg6BvKCRvtCUcmcXqeMIUqWN8Rc5X8yKuROQ==",
-          "dev": true,
-          "requires": {
-            "@hapi/hoek": "9.x.x"
-          }
-        },
-        "@hapi/bounce": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/@hapi/bounce/-/bounce-2.0.0.tgz",
-          "integrity": "sha512-JesW92uyzOOyuzJKjoLHM1ThiOvHPOLDHw01YV8yh5nCso7sDwJho1h0Ad2N+E62bZyz46TG3xhAi/78Gsct6A==",
-          "dev": true,
-          "requires": {
-            "@hapi/boom": "9.x.x",
-            "@hapi/hoek": "9.x.x"
-          }
-        },
-        "@hapi/bourne": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-2.0.0.tgz",
-          "integrity": "sha512-WEezM1FWztfbzqIUbsDzFRVMxSoLy3HugVcux6KDDtTqzPsLE8NDRHfXvev66aH1i2oOKKar3/XDjbvh/OUBdg==",
-          "dev": true
-        },
-        "@hapi/call": {
-          "version": "8.0.1",
-          "resolved": "https://registry.npmjs.org/@hapi/call/-/call-8.0.1.tgz",
-          "integrity": "sha512-bOff6GTdOnoe5b8oXRV3lwkQSb/LAWylvDMae6RgEWWntd0SHtkYbQukDHKlfaYtVnSAgIavJ0kqszF/AIBb6g==",
-          "dev": true,
-          "requires": {
-            "@hapi/boom": "9.x.x",
-            "@hapi/hoek": "9.x.x"
-          }
-        },
-        "@hapi/catbox": {
-          "version": "11.1.1",
-          "resolved": "https://registry.npmjs.org/@hapi/catbox/-/catbox-11.1.1.tgz",
-          "integrity": "sha512-u/8HvB7dD/6X8hsZIpskSDo4yMKpHxFd7NluoylhGrL6cUfYxdQPnvUp9YU2C6F9hsyBVLGulBd9vBN1ebfXOQ==",
-          "dev": true,
-          "requires": {
-            "@hapi/boom": "9.x.x",
-            "@hapi/hoek": "9.x.x",
-            "@hapi/podium": "4.x.x",
-            "@hapi/validate": "1.x.x"
-          }
-        },
-        "@hapi/catbox-memory": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/@hapi/catbox-memory/-/catbox-memory-5.0.0.tgz",
-          "integrity": "sha512-ByuxVJPHNaXwLzbBv4GdTr6ccpe1nG+AfYt+8ftDWEJY7EWBWzD+Klhy5oPTDGzU26pNUh1e7fcYI1ILZRxAXQ==",
-          "dev": true,
-          "requires": {
-            "@hapi/boom": "9.x.x",
-            "@hapi/hoek": "9.x.x"
-          }
-        },
-        "@hapi/content": {
-          "version": "5.0.2",
-          "resolved": "https://registry.npmjs.org/@hapi/content/-/content-5.0.2.tgz",
-          "integrity": "sha512-mre4dl1ygd4ZyOH3tiYBrOUBzV7Pu/EOs8VLGf58vtOEECWed8Uuw6B4iR9AN/8uQt42tB04qpVaMyoMQh0oMw==",
-          "dev": true,
-          "requires": {
-            "@hapi/boom": "9.x.x"
-          }
-        },
-        "@hapi/cryptiles": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/@hapi/cryptiles/-/cryptiles-5.1.0.tgz",
-          "integrity": "sha512-fo9+d1Ba5/FIoMySfMqPBR/7Pa29J2RsiPrl7bkwo5W5o+AN1dAYQRi4SPrPwwVxVGKjgLOEWrsvt1BonJSfLA==",
-          "dev": true,
-          "requires": {
-            "@hapi/boom": "9.x.x"
-          }
-        },
-        "@hapi/file": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/@hapi/file/-/file-2.0.0.tgz",
-          "integrity": "sha512-WSrlgpvEqgPWkI18kkGELEZfXr0bYLtr16iIN4Krh9sRnzBZN6nnWxHFxtsnP684wueEySBbXPDg/WfA9xJdBQ==",
-          "dev": true
-        },
-        "@hapi/hapi": {
-          "version": "20.0.0",
-          "resolved": "https://registry.npmjs.org/@hapi/hapi/-/hapi-20.0.0.tgz",
-          "integrity": "sha512-Wh0tIDFsl7nemU2JQYW4zZVr9XkpuZ1eM3yaX8tzaYdaYXon8QeB5NzrTNQY3R1/+fO7amQUrOoLLNPRwIZfgw==",
-          "dev": true,
-          "requires": {
-            "@hapi/accept": "^5.0.1",
-            "@hapi/ammo": "^5.0.1",
-            "@hapi/boom": "9.x.x",
-            "@hapi/bounce": "2.x.x",
-            "@hapi/call": "8.x.x",
-            "@hapi/catbox": "^11.1.1",
-            "@hapi/catbox-memory": "5.x.x",
-            "@hapi/heavy": "^7.0.1",
-            "@hapi/hoek": "9.x.x",
-            "@hapi/mimos": "5.x.x",
-            "@hapi/podium": "^4.1.1",
-            "@hapi/shot": "^5.0.1",
-            "@hapi/somever": "3.x.x",
-            "@hapi/statehood": "^7.0.3",
-            "@hapi/subtext": "^7.0.3",
-            "@hapi/teamwork": "5.x.x",
-            "@hapi/topo": "5.x.x",
-            "@hapi/validate": "^1.1.0"
-          }
-        },
-        "@hapi/heavy": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/@hapi/heavy/-/heavy-7.0.1.tgz",
-          "integrity": "sha512-vJ/vzRQ13MtRzz6Qd4zRHWS3FaUc/5uivV2TIuExGTM9Qk+7Zzqj0e2G7EpE6KztO9SalTbiIkTh7qFKj/33cA==",
-          "dev": true,
-          "requires": {
-            "@hapi/boom": "9.x.x",
-            "@hapi/hoek": "9.x.x",
-            "@hapi/validate": "1.x.x"
-          }
-        },
-        "@hapi/hoek": {
-          "version": "9.1.0",
-          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.1.0.tgz",
-          "integrity": "sha512-i9YbZPN3QgfighY/1X1Pu118VUz2Fmmhd6b2n0/O8YVgGGfw0FbUYoA97k7FkpGJ+pLCFEDLUmAPPV4D1kpeFw==",
-          "dev": true
-        },
-        "@hapi/iron": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/@hapi/iron/-/iron-6.0.0.tgz",
-          "integrity": "sha512-zvGvWDufiTGpTJPG1Y/McN8UqWBu0k/xs/7l++HVU535NLHXsHhy54cfEMdW7EjwKfbBfM9Xy25FmTiobb7Hvw==",
-          "dev": true,
-          "requires": {
-            "@hapi/b64": "5.x.x",
-            "@hapi/boom": "9.x.x",
-            "@hapi/bourne": "2.x.x",
-            "@hapi/cryptiles": "5.x.x",
-            "@hapi/hoek": "9.x.x"
-          }
-        },
-        "@hapi/mimos": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/@hapi/mimos/-/mimos-5.0.0.tgz",
-          "integrity": "sha512-EVS6wJYeE73InTlPWt+2e3Izn319iIvffDreci3qDNT+t3lA5ylJ0/SoTaID8e0TPNUkHUSsgJZXEmLHvoYzrA==",
-          "dev": true,
-          "requires": {
-            "@hapi/hoek": "9.x.x",
-            "mime-db": "1.x.x"
-          }
-        },
-        "@hapi/nigel": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/@hapi/nigel/-/nigel-4.0.2.tgz",
-          "integrity": "sha512-ht2KoEsDW22BxQOEkLEJaqfpoKPXxi7tvabXy7B/77eFtOyG5ZEstfZwxHQcqAiZhp58Ae5vkhEqI03kawkYNw==",
-          "dev": true,
-          "requires": {
-            "@hapi/hoek": "^9.0.4",
-            "@hapi/vise": "^4.0.0"
-          }
-        },
-        "@hapi/pez": {
-          "version": "5.0.3",
-          "resolved": "https://registry.npmjs.org/@hapi/pez/-/pez-5.0.3.tgz",
-          "integrity": "sha512-mpikYRJjtrbJgdDHG/H9ySqYqwJ+QU/D7FXsYciS9P7NYBXE2ayKDAy3H0ou6CohOCaxPuTV4SZ0D936+VomHA==",
-          "dev": true,
-          "requires": {
-            "@hapi/b64": "5.x.x",
-            "@hapi/boom": "9.x.x",
-            "@hapi/content": "^5.0.2",
-            "@hapi/hoek": "9.x.x",
-            "@hapi/nigel": "4.x.x"
-          }
-        },
-        "@hapi/podium": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/@hapi/podium/-/podium-4.1.1.tgz",
-          "integrity": "sha512-jh7a6+5Z4FUWzx8fgmxjaAa1DTBu+Qfg+NbVdo0f++rE5DgsVidUYrLDp3db65+QjDLleA2MfKQXkpT8ylBDXA==",
-          "dev": true,
-          "requires": {
-            "@hapi/hoek": "9.x.x",
-            "@hapi/teamwork": "5.x.x",
-            "@hapi/validate": "1.x.x"
-          }
-        },
-        "@hapi/shot": {
-          "version": "5.0.4",
-          "resolved": "https://registry.npmjs.org/@hapi/shot/-/shot-5.0.4.tgz",
-          "integrity": "sha512-PcEz0WJgFDA3xNSMeONgQmothFr7jhbbRRSAKaDh7chN7zOXBlhl13bvKZW6CMb2xVfJUmt34CW3e/oExMgBhQ==",
-          "dev": true,
-          "requires": {
-            "@hapi/hoek": "9.x.x",
-            "@hapi/validate": "1.x.x"
-          }
-        },
-        "@hapi/somever": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@hapi/somever/-/somever-3.0.0.tgz",
-          "integrity": "sha512-Upw/kmKotC9iEmK4y047HMYe4LDKsE5NWfjgX41XNKmFvxsQL7OiaCWVhuyyhU0ShDGBfIAnCH8jZr49z/JzZA==",
-          "dev": true,
-          "requires": {
-            "@hapi/bounce": "2.x.x",
-            "@hapi/hoek": "9.x.x"
-          }
-        },
-        "@hapi/statehood": {
-          "version": "7.0.3",
-          "resolved": "https://registry.npmjs.org/@hapi/statehood/-/statehood-7.0.3.tgz",
-          "integrity": "sha512-pYB+pyCHkf2Amh67QAXz7e/DN9jcMplIL7Z6N8h0K+ZTy0b404JKPEYkbWHSnDtxLjJB/OtgElxocr2fMH4G7w==",
-          "dev": true,
-          "requires": {
-            "@hapi/boom": "9.x.x",
-            "@hapi/bounce": "2.x.x",
-            "@hapi/bourne": "2.x.x",
-            "@hapi/cryptiles": "5.x.x",
-            "@hapi/hoek": "9.x.x",
-            "@hapi/iron": "6.x.x",
-            "@hapi/validate": "1.x.x"
-          }
-        },
-        "@hapi/subtext": {
-          "version": "7.0.3",
-          "resolved": "https://registry.npmjs.org/@hapi/subtext/-/subtext-7.0.3.tgz",
-          "integrity": "sha512-CekDizZkDGERJ01C0+TzHlKtqdXZxzSWTOaH6THBrbOHnsr3GY+yiMZC+AfNCypfE17RaIakGIAbpL2Tk1z2+A==",
-          "dev": true,
-          "requires": {
-            "@hapi/boom": "9.x.x",
-            "@hapi/bourne": "2.x.x",
-            "@hapi/content": "^5.0.2",
-            "@hapi/file": "2.x.x",
-            "@hapi/hoek": "9.x.x",
-            "@hapi/pez": "^5.0.1",
-            "@hapi/wreck": "17.x.x"
-          }
-        },
-        "@hapi/teamwork": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/@hapi/teamwork/-/teamwork-5.1.0.tgz",
-          "integrity": "sha512-llqoQTrAJDTXxG3c4Kz/uzhBS1TsmSBa/XG5SPcVXgmffHE1nFtyLIK0hNJHCB3EuBKT84adzd1hZNY9GJLWtg==",
-          "dev": true
-        },
-        "@hapi/topo": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.0.0.tgz",
-          "integrity": "sha512-tFJlT47db0kMqVm3H4nQYgn6Pwg10GTZHb1pwmSiv1K4ks6drQOtfEF5ZnPjkvC+y4/bUPHK+bc87QvLcL+WMw==",
-          "dev": true,
-          "requires": {
-            "@hapi/hoek": "^9.0.0"
-          }
-        },
-        "@hapi/vise": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/@hapi/vise/-/vise-4.0.0.tgz",
-          "integrity": "sha512-eYyLkuUiFZTer59h+SGy7hUm+qE9p+UemePTHLlIWppEd+wExn3Df5jO04bFQTm7nleF5V8CtuYQYb+VFpZ6Sg==",
-          "dev": true,
-          "requires": {
-            "@hapi/hoek": "9.x.x"
-          }
-        },
-        "@hapi/wreck": {
-          "version": "17.0.0",
-          "resolved": "https://registry.npmjs.org/@hapi/wreck/-/wreck-17.0.0.tgz",
-          "integrity": "sha512-d8lqCinbKyDByn7GzJDRDbitddhIEydNm44UcAMejfhEH3o4IYvKYq6K8cAqXbilXPuvZc0ErlUOg9SDdgRtMw==",
-          "dev": true,
-          "requires": {
-            "@hapi/boom": "9.x.x",
-            "@hapi/bourne": "2.x.x",
-            "@hapi/hoek": "9.x.x"
-          }
-        },
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ipfs-utils": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-3.0.0.tgz",
-          "integrity": "sha512-qahDc+fghrM57sbySr2TeWjaVR/RH/YEB/hvdAjiTbjESeD87qZawrXwj+19Q2LtGmFGusKNLo5wExeuI5ZfDQ==",
-          "dev": true,
-          "requires": {
-            "abort-controller": "^3.0.0",
-            "any-signal": "^1.1.0",
-            "buffer": "^5.6.0",
-            "err-code": "^2.0.0",
-            "fs-extra": "^9.0.1",
-            "is-electron": "^2.2.0",
-            "iso-url": "^0.4.7",
-            "it-glob": "0.0.8",
-            "merge-options": "^2.0.0",
-            "nanoid": "^3.1.3",
-            "node-fetch": "^2.6.0",
-            "stream-to-it": "^0.2.0"
-          },
-          "dependencies": {
-            "merge-options": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-2.0.0.tgz",
-              "integrity": "sha512-S7xYIeWHl2ZUKF7SDeBhGg6rfv5bKxVBdk95s/I7wVF8d+hjLSztJ/B271cnUiF6CAFduEQ5Zn3HYwAjT16DlQ==",
-              "dev": true,
-              "requires": {
-                "is-plain-obj": "^2.0.0"
-              }
-            }
-          }
-        },
-        "is-plain-obj": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
-          "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
-          "dev": true
-        },
         "merge-options": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.2.tgz",
-          "integrity": "sha512-7TM9KD5J6TfT7Frs7PUnhA7Agkuag/vG9BdDbFtP54mrquqflOTJ30QXzlpI/ZX2cLDi6lw96eRF3ZhxkUVgKw==",
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.3.tgz",
+          "integrity": "sha512-jytfjQxL5mVrtD9O24zOXU4neV3uVbQdn1F0o1pzSa1yH9LTEUOtfwpWSsyAxrrrXqAFTxaU4ynqkmekHLvYew==",
           "dev": true,
           "requires": {
             "is-plain-obj": "^2.1.0"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        },
-        "multiaddr": {
-          "version": "8.0.0",
-          "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-8.0.0.tgz",
-          "integrity": "sha512-4OOyr0u0i4lvh9MY/mvuCNmH5eqoTamcnGeXz6umFGc0eaVQUGPDQNbp52YfFY92NlZ76pO6h4K2HkXsT5X43w==",
-          "dev": true,
-          "requires": {
-            "cids": "^1.0.0",
-            "class-is": "^1.1.0",
-            "is-ip": "^3.1.0",
-            "multibase": "^3.0.0",
-            "uint8arrays": "^1.1.0",
-            "varint": "^5.0.0"
           }
         }
       }
     },
     "ipld": {
-      "version": "0.26.4",
-      "resolved": "https://registry.npmjs.org/ipld/-/ipld-0.26.4.tgz",
-      "integrity": "sha512-beRa9tayJDbzlqA7UEnUXQq654dAgnsrTSIJIe/vOBJToH8lDc/pLuIOmPYrDCVlv6XtJuZ7qgk3bIPppb21dA==",
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/ipld/-/ipld-0.27.1.tgz",
+      "integrity": "sha512-rX9TVFk9ZpMtjVdi74yaOgBcGRcz8NhGQHS4t/A4v/4UKp+nBWzDSMSAHpKXM1PGXYdlzYyIsfQMMoimQXVTxw==",
       "dev": true,
       "requires": {
-        "buffer": "^5.6.0",
-        "cids": "^0.8.3",
-        "ipld-block": "^0.9.1",
-        "ipld-dag-cbor": "^0.16.0",
-        "ipld-dag-pb": "^0.19.0",
-        "ipld-raw": "^5.0.0",
+        "cids": "^1.0.0",
+        "ipld-block": "^0.10.0",
+        "ipld-dag-cbor": "^0.17.0",
+        "ipld-dag-pb": "^0.20.0",
+        "ipld-raw": "^6.0.0",
         "merge-options": "^2.0.0",
-        "multicodec": "^1.0.0",
+        "multicodec": "^2.0.0",
         "typical": "^6.0.0"
-      },
-      "dependencies": {
-        "cids": {
-          "version": "0.8.3",
-          "resolved": "https://registry.npmjs.org/cids/-/cids-0.8.3.tgz",
-          "integrity": "sha512-yoXTbV3llpm+EBGWKeL9xKtksPE/s6DPoDSY4fn8I8TEW1zehWXPSB0pwAXVDlLaOlrw+sNynj995uD9abmPhA==",
-          "dev": true,
-          "requires": {
-            "buffer": "^5.6.0",
-            "class-is": "^1.1.0",
-            "multibase": "^1.0.0",
-            "multicodec": "^1.0.1",
-            "multihashes": "^1.0.1"
-          }
-        },
-        "ipld-dag-pb": {
-          "version": "0.19.0",
-          "resolved": "https://registry.npmjs.org/ipld-dag-pb/-/ipld-dag-pb-0.19.0.tgz",
-          "integrity": "sha512-qwuJM2Ev74HLKxgfmH7Qw/ob/Iwo4Te6ADZas8OqV2FCY+I4H+KJujLvaBs+By2g3h0aagv0ei3aUgqE8XzDfw==",
-          "dev": true,
-          "requires": {
-            "buffer": "^5.6.0",
-            "cids": "~0.8.3",
-            "class-is": "^1.1.0",
-            "multicodec": "^1.0.3",
-            "multihashing-async": "^1.0.0",
-            "protons": "^1.2.1",
-            "stable": "^0.1.8"
-          }
-        },
-        "multibase": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
-          "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
-          "dev": true,
-          "requires": {
-            "base-x": "^3.0.8",
-            "buffer": "^5.5.0"
-          }
-        },
-        "multicodec": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-1.0.4.tgz",
-          "integrity": "sha512-NDd7FeS3QamVtbgfvu5h7fd1IlbaC4EQ0/pgU4zqE2vdHCmBGsUa0TiM8/TdSeG6BMPC92OOCf8F1ocE/Wkrrg==",
-          "dev": true,
-          "requires": {
-            "buffer": "^5.6.0",
-            "varint": "^5.0.0"
-          }
-        },
-        "multihashes": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
-          "integrity": "sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==",
-          "dev": true,
-          "requires": {
-            "buffer": "^5.6.0",
-            "multibase": "^1.0.1",
-            "varint": "^5.0.0"
-          }
-        },
-        "multihashing-async": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-1.0.0.tgz",
-          "integrity": "sha512-gRtHjJuULvo2dd9ybIsF+aUEamraAwet/ib3YapWdaP7QWkI8JtN/6EZBhdoqlzSVU7POrC3/rp13Or7zY7x1A==",
-          "dev": true,
-          "requires": {
-            "blakejs": "^1.1.0",
-            "buffer": "^5.4.3",
-            "err-code": "^2.0.0",
-            "js-sha3": "^0.8.0",
-            "multihashes": "^1.0.1",
-            "murmurhash3js-revisited": "^3.0.0"
-          }
-        }
       }
     },
     "ipld-bitcoin": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/ipld-bitcoin/-/ipld-bitcoin-0.3.2.tgz",
-      "integrity": "sha512-cglP2KmfpQK6UWR6Yu4+F2Aj8z5m3z/ng4Bq2FV9rxASGSQn1nmVRFQu39j2lYcEUrvPPc+HRsDz1Ppvd6xODQ==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/ipld-bitcoin/-/ipld-bitcoin-0.4.0.tgz",
+      "integrity": "sha512-SRcNRMvdeIKlCCMymqas5ZX9tVjAZ/cid2LPd0vWrLtwc1r4liWvHAxbaU/fJa8Xo6neYWuS/XIqaE/yzMAhRw==",
       "dev": true,
       "requires": {
         "bitcoinjs-lib": "^5.0.0",
         "buffer": "^5.6.0",
-        "cids": "^0.8.3",
-        "multicodec": "^1.0.0",
-        "multihashes": "^1.0.1",
-        "multihashing-async": "^1.0.0"
-      },
-      "dependencies": {
-        "cids": {
-          "version": "0.8.3",
-          "resolved": "https://registry.npmjs.org/cids/-/cids-0.8.3.tgz",
-          "integrity": "sha512-yoXTbV3llpm+EBGWKeL9xKtksPE/s6DPoDSY4fn8I8TEW1zehWXPSB0pwAXVDlLaOlrw+sNynj995uD9abmPhA==",
-          "dev": true,
-          "requires": {
-            "buffer": "^5.6.0",
-            "class-is": "^1.1.0",
-            "multibase": "^1.0.0",
-            "multicodec": "^1.0.1",
-            "multihashes": "^1.0.1"
-          }
-        },
-        "multibase": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
-          "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
-          "dev": true,
-          "requires": {
-            "base-x": "^3.0.8",
-            "buffer": "^5.5.0"
-          }
-        },
-        "multicodec": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-1.0.4.tgz",
-          "integrity": "sha512-NDd7FeS3QamVtbgfvu5h7fd1IlbaC4EQ0/pgU4zqE2vdHCmBGsUa0TiM8/TdSeG6BMPC92OOCf8F1ocE/Wkrrg==",
-          "dev": true,
-          "requires": {
-            "buffer": "^5.6.0",
-            "varint": "^5.0.0"
-          }
-        },
-        "multihashes": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
-          "integrity": "sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==",
-          "dev": true,
-          "requires": {
-            "buffer": "^5.6.0",
-            "multibase": "^1.0.1",
-            "varint": "^5.0.0"
-          }
-        },
-        "multihashing-async": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-1.0.0.tgz",
-          "integrity": "sha512-gRtHjJuULvo2dd9ybIsF+aUEamraAwet/ib3YapWdaP7QWkI8JtN/6EZBhdoqlzSVU7POrC3/rp13Or7zY7x1A==",
-          "dev": true,
-          "requires": {
-            "blakejs": "^1.1.0",
-            "buffer": "^5.4.3",
-            "err-code": "^2.0.0",
-            "js-sha3": "^0.8.0",
-            "multihashes": "^1.0.1",
-            "murmurhash3js-revisited": "^3.0.0"
-          }
-        }
+        "cids": "^1.0.0",
+        "multicodec": "^2.0.0",
+        "multihashes": "^3.0.0",
+        "multihashing-async": "^2.0.0",
+        "uint8arrays": "^1.0.0"
       }
     },
     "ipld-block": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/ipld-block/-/ipld-block-0.9.2.tgz",
-      "integrity": "sha512-/i99foB+QI8WhyZWu6ZVPFw2sP6kzZSnnjPNlxxrgaJeFX22w2z00nYWafY2YYYP4mZ9xkLZDSS/msli7XXyvw==",
-      "dev": true,
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/ipld-block/-/ipld-block-0.10.1.tgz",
+      "integrity": "sha512-lPMfW9tA2hVZw9hdO/YSppTxFmA0+5zxcefBOlCTOn+12RLyy+pdepKMbQw8u0KESFu3pYVmabNRWuFGcgHLLw==",
       "requires": {
-        "buffer": "^5.5.0",
-        "cids": "~0.8.0",
+        "cids": "^1.0.0",
         "class-is": "^1.1.0"
-      },
-      "dependencies": {
-        "cids": {
-          "version": "0.8.3",
-          "resolved": "https://registry.npmjs.org/cids/-/cids-0.8.3.tgz",
-          "integrity": "sha512-yoXTbV3llpm+EBGWKeL9xKtksPE/s6DPoDSY4fn8I8TEW1zehWXPSB0pwAXVDlLaOlrw+sNynj995uD9abmPhA==",
-          "dev": true,
-          "requires": {
-            "buffer": "^5.6.0",
-            "class-is": "^1.1.0",
-            "multibase": "^1.0.0",
-            "multicodec": "^1.0.1",
-            "multihashes": "^1.0.1"
-          }
-        },
-        "multibase": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
-          "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
-          "dev": true,
-          "requires": {
-            "base-x": "^3.0.8",
-            "buffer": "^5.5.0"
-          }
-        },
-        "multicodec": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-1.0.4.tgz",
-          "integrity": "sha512-NDd7FeS3QamVtbgfvu5h7fd1IlbaC4EQ0/pgU4zqE2vdHCmBGsUa0TiM8/TdSeG6BMPC92OOCf8F1ocE/Wkrrg==",
-          "dev": true,
-          "requires": {
-            "buffer": "^5.6.0",
-            "varint": "^5.0.0"
-          }
-        },
-        "multihashes": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
-          "integrity": "sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==",
-          "dev": true,
-          "requires": {
-            "buffer": "^5.6.0",
-            "multibase": "^1.0.1",
-            "varint": "^5.0.0"
-          }
-        }
       }
     },
     "ipld-dag-cbor": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/ipld-dag-cbor/-/ipld-dag-cbor-0.16.0.tgz",
-      "integrity": "sha512-dnmR8Pgt1gGmEXWSf/V3dKDPveGnHsovvAAN7m/WHW5mXsBqYYOStt98K1RhCifbB7vY+IHmpdRhVka0g9DWFQ==",
-      "dev": true,
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/ipld-dag-cbor/-/ipld-dag-cbor-0.17.0.tgz",
+      "integrity": "sha512-YprSTQClJQUyC+RhbWrVXhg7ysII5R/jrmZZ4en4n9Mav+MRbntAW699zd1PHRLB71lNCJbxABE2Uc9QU2Ka7g==",
       "requires": {
         "borc": "^2.1.2",
-        "buffer": "^5.6.0",
-        "cids": "~0.8.3",
+        "cids": "^1.0.0",
         "is-circular": "^1.0.2",
-        "multicodec": "^1.0.3",
-        "multihashing-async": "^1.0.0"
-      },
-      "dependencies": {
-        "cids": {
-          "version": "0.8.3",
-          "resolved": "https://registry.npmjs.org/cids/-/cids-0.8.3.tgz",
-          "integrity": "sha512-yoXTbV3llpm+EBGWKeL9xKtksPE/s6DPoDSY4fn8I8TEW1zehWXPSB0pwAXVDlLaOlrw+sNynj995uD9abmPhA==",
-          "dev": true,
-          "requires": {
-            "buffer": "^5.6.0",
-            "class-is": "^1.1.0",
-            "multibase": "^1.0.0",
-            "multicodec": "^1.0.1",
-            "multihashes": "^1.0.1"
-          }
-        },
-        "multibase": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
-          "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
-          "dev": true,
-          "requires": {
-            "base-x": "^3.0.8",
-            "buffer": "^5.5.0"
-          }
-        },
-        "multicodec": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-1.0.4.tgz",
-          "integrity": "sha512-NDd7FeS3QamVtbgfvu5h7fd1IlbaC4EQ0/pgU4zqE2vdHCmBGsUa0TiM8/TdSeG6BMPC92OOCf8F1ocE/Wkrrg==",
-          "dev": true,
-          "requires": {
-            "buffer": "^5.6.0",
-            "varint": "^5.0.0"
-          }
-        },
-        "multihashes": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
-          "integrity": "sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==",
-          "dev": true,
-          "requires": {
-            "buffer": "^5.6.0",
-            "multibase": "^1.0.1",
-            "varint": "^5.0.0"
-          }
-        },
-        "multihashing-async": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-1.0.0.tgz",
-          "integrity": "sha512-gRtHjJuULvo2dd9ybIsF+aUEamraAwet/ib3YapWdaP7QWkI8JtN/6EZBhdoqlzSVU7POrC3/rp13Or7zY7x1A==",
-          "dev": true,
-          "requires": {
-            "blakejs": "^1.1.0",
-            "buffer": "^5.4.3",
-            "err-code": "^2.0.0",
-            "js-sha3": "^0.8.0",
-            "multihashes": "^1.0.1",
-            "murmurhash3js-revisited": "^3.0.0"
-          }
-        }
+        "multicodec": "^2.0.0",
+        "multihashing-async": "^2.0.0",
+        "uint8arrays": "^1.0.0"
       }
     },
     "ipld-dag-pb": {
-      "version": "0.18.5",
-      "resolved": "https://registry.npmjs.org/ipld-dag-pb/-/ipld-dag-pb-0.18.5.tgz",
-      "integrity": "sha512-8IAPZrkRjgTpkxV9JOwXSBe0GXNxd4B2lubPgbifTGL92rZOEKWutpijsWsWvjXOltDFHKMQIIIhkgLC5RPqbA==",
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/ipld-dag-pb/-/ipld-dag-pb-0.20.0.tgz",
+      "integrity": "sha512-zfM0EdaolqNjAxIrtpuGKvXxWk5YtH9jKinBuQGTcngOsWFQhyybGCTJHGNGGtRjHNJi2hz5Udy/8pzv4kcKyg==",
       "requires": {
-        "buffer": "^5.6.0",
-        "cids": "~0.8.0",
+        "cids": "^1.0.0",
         "class-is": "^1.1.0",
-        "multicodec": "^1.0.1",
-        "multihashing-async": "~0.8.1",
-        "protons": "^1.0.2",
-        "stable": "^0.1.8"
-      },
-      "dependencies": {
-        "cids": {
-          "version": "0.8.3",
-          "resolved": "https://registry.npmjs.org/cids/-/cids-0.8.3.tgz",
-          "integrity": "sha512-yoXTbV3llpm+EBGWKeL9xKtksPE/s6DPoDSY4fn8I8TEW1zehWXPSB0pwAXVDlLaOlrw+sNynj995uD9abmPhA==",
-          "requires": {
-            "buffer": "^5.6.0",
-            "class-is": "^1.1.0",
-            "multibase": "^1.0.0",
-            "multicodec": "^1.0.1",
-            "multihashes": "^1.0.1"
-          }
-        },
-        "multibase": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
-          "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
-          "requires": {
-            "base-x": "^3.0.8",
-            "buffer": "^5.5.0"
-          }
-        },
-        "multicodec": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-1.0.4.tgz",
-          "integrity": "sha512-NDd7FeS3QamVtbgfvu5h7fd1IlbaC4EQ0/pgU4zqE2vdHCmBGsUa0TiM8/TdSeG6BMPC92OOCf8F1ocE/Wkrrg==",
-          "requires": {
-            "buffer": "^5.6.0",
-            "varint": "^5.0.0"
-          }
-        },
-        "multihashes": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
-          "integrity": "sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==",
-          "requires": {
-            "buffer": "^5.6.0",
-            "multibase": "^1.0.1",
-            "varint": "^5.0.0"
-          }
-        }
+        "multicodec": "^2.0.0",
+        "multihashing-async": "^2.0.0",
+        "protons": "^2.0.0",
+        "reset": "^0.1.0",
+        "run": "^1.4.0",
+        "stable": "^0.1.8",
+        "uint8arrays": "^1.0.0"
       }
     },
     "ipld-ethereum": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/ipld-ethereum/-/ipld-ethereum-4.0.2.tgz",
-      "integrity": "sha512-0uShqn7PcCgWca7lkn8WE8sS8GVDxoi7+juiSLw2MApx+r11hPBjiMDKy0SFZoyXMRYPZA6Xh1WTqzH8UM2eHA==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ipld-ethereum/-/ipld-ethereum-5.0.1.tgz",
+      "integrity": "sha512-M0n4z4y0LwsBKIvQev8xHOfxwjwR+jl6ot8z2ujScE6MX+inhojw2/vjvoWIk4N7oleNf3sg4ZxBzdttulvPTA==",
       "dev": true,
       "requires": {
         "buffer": "^5.6.0",
-        "cids": "^0.8.3",
+        "cids": "^1.0.0",
         "ethereumjs-account": "^3.0.0",
         "ethereumjs-block": "^2.2.1",
         "ethereumjs-tx": "^2.1.1",
         "merkle-patricia-tree": "^3.0.0",
-        "multicodec": "^1.0.0",
-        "multihashes": "^1.0.1",
-        "multihashing-async": "^1.0.0",
+        "multicodec": "^2.0.0",
+        "multihashes": "^3.0.1",
+        "multihashing-async": "^2.0.0",
         "rlp": "^2.2.4"
-      },
-      "dependencies": {
-        "cids": {
-          "version": "0.8.3",
-          "resolved": "https://registry.npmjs.org/cids/-/cids-0.8.3.tgz",
-          "integrity": "sha512-yoXTbV3llpm+EBGWKeL9xKtksPE/s6DPoDSY4fn8I8TEW1zehWXPSB0pwAXVDlLaOlrw+sNynj995uD9abmPhA==",
-          "dev": true,
-          "requires": {
-            "buffer": "^5.6.0",
-            "class-is": "^1.1.0",
-            "multibase": "^1.0.0",
-            "multicodec": "^1.0.1",
-            "multihashes": "^1.0.1"
-          }
-        },
-        "multibase": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
-          "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
-          "dev": true,
-          "requires": {
-            "base-x": "^3.0.8",
-            "buffer": "^5.5.0"
-          }
-        },
-        "multicodec": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-1.0.4.tgz",
-          "integrity": "sha512-NDd7FeS3QamVtbgfvu5h7fd1IlbaC4EQ0/pgU4zqE2vdHCmBGsUa0TiM8/TdSeG6BMPC92OOCf8F1ocE/Wkrrg==",
-          "dev": true,
-          "requires": {
-            "buffer": "^5.6.0",
-            "varint": "^5.0.0"
-          }
-        },
-        "multihashes": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
-          "integrity": "sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==",
-          "dev": true,
-          "requires": {
-            "buffer": "^5.6.0",
-            "multibase": "^1.0.1",
-            "varint": "^5.0.0"
-          }
-        },
-        "multihashing-async": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-1.0.0.tgz",
-          "integrity": "sha512-gRtHjJuULvo2dd9ybIsF+aUEamraAwet/ib3YapWdaP7QWkI8JtN/6EZBhdoqlzSVU7POrC3/rp13Or7zY7x1A==",
-          "dev": true,
-          "requires": {
-            "blakejs": "^1.1.0",
-            "buffer": "^5.4.3",
-            "err-code": "^2.0.0",
-            "js-sha3": "^0.8.0",
-            "multihashes": "^1.0.1",
-            "murmurhash3js-revisited": "^3.0.0"
-          }
-        }
       }
     },
     "ipld-git": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/ipld-git/-/ipld-git-0.5.3.tgz",
-      "integrity": "sha512-ffJgkGFb7VnTh8AOZNu19de1pXecbInJ62iEfL1ydn330tgwWtSMI2ny2EXGuOg1LvR9DF87Shz92CdtW4zYTw==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/ipld-git/-/ipld-git-0.6.1.tgz",
+      "integrity": "sha512-HjKjmMX8vIEMk+isMBaU0/g+xi6LZOQHQ7oFaQ15wUUYLWe5rwkpdr8/3GqHEt3hKdEeWDCX2FqrmQsT9lrQFA==",
       "dev": true,
       "requires": {
         "buffer": "^5.6.0",
-        "cids": "^0.8.3",
-        "multicodec": "^1.0.2",
-        "multihashing-async": "^1.0.0",
+        "cids": "^1.0.0",
+        "multicodec": "^2.0.0",
+        "multihashing-async": "^2.0.1",
         "smart-buffer": "^4.1.0",
-        "strftime": "^0.10.0"
-      },
-      "dependencies": {
-        "cids": {
-          "version": "0.8.3",
-          "resolved": "https://registry.npmjs.org/cids/-/cids-0.8.3.tgz",
-          "integrity": "sha512-yoXTbV3llpm+EBGWKeL9xKtksPE/s6DPoDSY4fn8I8TEW1zehWXPSB0pwAXVDlLaOlrw+sNynj995uD9abmPhA==",
-          "dev": true,
-          "requires": {
-            "buffer": "^5.6.0",
-            "class-is": "^1.1.0",
-            "multibase": "^1.0.0",
-            "multicodec": "^1.0.1",
-            "multihashes": "^1.0.1"
-          }
-        },
-        "multibase": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
-          "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
-          "dev": true,
-          "requires": {
-            "base-x": "^3.0.8",
-            "buffer": "^5.5.0"
-          }
-        },
-        "multicodec": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-1.0.4.tgz",
-          "integrity": "sha512-NDd7FeS3QamVtbgfvu5h7fd1IlbaC4EQ0/pgU4zqE2vdHCmBGsUa0TiM8/TdSeG6BMPC92OOCf8F1ocE/Wkrrg==",
-          "dev": true,
-          "requires": {
-            "buffer": "^5.6.0",
-            "varint": "^5.0.0"
-          }
-        },
-        "multihashes": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
-          "integrity": "sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==",
-          "dev": true,
-          "requires": {
-            "buffer": "^5.6.0",
-            "multibase": "^1.0.1",
-            "varint": "^5.0.0"
-          }
-        },
-        "multihashing-async": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-1.0.0.tgz",
-          "integrity": "sha512-gRtHjJuULvo2dd9ybIsF+aUEamraAwet/ib3YapWdaP7QWkI8JtN/6EZBhdoqlzSVU7POrC3/rp13Or7zY7x1A==",
-          "dev": true,
-          "requires": {
-            "blakejs": "^1.1.0",
-            "buffer": "^5.4.3",
-            "err-code": "^2.0.0",
-            "js-sha3": "^0.8.0",
-            "multihashes": "^1.0.1",
-            "murmurhash3js-revisited": "^3.0.0"
-          }
-        }
+        "strftime": "^0.10.0",
+        "uint8arrays": "^1.0.0"
       }
     },
     "ipld-raw": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ipld-raw/-/ipld-raw-5.0.0.tgz",
-      "integrity": "sha512-z1Fie224lTtQZbFg+wC5WDY692G3SIpO8vT86yCU83vqpIvasVuV3SzDSv7G36kRxP03PPZOkvKAOFrcjb7gpw==",
-      "dev": true,
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/ipld-raw/-/ipld-raw-6.0.0.tgz",
+      "integrity": "sha512-UK7fjncAzs59iu/o2kwYtb8jgTtW6B+cNWIiNpAJkfRwqoMk1xD/6i25ktzwe4qO8gQgoR9RxA5ibC23nq8BLg==",
       "requires": {
-        "cids": "~0.8.0",
-        "multicodec": "^1.0.1",
-        "multihashing-async": "~0.8.1"
-      },
-      "dependencies": {
-        "cids": {
-          "version": "0.8.3",
-          "resolved": "https://registry.npmjs.org/cids/-/cids-0.8.3.tgz",
-          "integrity": "sha512-yoXTbV3llpm+EBGWKeL9xKtksPE/s6DPoDSY4fn8I8TEW1zehWXPSB0pwAXVDlLaOlrw+sNynj995uD9abmPhA==",
-          "dev": true,
-          "requires": {
-            "buffer": "^5.6.0",
-            "class-is": "^1.1.0",
-            "multibase": "^1.0.0",
-            "multicodec": "^1.0.1",
-            "multihashes": "^1.0.1"
-          }
-        },
-        "multibase": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
-          "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
-          "dev": true,
-          "requires": {
-            "base-x": "^3.0.8",
-            "buffer": "^5.5.0"
-          }
-        },
-        "multicodec": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-1.0.4.tgz",
-          "integrity": "sha512-NDd7FeS3QamVtbgfvu5h7fd1IlbaC4EQ0/pgU4zqE2vdHCmBGsUa0TiM8/TdSeG6BMPC92OOCf8F1ocE/Wkrrg==",
-          "dev": true,
-          "requires": {
-            "buffer": "^5.6.0",
-            "varint": "^5.0.0"
-          }
-        },
-        "multihashes": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
-          "integrity": "sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==",
-          "dev": true,
-          "requires": {
-            "buffer": "^5.6.0",
-            "multibase": "^1.0.1",
-            "varint": "^5.0.0"
-          }
-        }
+        "cids": "^1.0.0",
+        "multicodec": "^2.0.0",
+        "multihashing-async": "^2.0.0"
       }
     },
     "ipld-zcash": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/ipld-zcash/-/ipld-zcash-0.4.3.tgz",
-      "integrity": "sha512-HBczqYbhRWOGmq4kcLnD9W8sM5BBJPGTH/hHia4b97BpF1JYDCu+vDv8xrJUAj6l+o+VX4xs+S50tMMEDEhXXA==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/ipld-zcash/-/ipld-zcash-0.5.0.tgz",
+      "integrity": "sha512-nBeyZ/g/hvP3FQl9IODe6mW+UoO10hQMb3k9elcAuwfromljE/rozoDMiMYagZAm03dkSHsk/YSeEWdWqRKaPQ==",
       "dev": true,
       "requires": {
         "buffer": "^5.6.0",
-        "cids": "^0.8.3",
-        "multicodec": "^1.0.0",
-        "multihashes": "^1.0.1",
-        "multihashing-async": "^1.0.0",
+        "cids": "^1.0.0",
+        "multicodec": "^2.0.0",
+        "multihashes": "^3.0.1",
+        "multihashing-async": "^2.0.0",
         "zcash-block": "^2.0.0"
-      },
-      "dependencies": {
-        "cids": {
-          "version": "0.8.3",
-          "resolved": "https://registry.npmjs.org/cids/-/cids-0.8.3.tgz",
-          "integrity": "sha512-yoXTbV3llpm+EBGWKeL9xKtksPE/s6DPoDSY4fn8I8TEW1zehWXPSB0pwAXVDlLaOlrw+sNynj995uD9abmPhA==",
-          "dev": true,
-          "requires": {
-            "buffer": "^5.6.0",
-            "class-is": "^1.1.0",
-            "multibase": "^1.0.0",
-            "multicodec": "^1.0.1",
-            "multihashes": "^1.0.1"
-          }
-        },
-        "multibase": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
-          "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
-          "dev": true,
-          "requires": {
-            "base-x": "^3.0.8",
-            "buffer": "^5.5.0"
-          }
-        },
-        "multicodec": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-1.0.4.tgz",
-          "integrity": "sha512-NDd7FeS3QamVtbgfvu5h7fd1IlbaC4EQ0/pgU4zqE2vdHCmBGsUa0TiM8/TdSeG6BMPC92OOCf8F1ocE/Wkrrg==",
-          "dev": true,
-          "requires": {
-            "buffer": "^5.6.0",
-            "varint": "^5.0.0"
-          }
-        },
-        "multihashes": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
-          "integrity": "sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==",
-          "dev": true,
-          "requires": {
-            "buffer": "^5.6.0",
-            "multibase": "^1.0.1",
-            "varint": "^5.0.0"
-          }
-        },
-        "multihashing-async": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-1.0.0.tgz",
-          "integrity": "sha512-gRtHjJuULvo2dd9ybIsF+aUEamraAwet/ib3YapWdaP7QWkI8JtN/6EZBhdoqlzSVU7POrC3/rp13Or7zY7x1A==",
-          "dev": true,
-          "requires": {
-            "blakejs": "^1.1.0",
-            "buffer": "^5.4.3",
-            "err-code": "^2.0.0",
-            "js-sha3": "^0.8.0",
-            "multihashes": "^1.0.1",
-            "murmurhash3js-revisited": "^3.0.0"
-          }
-        }
       }
     },
     "ipns": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/ipns/-/ipns-0.7.4.tgz",
-      "integrity": "sha512-M1yX3oU5NSTC1fRb7GFs3RZk9b7bKxtPfDLRO5ezOVaqviTWNsZerMi/AueD9HuwTMVRhFQODRXnsOWntU0oBg==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/ipns/-/ipns-0.8.0.tgz",
+      "integrity": "sha512-DbveKyLuiO6GgZ4lILxQ3h+27dV/5MPriDTDny3/WHEaCOYH8Gs64CRP5MBQPQcsnZ2Tg+YkjnUAKX/pWAwNhA==",
       "dev": true,
       "requires": {
-        "buffer": "^5.6.0",
         "debug": "^4.1.1",
         "err-code": "^2.0.0",
-        "interface-datastore": "^1.0.2",
-        "libp2p-crypto": "^0.17.1",
+        "interface-datastore": "^2.0.0",
+        "libp2p-crypto": "^0.18.0",
         "multibase": "^3.0.0",
         "multihashes": "^3.0.1",
-        "peer-id": "^0.13.6",
-        "protons": "^1.0.1",
-        "timestamp-nano": "^1.0.0"
+        "peer-id": "^0.14.0",
+        "protons": "^2.0.0",
+        "timestamp-nano": "^1.0.0",
+        "uint8arrays": "^1.1.0"
       },
       "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "interface-datastore": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-1.0.4.tgz",
-          "integrity": "sha512-nIOP/mVwDUc7OenayUyFQB3D6c3SxDG5opTPeSrhA0jS5q0XWkf8Nz2GtNBm3wkeSKUM6iXt6LwIOCH/+jFXIQ==",
-          "dev": true,
-          "requires": {
-            "buffer": "^5.5.0",
-            "class-is": "^1.1.0",
-            "err-code": "^2.0.1",
-            "ipfs-utils": "^2.2.2",
-            "iso-random-stream": "^1.1.1",
-            "it-all": "^1.0.2",
-            "it-drain": "^1.0.1",
-            "nanoid": "^3.0.2"
-          }
-        },
         "libp2p-crypto": {
-          "version": "0.17.9",
-          "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.17.9.tgz",
-          "integrity": "sha512-nH3vTfQ4UqhZ1SORTP7HOsmFdJBs604Qy0Xi3IFFtU6ofYt+rFAZ2QNgo4MH1ZTT38/LEM374N9K7yzj1IQm0g==",
+          "version": "0.18.0",
+          "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.18.0.tgz",
+          "integrity": "sha512-zNMHDwf2J4t1LRjrBPMiSa4+14u0SfZRu66FyIVZtOnBGo3V/8imbJsOp8RPT8IgeHRN7EVIUt9lp8dcgXHMOw==",
           "dev": true,
           "requires": {
-            "buffer": "^5.5.0",
             "err-code": "^2.0.0",
             "is-typedarray": "^1.0.0",
             "iso-random-stream": "^1.1.0",
             "keypair": "^1.0.1",
-            "multibase": "^1.0.1",
-            "multicodec": "^1.0.4",
-            "multihashing-async": "^0.8.1",
+            "multibase": "^3.0.0",
+            "multicodec": "^2.0.0",
+            "multihashing-async": "^2.0.1",
             "node-forge": "^0.9.1",
             "pem-jwk": "^2.0.0",
-            "protons": "^1.2.1",
+            "protons": "^2.0.0",
             "secp256k1": "^4.0.0",
-            "uint8arrays": "^1.0.0",
+            "uint8arrays": "^1.1.0",
             "ursa-optional": "^0.10.1"
-          },
-          "dependencies": {
-            "multibase": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
-              "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
-              "dev": true,
-              "requires": {
-                "base-x": "^3.0.8",
-                "buffer": "^5.5.0"
-              }
-            }
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        },
-        "multicodec": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-1.0.4.tgz",
-          "integrity": "sha512-NDd7FeS3QamVtbgfvu5h7fd1IlbaC4EQ0/pgU4zqE2vdHCmBGsUa0TiM8/TdSeG6BMPC92OOCf8F1ocE/Wkrrg==",
-          "dev": true,
-          "requires": {
-            "buffer": "^5.6.0",
-            "varint": "^5.0.0"
           }
         },
         "node-gyp-build": {
@@ -12165,8 +10059,7 @@
     "is-circular": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-circular/-/is-circular-1.0.2.tgz",
-      "integrity": "sha512-YttjnrswnUYRVJvxCvu8z+PGMUSzC2JttP0OEXezlAEdp3EXzhf7IZ3j0gRAybJBQupedIZFhY61Tga6E0qASA==",
-      "dev": true
+      "integrity": "sha512-YttjnrswnUYRVJvxCvu8z+PGMUSzC2JttP0OEXezlAEdp3EXzhf7IZ3j0gRAybJBQupedIZFhY61Tga6E0qASA=="
     },
     "is-data-descriptor": {
       "version": "0.1.4",
@@ -12230,8 +10123,7 @@
     "is-electron": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/is-electron/-/is-electron-2.2.0.tgz",
-      "integrity": "sha512-SpMppC2XR3YdxSzczXReBjqs2zGscWQpBIKqwXYBFic0ERaxNVgwLCHwOLZeESfdJQjX0RDvrJ1lBXX2ij+G1Q==",
-      "dev": true
+      "integrity": "sha512-SpMppC2XR3YdxSzczXReBjqs2zGscWQpBIKqwXYBFic0ERaxNVgwLCHwOLZeESfdJQjX0RDvrJ1lBXX2ij+G1Q=="
     },
     "is-empty": {
       "version": "1.2.0",
@@ -12322,93 +10214,23 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/is-ip/-/is-ip-3.1.0.tgz",
       "integrity": "sha512-35vd5necO7IitFPjd/YBeqwWnyDWbuLH9ZXQdMfDA8TEo7pv5X8yfrvVO3xbJbLUlERCMvf6X0hTUamQxCYJ9Q==",
-      "dev": true,
       "requires": {
         "ip-regex": "^4.0.0"
       }
     },
     "is-ipfs": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/is-ipfs/-/is-ipfs-1.0.3.tgz",
-      "integrity": "sha512-7SAfhxp39rxMvr95qjHMtsle1xa7zXpIbhX/Q77iXKtMVnQ0Fr9AVpAUq+bl3HPXGXDpZJFP0hzWBZaMwD6vGg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-ipfs/-/is-ipfs-2.0.0.tgz",
+      "integrity": "sha512-X4Cg/JO+h/ygBCrIQSMgicHRLo5QpB+i5tHLhFgGBksKi3zvX6ByFCshDxNBvcq4NFxF3coI2AaLqwzugNzKcw==",
       "dev": true,
       "requires": {
-        "buffer": "^5.6.0",
-        "cids": "~0.8.0",
+        "cids": "^1.0.0",
         "iso-url": "~0.4.7",
-        "mafmt": "^7.1.0",
-        "multiaddr": "^7.4.3",
-        "multibase": "~0.7.0",
-        "multihashes": "~0.4.19"
-      },
-      "dependencies": {
-        "cids": {
-          "version": "0.8.3",
-          "resolved": "https://registry.npmjs.org/cids/-/cids-0.8.3.tgz",
-          "integrity": "sha512-yoXTbV3llpm+EBGWKeL9xKtksPE/s6DPoDSY4fn8I8TEW1zehWXPSB0pwAXVDlLaOlrw+sNynj995uD9abmPhA==",
-          "dev": true,
-          "requires": {
-            "buffer": "^5.6.0",
-            "class-is": "^1.1.0",
-            "multibase": "^1.0.0",
-            "multicodec": "^1.0.1",
-            "multihashes": "^1.0.1"
-          },
-          "dependencies": {
-            "multibase": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
-              "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
-              "dev": true,
-              "requires": {
-                "base-x": "^3.0.8",
-                "buffer": "^5.5.0"
-              }
-            },
-            "multihashes": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
-              "integrity": "sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==",
-              "dev": true,
-              "requires": {
-                "buffer": "^5.6.0",
-                "multibase": "^1.0.1",
-                "varint": "^5.0.0"
-              }
-            }
-          }
-        },
-        "multibase": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.7.0.tgz",
-          "integrity": "sha512-TW8q03O0f6PNFTQDvh3xxH03c8CjGaaYrjkl9UQPG6rz53TQzzxJVCIWVjzcbN/Q5Y53Zd0IBQBMVktVgNx4Fg==",
-          "dev": true,
-          "requires": {
-            "base-x": "^3.0.8",
-            "buffer": "^5.5.0"
-          }
-        },
-        "multicodec": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-1.0.4.tgz",
-          "integrity": "sha512-NDd7FeS3QamVtbgfvu5h7fd1IlbaC4EQ0/pgU4zqE2vdHCmBGsUa0TiM8/TdSeG6BMPC92OOCf8F1ocE/Wkrrg==",
-          "dev": true,
-          "requires": {
-            "buffer": "^5.6.0",
-            "varint": "^5.0.0"
-          }
-        },
-        "multihashes": {
-          "version": "0.4.21",
-          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-0.4.21.tgz",
-          "integrity": "sha512-uVSvmeCWf36pU2nB4/1kzYZjsXD9vofZKpgudqkceYY5g2aZZXJ5r9lxuzoRLl1OAp28XljXsEJ/X/85ZsKmKw==",
-          "dev": true,
-          "requires": {
-            "buffer": "^5.5.0",
-            "multibase": "^0.7.0",
-            "varint": "^5.0.0"
-          }
-        }
+        "mafmt": "^8.0.0",
+        "multiaddr": "^8.0.0",
+        "multibase": "^3.0.0",
+        "multihashes": "^3.0.1",
+        "uint8arrays": "^1.1.0"
       }
     },
     "is-map": {
@@ -12450,10 +10272,9 @@
       "dev": true
     },
     "is-plain-obj": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
-      "dev": true
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA=="
     },
     "is-plain-object": {
       "version": "2.0.4",
@@ -12577,8 +10398,7 @@
     "iso-constants": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/iso-constants/-/iso-constants-0.1.2.tgz",
-      "integrity": "sha512-OTCM5ZCQsHBCI4Wdu4tSxvDIkmDHd5EwJDps5mKqnQnWJSKlnwMs3EDZ4n3Fh1tmkWkDlyd2vCDbEYuPbyrUNQ==",
-      "dev": true
+      "integrity": "sha512-OTCM5ZCQsHBCI4Wdu4tSxvDIkmDHd5EwJDps5mKqnQnWJSKlnwMs3EDZ4n3Fh1tmkWkDlyd2vCDbEYuPbyrUNQ=="
     },
     "iso-random-stream": {
       "version": "1.1.1",
@@ -12592,8 +10412,7 @@
     "iso-url": {
       "version": "0.4.7",
       "resolved": "https://registry.npmjs.org/iso-url/-/iso-url-0.4.7.tgz",
-      "integrity": "sha512-27fFRDnPAMnHGLq36bWTpKET+eiXct3ENlCcdcMdk+mjXrb2kw3mhBUg1B7ewAC0kVzlOPhADzQgz1SE6Tglog==",
-      "dev": true
+      "integrity": "sha512-27fFRDnPAMnHGLq36bWTpKET+eiXct3ENlCcdcMdk+mjXrb2kw3mhBUg1B7ewAC0kVzlOPhADzQgz1SE6Tglog=="
     },
     "isobject": {
       "version": "2.1.0",
@@ -12684,21 +10503,6 @@
         "source-map": "^0.6.1"
       },
       "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        },
         "rimraf": {
           "version": "2.7.1",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
@@ -12726,15 +10530,14 @@
       }
     },
     "it-all": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/it-all/-/it-all-1.0.2.tgz",
-      "integrity": "sha512-3hrCLLcuHS1/VUn1qETPuh9rFTw31SBCUUijjs41VJ+oQGx3H+3Lpxo1bFD3q3570w3o99a+sfRGic5PBBt3Vg==",
-      "dev": true
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/it-all/-/it-all-1.0.4.tgz",
+      "integrity": "sha512-7K+gjHHzZ7t+bCkrtulYiow35k3UgqH7miC+iUa9RGiyDRXJ6hVDeFsDrnWrlscjrkLFOJRKHxNOke4FNoQnhw=="
     },
     "it-batch": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/it-batch/-/it-batch-1.0.4.tgz",
-      "integrity": "sha512-hZ+gaj5MaECauRd+Ahvo9iAxg90YGVBg7AZ32wOeXJ08IRjfQRMSnZ9oA0JjNeJeSGuVjWf91UUD5y2SYmKlwQ==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/it-batch/-/it-batch-1.0.6.tgz",
+      "integrity": "sha512-W17vOT8tZTaPMw2NcXItBIAglBz3JxNdXE0+zgqPGMk6zrEb5YF+sAn+PuNed7R6Fsnp8IKDr1sa76GL8Cp52g==",
       "dev": true
     },
     "it-buffer": {
@@ -12751,28 +10554,26 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/it-concat/-/it-concat-1.0.1.tgz",
       "integrity": "sha512-ca7tnIqSpPycty9K+x08OwFj9kLSrsXgENn7ry2mNXlFlUkgEZe1/xvBjwnUlUEHvnITMj4Mq7ozPm1VaOm8FQ==",
-      "dev": true,
       "requires": {
         "bl": "^4.0.0"
       }
     },
     "it-drain": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/it-drain/-/it-drain-1.0.1.tgz",
-      "integrity": "sha512-4aX8AsJWjRh0inNXGLa90fvxuB7vQY70WFasvskUMtpXXz8+MUH8R7PODBtn4yXCJ25ud2iRwWwa1g8DRDbrlA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/it-drain/-/it-drain-1.0.3.tgz",
+      "integrity": "sha512-KxwHBEpWW+0/EkGCOPR2MaHanvBW2A76tOC5CiitoJGLd8J56FxM6jJX3uow20v5qMidX5lnKgwH5oCIyYDszQ==",
       "dev": true
     },
     "it-first": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/it-first/-/it-first-1.0.2.tgz",
-      "integrity": "sha512-hU5ObR14987PR7l0J7dfWAgKYiWoKbXcoXKqhQDGgHSZML6UPmHSS9ILBGucZkoA2B152kEqEOllS4tVQq11fg==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/it-first/-/it-first-1.0.4.tgz",
+      "integrity": "sha512-L5ZB5k3Ol5ouAzLHo6fOCtByOy2lNjteNJpZLkE+VgmRt0MbC1ibmBW1AbOt6WzDx/QXFG5C8EEvY2nTXHg+Hw==",
       "dev": true
     },
     "it-glob": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/it-glob/-/it-glob-0.0.8.tgz",
       "integrity": "sha512-PmIAgb64aJPM6wwT1UTlNDAJnNgdGrvr0vRr3AYCngcUuq1KaAovuz0dQAmUkaXudDG3EQzc7OttuLW9DaL3YQ==",
-      "dev": true,
       "requires": {
         "fs-extra": "^8.1.0",
         "minimatch": "^3.0.4"
@@ -12782,7 +10583,6 @@
           "version": "8.1.0",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
           "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-          "dev": true,
           "requires": {
             "graceful-fs": "^4.2.0",
             "jsonfile": "^4.0.0",
@@ -12793,7 +10593,6 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
           "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-          "dev": true,
           "requires": {
             "graceful-fs": "^4.1.6"
           }
@@ -12801,8 +10600,7 @@
         "universalify": {
           "version": "0.1.2",
           "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-          "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-          "dev": true
+          "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
         }
       }
     },
@@ -12827,10 +10625,9 @@
       }
     },
     "it-last": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/it-last/-/it-last-1.0.2.tgz",
-      "integrity": "sha512-zjWiVvkDXKxGA+u2ZNzq321RWnj52RLucsIX0Bve3NUX3X/b1RjtUufvUdjtkFtQLKG1yCf5+hxbdeIYiRT1rQ==",
-      "dev": true
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/it-last/-/it-last-1.0.4.tgz",
+      "integrity": "sha512-h0aV43BaD+1nubAKwStWcda6vlbejPSTQKfOrQvyNrrceluWfoq8DrBXnL0PSz6RkyHSiVSHtAEaqUijYMPo8Q=="
     },
     "it-length": {
       "version": "0.0.2",
@@ -12851,15 +10648,14 @@
       }
     },
     "it-map": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/it-map/-/it-map-1.0.2.tgz",
-      "integrity": "sha512-WTy7ZK4MDo5B9JgcGz2VLwDxqItUHzv8Mg0YzVM7jhcqY8EdjUuMoAcL7PqzJed+TMy/AYorw47Muc87sdD4sA==",
-      "dev": true
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/it-map/-/it-map-1.0.4.tgz",
+      "integrity": "sha512-LZgYdb89XMo8cFUp6jF0cn5j3gF7wcZnKRVFS3qHHn0bPB2rpToh2vIkTBKduZLZxRRjWx1VW/udd98x+j2ulg=="
     },
     "it-multipart": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/it-multipart/-/it-multipart-1.0.3.tgz",
-      "integrity": "sha512-8PSjOl5OSx2fCbBJ73uV4ZVMY0Q/yCQrWHNk6XYXYDwByH5rnSBYEyuSSiOM2grDLY39atybbKTbMi3GWEbACA==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/it-multipart/-/it-multipart-1.0.5.tgz",
+      "integrity": "sha512-HW0/ycdwqM1Xz1cwkBUwmU2HTxrJrUdVZBIgX5/fNzEjIgbnL3oZUysG2NeKNbIA0vt4wnqLK6fAps/nvQ0AbA==",
       "dev": true,
       "requires": {
         "buffer": "^5.5.0",
@@ -12877,12 +10673,12 @@
       }
     },
     "it-parallel-batch": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/it-parallel-batch/-/it-parallel-batch-1.0.4.tgz",
-      "integrity": "sha512-YyIa0urQO7C/YmWaKAXILv7glvvsfM9jsL+u1CUQxyO8vslLyv9i3LT8AFC55Y9r6xT3A4jK9FhaXND2NmcPFw==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/it-parallel-batch/-/it-parallel-batch-1.0.6.tgz",
+      "integrity": "sha512-ym2o1bZHZAl2euR79ojKsvVJt77DGQrmSTgDf+g3ERF/Agp2+VI9VM3ikQ9T1BBdgbSIylPeatNGMIyZgz7J7g==",
       "dev": true,
       "requires": {
-        "it-batch": "^1.0.4"
+        "it-batch": "^1.0.6"
       }
     },
     "it-pb-rpc": {
@@ -12907,8 +10703,7 @@
     "it-peekable": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/it-peekable/-/it-peekable-0.0.1.tgz",
-      "integrity": "sha512-fd0JzbNldseeq+FFWthbqYB991UpKNyjPG6LqFhIOmJviCxSompMyoopKIXvLPLY+fBhhv2CT5PT31O/lEnTHw==",
-      "dev": true
+      "integrity": "sha512-fd0JzbNldseeq+FFWthbqYB991UpKNyjPG6LqFhIOmJviCxSompMyoopKIXvLPLY+fBhhv2CT5PT31O/lEnTHw=="
     },
     "it-pipe": {
       "version": "1.1.0",
@@ -12939,7 +10734,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/it-reader/-/it-reader-2.1.0.tgz",
       "integrity": "sha512-hSysqWTO9Tlwc5EGjVf8JYZzw0D2FsxD/g+eNNWrez9zODxWt6QlN6JAMmycK72Mv4jHEKEXoyzUN4FYGmJaZw==",
-      "dev": true,
       "requires": {
         "bl": "^4.0.0"
       }
@@ -12948,7 +10742,6 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/it-tar/-/it-tar-1.2.2.tgz",
       "integrity": "sha512-M8V4a9I+x/vwXTjqvixcEZbQZHjwDIb8iUQ+D4M2QbhAdNs3WKVSl+45u5/F2XFx6jYMFOGzMVlKNK/uONgNIA==",
-      "dev": true,
       "requires": {
         "bl": "^4.0.0",
         "buffer": "^5.4.3",
@@ -12959,10 +10752,9 @@
       }
     },
     "it-to-buffer": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/it-to-buffer/-/it-to-buffer-1.0.2.tgz",
-      "integrity": "sha512-mTuceNC6deSbANZSQFxNRwFlVPvIZkjzxX10mOBxgzzhBGOkih2+OkOyGbhhcGNu/jxd4hk8qkjjOipx+tNIGA==",
-      "dev": true,
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/it-to-buffer/-/it-to-buffer-1.0.4.tgz",
+      "integrity": "sha512-wycpGeAdQ8WH8eSBkMHN/HMNiQ0Y88XEXo6s6LGJbQZjf9K7ppVzUfCXn7OnxFfUPN0HTWZr+uhthwtrwMTTfw==",
       "requires": {
         "buffer": "^5.5.0"
       }
@@ -13042,44 +10834,6 @@
         "@hapi/hoek": "^9.0.0",
         "@hapi/pinpoint": "^2.0.0",
         "@hapi/topo": "^5.0.0"
-      },
-      "dependencies": {
-        "@hapi/address": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/@hapi/address/-/address-4.1.0.tgz",
-          "integrity": "sha512-SkszZf13HVgGmChdHo/PxchnSaCJ6cetVqLzyciudzZRT0jcOouIF/Q93mgjw8cce+D+4F4C1Z/WrfFN+O3VHQ==",
-          "dev": true,
-          "requires": {
-            "@hapi/hoek": "^9.0.0"
-          }
-        },
-        "@hapi/formula": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/@hapi/formula/-/formula-2.0.0.tgz",
-          "integrity": "sha512-V87P8fv7PI0LH7LiVi8Lkf3x+KCO7pQozXRssAHNXXL9L1K+uyu4XypLXwxqVDKgyQai6qj3/KteNlrqDx4W5A==",
-          "dev": true
-        },
-        "@hapi/hoek": {
-          "version": "9.1.0",
-          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.1.0.tgz",
-          "integrity": "sha512-i9YbZPN3QgfighY/1X1Pu118VUz2Fmmhd6b2n0/O8YVgGGfw0FbUYoA97k7FkpGJ+pLCFEDLUmAPPV4D1kpeFw==",
-          "dev": true
-        },
-        "@hapi/pinpoint": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/@hapi/pinpoint/-/pinpoint-2.0.0.tgz",
-          "integrity": "sha512-vzXR5MY7n4XeIvLpfl3HtE3coZYO4raKXW766R6DZw/6aLqR26iuZ109K7a0NtF2Db0jxqh7xz2AxkUwpUFybw==",
-          "dev": true
-        },
-        "@hapi/topo": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.0.0.tgz",
-          "integrity": "sha512-tFJlT47db0kMqVm3H4nQYgn6Pwg10GTZHb1pwmSiv1K4ks6drQOtfEF5ZnPjkvC+y4/bUPHK+bc87QvLcL+WMw==",
-          "dev": true,
-          "requires": {
-            "@hapi/hoek": "^9.0.0"
-          }
-        }
       }
     },
     "joycon": {
@@ -13186,7 +10940,6 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/json-text-sequence/-/json-text-sequence-0.1.1.tgz",
       "integrity": "sha1-py8hfcSvxGKf/1/rME3BvVGi89I=",
-      "dev": true,
       "requires": {
         "delimit-stream": "0.1.0"
       }
@@ -13304,7 +11057,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.0.1.tgz",
       "integrity": "sha512-jR2b5v7d2vIOust+w3wtFKZIfpC2pnRmFAhAC/BuweZFQR8qZzxH1OyrQ10HmdVYiXWkYUqPVsz91cG7EL2FBg==",
-      "dev": true,
       "requires": {
         "graceful-fs": "^4.1.6",
         "universalify": "^1.0.0"
@@ -13374,9 +11126,9 @@
       "dev": true
     },
     "just-extend": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.1.0.tgz",
-      "integrity": "sha512-ApcjaOdVTJ7y4r08xI5wIqpvwS48Q0PBG4DJROcEkH1f8MdAiNFyFxz3xoL0LWAVwjrwPYZdVHHxhRHcx/uGLA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.1.1.tgz",
+      "integrity": "sha512-aWgeGFW67BP3e5181Ep1Fv2v8z//iBJfrvyTnq8wG86vEESwmonn1zPBJ0VfmT9CJq2FIT0VsETtrNFm2a+SHA==",
       "dev": true
     },
     "just-safe-get": {
@@ -13463,6 +11215,15 @@
         "v8flags": "^2.0.2"
       },
       "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
         "isarray": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
@@ -13497,6 +11258,12 @@
               "dev": true
             }
           }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
         },
         "readable-stream": {
           "version": "1.1.14",
@@ -13930,9 +11697,9 @@
       }
     },
     "libp2p": {
-      "version": "0.28.10",
-      "resolved": "https://registry.npmjs.org/libp2p/-/libp2p-0.28.10.tgz",
-      "integrity": "sha512-0WR86vPj3RIEP7jFWBy1J4GBp8wweC1pmzy5nfKZazP22wA/crqqnxcr4xGs/7lzFyfBJuqRIswz3/IrlgO+ag==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/libp2p/-/libp2p-0.29.0.tgz",
+      "integrity": "sha512-eALoJ0vpsonRwzLpdPY2/272RIl2MImIg2QToqLb+wBChcSQFB4U/r3LU8rZqEaDfRNupOBG/rx67gJTWC0h2Q==",
       "dev": true,
       "requires": {
         "abort-controller": "^3.0.0",
@@ -13944,7 +11711,7 @@
         "err-code": "^2.0.0",
         "events": "^3.1.0",
         "hashlru": "^2.3.0",
-        "interface-datastore": "^1.0.4",
+        "interface-datastore": "^2.0.0",
         "ipfs-utils": "^2.2.0",
         "it-all": "^1.0.1",
         "it-buffer": "^0.1.2",
@@ -13952,99 +11719,105 @@
         "it-length-prefixed": "^3.0.1",
         "it-pipe": "^1.1.0",
         "it-protocol-buffers": "^0.2.0",
-        "libp2p-crypto": "^0.17.9",
-        "libp2p-interfaces": "^0.3.1",
-        "libp2p-utils": "^0.1.2",
-        "mafmt": "^7.0.0",
+        "libp2p-crypto": "^0.18.0",
+        "libp2p-interfaces": "^0.5.1",
+        "libp2p-utils": "^0.2.0",
+        "mafmt": "^8.0.0",
         "merge-options": "^2.0.0",
         "moving-average": "^1.0.0",
-        "multiaddr": "^7.4.3",
-        "multistream-select": "^0.15.0",
+        "multiaddr": "^8.0.0",
+        "multicodec": "^2.0.0",
+        "multistream-select": "^1.0.0",
         "mutable-proxy": "^1.0.0",
         "node-forge": "^0.9.1",
         "p-any": "^3.0.0",
         "p-fifo": "^1.0.0",
         "p-settle": "^4.0.1",
-        "peer-id": "^0.13.11",
-        "protons": "^1.0.1",
+        "peer-id": "^0.14.0",
+        "protons": "^2.0.0",
         "retimer": "^2.0.0",
         "sanitize-filename": "^1.6.3",
-        "streaming-iterables": "^4.1.0",
-        "timeout-abort-controller": "^1.0.0",
+        "streaming-iterables": "^5.0.2",
+        "timeout-abort-controller": "^1.1.1",
+        "varint": "^5.0.0",
         "xsalsa20": "^1.0.2"
       },
       "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+        "ipfs-utils": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-2.4.0.tgz",
+          "integrity": "sha512-0RH8rMIEhrXyrbh87V8SQC6E6/5EJs+YionqZGAXnVoTzkpFhxC3x3FlsxwZ9s72yaieGP1Mx1tRYgfCFM/mJg==",
           "dev": true,
           "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "interface-datastore": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-1.0.4.tgz",
-          "integrity": "sha512-nIOP/mVwDUc7OenayUyFQB3D6c3SxDG5opTPeSrhA0jS5q0XWkf8Nz2GtNBm3wkeSKUM6iXt6LwIOCH/+jFXIQ==",
-          "dev": true,
-          "requires": {
-            "buffer": "^5.5.0",
-            "class-is": "^1.1.0",
-            "err-code": "^2.0.1",
-            "ipfs-utils": "^2.2.2",
-            "iso-random-stream": "^1.1.1",
-            "it-all": "^1.0.2",
-            "it-drain": "^1.0.1",
-            "nanoid": "^3.0.2"
+            "abort-controller": "^3.0.0",
+            "any-signal": "^1.1.0",
+            "buffer": "^5.6.0",
+            "err-code": "^2.0.0",
+            "fs-extra": "^9.0.1",
+            "is-electron": "^2.2.0",
+            "iso-url": "^0.4.7",
+            "it-glob": "0.0.8",
+            "it-to-stream": "^0.1.2",
+            "merge-options": "^2.0.0",
+            "nanoid": "^3.1.3",
+            "node-fetch": "^2.6.0",
+            "stream-to-it": "^0.2.0"
           }
         },
         "libp2p-crypto": {
-          "version": "0.17.9",
-          "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.17.9.tgz",
-          "integrity": "sha512-nH3vTfQ4UqhZ1SORTP7HOsmFdJBs604Qy0Xi3IFFtU6ofYt+rFAZ2QNgo4MH1ZTT38/LEM374N9K7yzj1IQm0g==",
+          "version": "0.18.0",
+          "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.18.0.tgz",
+          "integrity": "sha512-zNMHDwf2J4t1LRjrBPMiSa4+14u0SfZRu66FyIVZtOnBGo3V/8imbJsOp8RPT8IgeHRN7EVIUt9lp8dcgXHMOw==",
           "dev": true,
           "requires": {
-            "buffer": "^5.5.0",
             "err-code": "^2.0.0",
             "is-typedarray": "^1.0.0",
             "iso-random-stream": "^1.1.0",
             "keypair": "^1.0.1",
-            "multibase": "^1.0.1",
-            "multicodec": "^1.0.4",
-            "multihashing-async": "^0.8.1",
+            "multibase": "^3.0.0",
+            "multicodec": "^2.0.0",
+            "multihashing-async": "^2.0.1",
             "node-forge": "^0.9.1",
             "pem-jwk": "^2.0.0",
-            "protons": "^1.2.1",
+            "protons": "^2.0.0",
             "secp256k1": "^4.0.0",
-            "uint8arrays": "^1.0.0",
+            "uint8arrays": "^1.1.0",
             "ursa-optional": "^0.10.1"
           }
         },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        },
-        "multibase": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
-          "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
+        "libp2p-interfaces": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/libp2p-interfaces/-/libp2p-interfaces-0.5.1.tgz",
+          "integrity": "sha512-mqu8kN5KppDjRIzdOZqg7yEMwLJOxFGDpdXhvTq4obephTIusW4lLSunst7C5VVSN6UE0SSVliN0tHvyW8tpag==",
           "dev": true,
           "requires": {
-            "base-x": "^3.0.8",
-            "buffer": "^5.5.0"
-          }
-        },
-        "multicodec": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-1.0.4.tgz",
-          "integrity": "sha512-NDd7FeS3QamVtbgfvu5h7fd1IlbaC4EQ0/pgU4zqE2vdHCmBGsUa0TiM8/TdSeG6BMPC92OOCf8F1ocE/Wkrrg==",
-          "dev": true,
-          "requires": {
-            "buffer": "^5.6.0",
-            "varint": "^5.0.0"
+            "abort-controller": "^3.0.0",
+            "abortable-iterator": "^3.0.0",
+            "chai": "^4.2.0",
+            "chai-checkmark": "^1.0.1",
+            "class-is": "^1.1.0",
+            "debug": "^4.1.1",
+            "delay": "^4.3.0",
+            "detect-node": "^2.0.4",
+            "dirty-chai": "^2.0.1",
+            "err-code": "^2.0.0",
+            "it-goodbye": "^2.0.1",
+            "it-length-prefixed": "^3.1.0",
+            "it-pair": "^1.0.0",
+            "it-pipe": "^1.1.0",
+            "it-pushable": "^1.4.0",
+            "libp2p-crypto": "^0.18.0",
+            "libp2p-tcp": "^0.15.0",
+            "multiaddr": "^8.0.0",
+            "multibase": "^3.0.0",
+            "p-defer": "^3.0.0",
+            "p-limit": "^2.3.0",
+            "p-wait-for": "^3.1.0",
+            "peer-id": "^0.14.0",
+            "protons": "^2.0.0",
+            "sinon": "^9.0.2",
+            "streaming-iterables": "^5.0.2",
+            "uint8arrays": "^1.1.0"
           }
         },
         "node-gyp-build": {
@@ -14063,42 +11836,19 @@
             "node-addon-api": "^2.0.0",
             "node-gyp-build": "^4.2.0"
           }
-        },
-        "streaming-iterables": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/streaming-iterables/-/streaming-iterables-4.1.2.tgz",
-          "integrity": "sha512-IzhmKnQ2thkNMUcaGsjedrxdAoXPhtIFn8hUlmSqSqafa2p0QmZudu6ImG7ckvPNfazpMfr6Ef8cxUWyIyxpxA==",
-          "dev": true
         }
       }
     },
     "libp2p-bootstrap": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/libp2p-bootstrap/-/libp2p-bootstrap-0.11.0.tgz",
-      "integrity": "sha512-vLMmCJsecnHdR9pPUxvOimtnZdOfGXv4EImNB+Y0DKX3LUSyzb868N5oWCGhKMxDwt2Nm6/7Vl/Vd+eHnsU79g==",
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/libp2p-bootstrap/-/libp2p-bootstrap-0.12.1.tgz",
+      "integrity": "sha512-atHXxfxE8isHb+XKHsJ5UgFMteqfi0Xal94h+2EAJmobXcIq1mBMUeIgmkHMsaZZNwJwQxq6MKFthJngWJ8vEw==",
       "dev": true,
       "requires": {
         "debug": "^4.1.1",
-        "mafmt": "^7.0.0",
-        "multiaddr": "^7.2.1",
-        "peer-id": "^0.13.5"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        }
+        "mafmt": "^8.0.0",
+        "multiaddr": "^8.0.0",
+        "peer-id": "^0.14.0"
       }
     },
     "libp2p-crypto": {
@@ -14154,6 +11904,17 @@
             "murmurhash3js": "^3.0.1",
             "nodeify": "^1.0.1"
           }
+        },
+        "protons": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/protons/-/protons-1.2.1.tgz",
+          "integrity": "sha512-2oqDyc/SN+tNcJf8XxrXhYL7sQn2/OMl8mSdD7NVGsWjMEmAbks4eDVnCyf0vAoRbBWyWTEXWk4D8XfuKVl3zg==",
+          "requires": {
+            "buffer": "^5.5.0",
+            "protocol-buffers-schema": "^3.3.1",
+            "signed-varint": "^2.0.1",
+            "varint": "^5.0.0"
+          }
         }
       }
     },
@@ -14204,137 +11965,214 @@
       }
     },
     "libp2p-delegated-content-routing": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/libp2p-delegated-content-routing/-/libp2p-delegated-content-routing-0.5.0.tgz",
-      "integrity": "sha512-ag5gt752n0TynbRsQN1JMF0FzSdMpHOprNdVm6vq/rsz/8wMGh9WxN+a1Zp9VoPp5rGHe7LTom13ziFf1Z/Nyg==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/libp2p-delegated-content-routing/-/libp2p-delegated-content-routing-0.7.0.tgz",
+      "integrity": "sha512-eyh6ckCJvAuH+dSI6lKrZ6JLdxazpPUpd2NbRcgmgb6sfpTyFaxhqMa5FHz304mX2FsvE3pX91pTShcL9Aitjg==",
       "dev": true,
       "requires": {
         "debug": "^4.1.1",
         "it-all": "^1.0.0",
-        "multiaddr": "^7.4.3",
+        "multiaddr": "^8.0.0",
         "p-defer": "^3.0.0",
         "p-queue": "^6.2.1"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        }
       }
     },
     "libp2p-delegated-peer-routing": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/libp2p-delegated-peer-routing/-/libp2p-delegated-peer-routing-0.5.0.tgz",
-      "integrity": "sha512-crnVXH56bTj0hqqsEb4xmfrZrdIxOBqnFp2D19inxTVwZtpg/Je1XJZDGSG2JJ2EnXxFGTNPFHcB5AIm8avDEg==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/libp2p-delegated-peer-routing/-/libp2p-delegated-peer-routing-0.7.0.tgz",
+      "integrity": "sha512-bdSnCRts+AMlUv592ZITot+vels1UYQc4WMg8/y+gur1ifEE6GeGWnxneJyCuuzrrjmo2Svr4yY72kuMev+wVQ==",
       "dev": true,
       "requires": {
+        "cids": "^1.0.0",
         "debug": "^4.1.1",
+        "p-defer": "^3.0.0",
         "p-queue": "^6.3.0",
-        "peer-id": "^0.13.11"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        }
+        "peer-id": "^0.14.0"
       }
     },
     "libp2p-floodsub": {
-      "version": "0.21.3",
-      "resolved": "https://registry.npmjs.org/libp2p-floodsub/-/libp2p-floodsub-0.21.3.tgz",
-      "integrity": "sha512-TTehsDd5kZos27qmugmviF9GvzfyH8Tq2/YNBpp7Ku1KoSZugcdQAhz8hmStMtMGDkW5ysoKSBG739IhHUtgdg==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/libp2p-floodsub/-/libp2p-floodsub-0.23.1.tgz",
+      "integrity": "sha512-d5Hl055SV3bkJ2u+bsRp+iWBsg1rVq2CehW2TYq4zoIp/bCGQyY/oQF6NzqnysKloElgRACfWOa/oQBRaSZFng==",
       "dev": true,
       "requires": {
-        "async.nexttick": "^0.5.2",
-        "buffer": "^5.6.0",
         "debug": "^4.1.1",
-        "it-length-prefixed": "^3.0.0",
-        "it-pipe": "^1.0.1",
-        "libp2p-pubsub": "~0.5.2",
-        "p-map": "^4.0.0",
-        "peer-id": "~0.13.3",
-        "protons": "^1.0.1",
-        "time-cache": "^0.3.0"
+        "libp2p-interfaces": "^0.5.1",
+        "time-cache": "^0.3.0",
+        "uint8arrays": "^1.1.0"
       },
       "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+        "libp2p-crypto": {
+          "version": "0.18.0",
+          "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.18.0.tgz",
+          "integrity": "sha512-zNMHDwf2J4t1LRjrBPMiSa4+14u0SfZRu66FyIVZtOnBGo3V/8imbJsOp8RPT8IgeHRN7EVIUt9lp8dcgXHMOw==",
           "dev": true,
           "requires": {
-            "ms": "^2.1.1"
+            "err-code": "^2.0.0",
+            "is-typedarray": "^1.0.0",
+            "iso-random-stream": "^1.1.0",
+            "keypair": "^1.0.1",
+            "multibase": "^3.0.0",
+            "multicodec": "^2.0.0",
+            "multihashing-async": "^2.0.1",
+            "node-forge": "^0.9.1",
+            "pem-jwk": "^2.0.0",
+            "protons": "^2.0.0",
+            "secp256k1": "^4.0.0",
+            "uint8arrays": "^1.1.0",
+            "ursa-optional": "^0.10.1"
           }
         },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+        "libp2p-interfaces": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/libp2p-interfaces/-/libp2p-interfaces-0.5.1.tgz",
+          "integrity": "sha512-mqu8kN5KppDjRIzdOZqg7yEMwLJOxFGDpdXhvTq4obephTIusW4lLSunst7C5VVSN6UE0SSVliN0tHvyW8tpag==",
+          "dev": true,
+          "requires": {
+            "abort-controller": "^3.0.0",
+            "abortable-iterator": "^3.0.0",
+            "chai": "^4.2.0",
+            "chai-checkmark": "^1.0.1",
+            "class-is": "^1.1.0",
+            "debug": "^4.1.1",
+            "delay": "^4.3.0",
+            "detect-node": "^2.0.4",
+            "dirty-chai": "^2.0.1",
+            "err-code": "^2.0.0",
+            "it-goodbye": "^2.0.1",
+            "it-length-prefixed": "^3.1.0",
+            "it-pair": "^1.0.0",
+            "it-pipe": "^1.1.0",
+            "it-pushable": "^1.4.0",
+            "libp2p-crypto": "^0.18.0",
+            "libp2p-tcp": "^0.15.0",
+            "multiaddr": "^8.0.0",
+            "multibase": "^3.0.0",
+            "p-defer": "^3.0.0",
+            "p-limit": "^2.3.0",
+            "p-wait-for": "^3.1.0",
+            "peer-id": "^0.14.0",
+            "protons": "^2.0.0",
+            "sinon": "^9.0.2",
+            "streaming-iterables": "^5.0.2",
+            "uint8arrays": "^1.1.0"
+          }
+        },
+        "node-gyp-build": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.3.tgz",
+          "integrity": "sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg==",
           "dev": true
+        },
+        "secp256k1": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.2.tgz",
+          "integrity": "sha512-UDar4sKvWAksIlfX3xIaQReADn+WFnHvbVujpcbr+9Sf/69odMwy2MUsz5CKLQgX9nsIyrjuxL2imVyoNHa3fg==",
+          "dev": true,
+          "requires": {
+            "elliptic": "^6.5.2",
+            "node-addon-api": "^2.0.0",
+            "node-gyp-build": "^4.2.0"
+          }
         }
       }
     },
     "libp2p-gossipsub": {
-      "version": "0.4.7",
-      "resolved": "https://registry.npmjs.org/libp2p-gossipsub/-/libp2p-gossipsub-0.4.7.tgz",
-      "integrity": "sha512-TW5uC3afNpDSp9Dm2K9zPa9Lfjjgm5UAVQPC1gWEm7VINBGZ/az54088UAL+S4RPMg9xykJX6Cn0wk07Wd0r5A==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/libp2p-gossipsub/-/libp2p-gossipsub-0.6.1.tgz",
+      "integrity": "sha512-gwmRlS//Zz1nYuq4BfOsV3yg27i++uXihnteF5RztqRz6FqrRd0JsID32HtzD+LQ93PGTB457sxuOOpDvXLapQ==",
       "dev": true,
       "requires": {
-        "buffer": "^5.6.0",
+        "@types/debug": "^4.1.5",
         "debug": "^4.1.1",
+        "denque": "^1.4.1",
         "err-code": "^2.0.0",
-        "it-length-prefixed": "^3.0.0",
         "it-pipe": "^1.0.1",
-        "libp2p-pubsub": "~0.5.2",
-        "p-map": "^4.0.0",
-        "peer-id": "~0.13.12",
-        "protons": "^1.0.1",
+        "libp2p-interfaces": "^0.5.1",
+        "peer-id": "^0.14.0",
+        "protons": "^2.0.0",
         "time-cache": "^0.3.0"
       },
       "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+        "libp2p-crypto": {
+          "version": "0.18.0",
+          "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.18.0.tgz",
+          "integrity": "sha512-zNMHDwf2J4t1LRjrBPMiSa4+14u0SfZRu66FyIVZtOnBGo3V/8imbJsOp8RPT8IgeHRN7EVIUt9lp8dcgXHMOw==",
           "dev": true,
           "requires": {
-            "ms": "^2.1.1"
+            "err-code": "^2.0.0",
+            "is-typedarray": "^1.0.0",
+            "iso-random-stream": "^1.1.0",
+            "keypair": "^1.0.1",
+            "multibase": "^3.0.0",
+            "multicodec": "^2.0.0",
+            "multihashing-async": "^2.0.1",
+            "node-forge": "^0.9.1",
+            "pem-jwk": "^2.0.0",
+            "protons": "^2.0.0",
+            "secp256k1": "^4.0.0",
+            "uint8arrays": "^1.1.0",
+            "ursa-optional": "^0.10.1"
           }
         },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+        "libp2p-interfaces": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/libp2p-interfaces/-/libp2p-interfaces-0.5.1.tgz",
+          "integrity": "sha512-mqu8kN5KppDjRIzdOZqg7yEMwLJOxFGDpdXhvTq4obephTIusW4lLSunst7C5VVSN6UE0SSVliN0tHvyW8tpag==",
+          "dev": true,
+          "requires": {
+            "abort-controller": "^3.0.0",
+            "abortable-iterator": "^3.0.0",
+            "chai": "^4.2.0",
+            "chai-checkmark": "^1.0.1",
+            "class-is": "^1.1.0",
+            "debug": "^4.1.1",
+            "delay": "^4.3.0",
+            "detect-node": "^2.0.4",
+            "dirty-chai": "^2.0.1",
+            "err-code": "^2.0.0",
+            "it-goodbye": "^2.0.1",
+            "it-length-prefixed": "^3.1.0",
+            "it-pair": "^1.0.0",
+            "it-pipe": "^1.1.0",
+            "it-pushable": "^1.4.0",
+            "libp2p-crypto": "^0.18.0",
+            "libp2p-tcp": "^0.15.0",
+            "multiaddr": "^8.0.0",
+            "multibase": "^3.0.0",
+            "p-defer": "^3.0.0",
+            "p-limit": "^2.3.0",
+            "p-wait-for": "^3.1.0",
+            "peer-id": "^0.14.0",
+            "protons": "^2.0.0",
+            "sinon": "^9.0.2",
+            "streaming-iterables": "^5.0.2",
+            "uint8arrays": "^1.1.0"
+          }
+        },
+        "node-gyp-build": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.3.tgz",
+          "integrity": "sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg==",
           "dev": true
+        },
+        "secp256k1": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.2.tgz",
+          "integrity": "sha512-UDar4sKvWAksIlfX3xIaQReADn+WFnHvbVujpcbr+9Sf/69odMwy2MUsz5CKLQgX9nsIyrjuxL2imVyoNHa3fg==",
+          "dev": true,
+          "requires": {
+            "elliptic": "^6.5.2",
+            "node-addon-api": "^2.0.0",
+            "node-gyp-build": "^4.2.0"
+          }
         }
       }
     },
     "libp2p-interfaces": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/libp2p-interfaces/-/libp2p-interfaces-0.3.2.tgz",
-      "integrity": "sha512-EZviUYO5d4T/mYwDFMC/tVvLiS95+Ui8agn/DovsnUhlYPojLJJNapEJYFqFbgKqP+dxpMVMZ5CyJXD334qsuA==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/libp2p-interfaces/-/libp2p-interfaces-0.4.1.tgz",
+      "integrity": "sha512-LvoK21WtoRxmdLFWGGKMomK4SLXSqcyntoCQ254IOao/EOjis0Za09THENjK+pL1Lk84D1tXLwwK+8pT19EWDw==",
       "dev": true,
       "requires": {
         "abort-controller": "^3.0.0",
@@ -14350,148 +12188,72 @@
         "it-goodbye": "^2.0.1",
         "it-pair": "^1.0.0",
         "it-pipe": "^1.1.0",
-        "libp2p-tcp": "^0.14.5",
-        "multiaddr": "^7.5.0",
+        "libp2p-tcp": "^0.15.0",
+        "multiaddr": "^8.0.0",
         "p-defer": "^3.0.0",
         "p-limit": "^2.3.0",
         "p-wait-for": "^3.1.0",
-        "peer-id": "^0.13.13",
+        "peer-id": "^0.14.0",
         "sinon": "^9.0.2",
         "streaming-iterables": "^5.0.2"
       }
     },
     "libp2p-kad-dht": {
-      "version": "0.19.9",
-      "resolved": "https://registry.npmjs.org/libp2p-kad-dht/-/libp2p-kad-dht-0.19.9.tgz",
-      "integrity": "sha512-nbXkusPRpWoLc89/6eGV+IrE105kcWUE/cUAJtaAPUFpuSonKk+TPYfsAJnYhX93y7JA8XGXZfuPDJbHIo7Qnw==",
+      "version": "0.20.1",
+      "resolved": "https://registry.npmjs.org/libp2p-kad-dht/-/libp2p-kad-dht-0.20.1.tgz",
+      "integrity": "sha512-khffe6L6O6oU53LO8BrI3bULH4i6FLibvFEyV+7FAPXnFYhTKHa9TsIifkL/MEAfLI0hI9QN4NwMf0DpOLMvDA==",
       "dev": true,
       "requires": {
         "abort-controller": "^3.0.0",
         "async": "^2.6.2",
         "base32.js": "~0.1.0",
-        "buffer": "^5.6.0",
-        "cids": "~0.8.0",
+        "cids": "^1.0.0",
         "debug": "^4.1.1",
         "err-code": "^2.0.0",
         "hashlru": "^2.3.0",
         "heap": "~0.2.6",
-        "interface-datastore": "^1.0.2",
+        "interface-datastore": "^2.0.0",
         "it-length-prefixed": "^3.0.0",
         "it-pipe": "^1.1.0",
         "k-bucket": "^5.0.0",
-        "libp2p-crypto": "~0.17.1",
-        "libp2p-interfaces": "^0.3.0",
-        "libp2p-record": "~0.7.0",
-        "multiaddr": "^7.4.3",
-        "multihashing-async": "^0.8.2",
+        "libp2p-crypto": "^0.18.0",
+        "libp2p-interfaces": "^0.4.0",
+        "libp2p-record": "^0.9.0",
+        "multiaddr": "^8.0.0",
+        "multihashing-async": "^2.0.1",
         "p-filter": "^2.1.0",
         "p-map": "^4.0.0",
         "p-queue": "^6.2.1",
         "p-timeout": "^3.2.0",
         "p-times": "^3.0.0",
-        "peer-id": "~0.13.5",
+        "peer-id": "^0.14.0",
         "promise-to-callback": "^1.0.0",
-        "protons": "^1.0.1",
-        "streaming-iterables": "^4.1.1",
+        "protons": "^2.0.0",
+        "streaming-iterables": "^5.0.2",
+        "uint8arrays": "^1.1.0",
         "varint": "^5.0.0",
         "xor-distance": "^2.0.0"
       },
       "dependencies": {
-        "cids": {
-          "version": "0.8.3",
-          "resolved": "https://registry.npmjs.org/cids/-/cids-0.8.3.tgz",
-          "integrity": "sha512-yoXTbV3llpm+EBGWKeL9xKtksPE/s6DPoDSY4fn8I8TEW1zehWXPSB0pwAXVDlLaOlrw+sNynj995uD9abmPhA==",
-          "dev": true,
-          "requires": {
-            "buffer": "^5.6.0",
-            "class-is": "^1.1.0",
-            "multibase": "^1.0.0",
-            "multicodec": "^1.0.1",
-            "multihashes": "^1.0.1"
-          }
-        },
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "interface-datastore": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-1.0.4.tgz",
-          "integrity": "sha512-nIOP/mVwDUc7OenayUyFQB3D6c3SxDG5opTPeSrhA0jS5q0XWkf8Nz2GtNBm3wkeSKUM6iXt6LwIOCH/+jFXIQ==",
-          "dev": true,
-          "requires": {
-            "buffer": "^5.5.0",
-            "class-is": "^1.1.0",
-            "err-code": "^2.0.1",
-            "ipfs-utils": "^2.2.2",
-            "iso-random-stream": "^1.1.1",
-            "it-all": "^1.0.2",
-            "it-drain": "^1.0.1",
-            "nanoid": "^3.0.2"
-          }
-        },
         "libp2p-crypto": {
-          "version": "0.17.9",
-          "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.17.9.tgz",
-          "integrity": "sha512-nH3vTfQ4UqhZ1SORTP7HOsmFdJBs604Qy0Xi3IFFtU6ofYt+rFAZ2QNgo4MH1ZTT38/LEM374N9K7yzj1IQm0g==",
+          "version": "0.18.0",
+          "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.18.0.tgz",
+          "integrity": "sha512-zNMHDwf2J4t1LRjrBPMiSa4+14u0SfZRu66FyIVZtOnBGo3V/8imbJsOp8RPT8IgeHRN7EVIUt9lp8dcgXHMOw==",
           "dev": true,
           "requires": {
-            "buffer": "^5.5.0",
             "err-code": "^2.0.0",
             "is-typedarray": "^1.0.0",
             "iso-random-stream": "^1.1.0",
             "keypair": "^1.0.1",
-            "multibase": "^1.0.1",
-            "multicodec": "^1.0.4",
-            "multihashing-async": "^0.8.1",
+            "multibase": "^3.0.0",
+            "multicodec": "^2.0.0",
+            "multihashing-async": "^2.0.1",
             "node-forge": "^0.9.1",
             "pem-jwk": "^2.0.0",
-            "protons": "^1.2.1",
+            "protons": "^2.0.0",
             "secp256k1": "^4.0.0",
-            "uint8arrays": "^1.0.0",
+            "uint8arrays": "^1.1.0",
             "ursa-optional": "^0.10.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        },
-        "multibase": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
-          "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
-          "dev": true,
-          "requires": {
-            "base-x": "^3.0.8",
-            "buffer": "^5.5.0"
-          }
-        },
-        "multicodec": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-1.0.4.tgz",
-          "integrity": "sha512-NDd7FeS3QamVtbgfvu5h7fd1IlbaC4EQ0/pgU4zqE2vdHCmBGsUa0TiM8/TdSeG6BMPC92OOCf8F1ocE/Wkrrg==",
-          "dev": true,
-          "requires": {
-            "buffer": "^5.6.0",
-            "varint": "^5.0.0"
-          }
-        },
-        "multihashes": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
-          "integrity": "sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==",
-          "dev": true,
-          "requires": {
-            "buffer": "^5.6.0",
-            "multibase": "^1.0.1",
-            "varint": "^5.0.0"
           }
         },
         "node-gyp-build": {
@@ -14510,84 +12272,43 @@
             "node-addon-api": "^2.0.0",
             "node-gyp-build": "^4.2.0"
           }
-        },
-        "streaming-iterables": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/streaming-iterables/-/streaming-iterables-4.1.2.tgz",
-          "integrity": "sha512-IzhmKnQ2thkNMUcaGsjedrxdAoXPhtIFn8hUlmSqSqafa2p0QmZudu6ImG7ckvPNfazpMfr6Ef8cxUWyIyxpxA==",
-          "dev": true
         }
       }
     },
     "libp2p-mdns": {
-      "version": "0.14.3",
-      "resolved": "https://registry.npmjs.org/libp2p-mdns/-/libp2p-mdns-0.14.3.tgz",
-      "integrity": "sha512-NxGFh469olcTr/AJ43BSmcAa5tvM6bXLXS54dq3Lw5IEeqr2JrTbxkcl+evFu3caKe/p+bN4c5kH7hGDZX6+yQ==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/libp2p-mdns/-/libp2p-mdns-0.15.0.tgz",
+      "integrity": "sha512-wuILE+mwC6ww/0TMkR3k2h53D5Ma9TXpz0siacbsACcGukkS+mIpsvruaf9U1Uxe0F1aC8+Y+Vi5lP8C3YR9Lg==",
       "dev": true,
       "requires": {
         "debug": "^4.1.1",
-        "multiaddr": "^7.5.0",
+        "multiaddr": "^8.0.0",
         "multicast-dns": "^7.2.0",
-        "peer-id": "^0.13.13"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        }
+        "peer-id": "^0.14.0"
       }
     },
     "libp2p-mplex": {
-      "version": "0.9.5",
-      "resolved": "https://registry.npmjs.org/libp2p-mplex/-/libp2p-mplex-0.9.5.tgz",
-      "integrity": "sha512-3YHtuhE5GWtWzsvz3zIwZMLHxMcwpPnI2HgT/FZzvi8kYF00Y6psZtzC9p+yDiu9deeq5ZlmcbKzKA36k8VoSQ==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/libp2p-mplex/-/libp2p-mplex-0.10.0.tgz",
+      "integrity": "sha512-q+zpo12ldm8E+AlnR/LK/j++MM8IkDHi/P19VMPWP07irXe1Pmy/lw6IrSqtDOD8KQc86ipib9d1PI3ALdN8vA==",
       "dev": true,
       "requires": {
         "abort-controller": "^3.0.0",
         "abortable-iterator": "^3.0.0",
         "bl": "^4.0.0",
-        "buffer": "^5.5.0",
         "debug": "^4.1.1",
         "it-pipe": "^1.0.1",
         "it-pushable": "^1.3.1",
         "varint": "^5.0.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        }
       }
     },
     "libp2p-noise": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/libp2p-noise/-/libp2p-noise-1.1.2.tgz",
-      "integrity": "sha512-iKXdzGnPsz3slh6Gm9oNj0h0X37f/YFuSkg7MikQgrx5l5XRaFRxVDoqbsTlQ5nIS02tGuLJvmbqpLOZ+aWVow==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/libp2p-noise/-/libp2p-noise-2.0.1.tgz",
+      "integrity": "sha512-Jhd/jirWL3qkqGqIC1P4SH+OYlmKFll6UjFVYdw7otBKnbmdBUTW2Lg75/L1+7dYKwitHKu5EWlAd3zPU36gfg==",
       "dev": true,
       "requires": {
-        "bcrypto": "5.1.0",
+        "bcrypto": "^5.2.0",
         "buffer": "^5.4.3",
         "debug": "^4.1.1",
         "it-buffer": "^0.1.1",
@@ -14595,172 +12316,31 @@
         "it-pair": "^1.0.0",
         "it-pb-rpc": "^0.1.8",
         "it-pipe": "^1.1.0",
-        "libp2p-crypto": "^0.17.6",
-        "peer-id": "^0.13.5",
-        "protobufjs": "6.8.8"
+        "libp2p-crypto": "^0.18.0",
+        "peer-id": "^0.14.0",
+        "protobufjs": "^6.10.1",
+        "uint8arrays": "^1.1.0"
       },
       "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
         "libp2p-crypto": {
-          "version": "0.17.9",
-          "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.17.9.tgz",
-          "integrity": "sha512-nH3vTfQ4UqhZ1SORTP7HOsmFdJBs604Qy0Xi3IFFtU6ofYt+rFAZ2QNgo4MH1ZTT38/LEM374N9K7yzj1IQm0g==",
+          "version": "0.18.0",
+          "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.18.0.tgz",
+          "integrity": "sha512-zNMHDwf2J4t1LRjrBPMiSa4+14u0SfZRu66FyIVZtOnBGo3V/8imbJsOp8RPT8IgeHRN7EVIUt9lp8dcgXHMOw==",
           "dev": true,
           "requires": {
-            "buffer": "^5.5.0",
             "err-code": "^2.0.0",
             "is-typedarray": "^1.0.0",
             "iso-random-stream": "^1.1.0",
             "keypair": "^1.0.1",
-            "multibase": "^1.0.1",
-            "multicodec": "^1.0.4",
-            "multihashing-async": "^0.8.1",
+            "multibase": "^3.0.0",
+            "multicodec": "^2.0.0",
+            "multihashing-async": "^2.0.1",
             "node-forge": "^0.9.1",
             "pem-jwk": "^2.0.0",
-            "protons": "^1.2.1",
+            "protons": "^2.0.0",
             "secp256k1": "^4.0.0",
-            "uint8arrays": "^1.0.0",
+            "uint8arrays": "^1.1.0",
             "ursa-optional": "^0.10.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        },
-        "multibase": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
-          "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
-          "dev": true,
-          "requires": {
-            "base-x": "^3.0.8",
-            "buffer": "^5.5.0"
-          }
-        },
-        "multicodec": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-1.0.4.tgz",
-          "integrity": "sha512-NDd7FeS3QamVtbgfvu5h7fd1IlbaC4EQ0/pgU4zqE2vdHCmBGsUa0TiM8/TdSeG6BMPC92OOCf8F1ocE/Wkrrg==",
-          "dev": true,
-          "requires": {
-            "buffer": "^5.6.0",
-            "varint": "^5.0.0"
-          }
-        },
-        "node-gyp-build": {
-          "version": "4.2.3",
-          "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.3.tgz",
-          "integrity": "sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg==",
-          "dev": true
-        },
-        "secp256k1": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.2.tgz",
-          "integrity": "sha512-UDar4sKvWAksIlfX3xIaQReADn+WFnHvbVujpcbr+9Sf/69odMwy2MUsz5CKLQgX9nsIyrjuxL2imVyoNHa3fg==",
-          "dev": true,
-          "requires": {
-            "elliptic": "^6.5.2",
-            "node-addon-api": "^2.0.0",
-            "node-gyp-build": "^4.2.0"
-          }
-        }
-      }
-    },
-    "libp2p-pubsub": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/libp2p-pubsub/-/libp2p-pubsub-0.5.6.tgz",
-      "integrity": "sha512-1nQ709amKckPOcK7nZZom66PZytn8VIdR9BxpxhXxwmMmeuCIUKB+65UK7tI07M4LrcWsWPwZH6PbQBKiQ+Fzw==",
-      "dev": true,
-      "requires": {
-        "debug": "^4.1.1",
-        "err-code": "^2.0.0",
-        "it-length-prefixed": "^3.0.0",
-        "it-pipe": "^1.0.1",
-        "it-pushable": "^1.3.2",
-        "libp2p-crypto": "~0.17.0",
-        "libp2p-interfaces": "^0.3.0",
-        "multibase": "^0.7.0",
-        "peer-id": "~0.13.3",
-        "protons": "^1.0.1"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "libp2p-crypto": {
-          "version": "0.17.9",
-          "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.17.9.tgz",
-          "integrity": "sha512-nH3vTfQ4UqhZ1SORTP7HOsmFdJBs604Qy0Xi3IFFtU6ofYt+rFAZ2QNgo4MH1ZTT38/LEM374N9K7yzj1IQm0g==",
-          "dev": true,
-          "requires": {
-            "buffer": "^5.5.0",
-            "err-code": "^2.0.0",
-            "is-typedarray": "^1.0.0",
-            "iso-random-stream": "^1.1.0",
-            "keypair": "^1.0.1",
-            "multibase": "^1.0.1",
-            "multicodec": "^1.0.4",
-            "multihashing-async": "^0.8.1",
-            "node-forge": "^0.9.1",
-            "pem-jwk": "^2.0.0",
-            "protons": "^1.2.1",
-            "secp256k1": "^4.0.0",
-            "uint8arrays": "^1.0.0",
-            "ursa-optional": "^0.10.1"
-          },
-          "dependencies": {
-            "multibase": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
-              "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
-              "dev": true,
-              "requires": {
-                "base-x": "^3.0.8",
-                "buffer": "^5.5.0"
-              }
-            }
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        },
-        "multibase": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.7.0.tgz",
-          "integrity": "sha512-TW8q03O0f6PNFTQDvh3xxH03c8CjGaaYrjkl9UQPG6rz53TQzzxJVCIWVjzcbN/Q5Y53Zd0IBQBMVktVgNx4Fg==",
-          "dev": true,
-          "requires": {
-            "base-x": "^3.0.8",
-            "buffer": "^5.5.0"
-          }
-        },
-        "multicodec": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-1.0.4.tgz",
-          "integrity": "sha512-NDd7FeS3QamVtbgfvu5h7fd1IlbaC4EQ0/pgU4zqE2vdHCmBGsUa0TiM8/TdSeG6BMPC92OOCf8F1ocE/Wkrrg==",
-          "dev": true,
-          "requires": {
-            "buffer": "^5.6.0",
-            "varint": "^5.0.0"
           }
         },
         "node-gyp-build": {
@@ -14783,45 +12363,22 @@
       }
     },
     "libp2p-record": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/libp2p-record/-/libp2p-record-0.7.3.tgz",
-      "integrity": "sha512-a6MrDeVqIkAUaDaiS3vWFu2OblpuBaBmY3bfQY+ZcEI/C2lWB0MixIby9RhrTmR+rqM+W3yoDLQa+clm1HVLhw==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/libp2p-record/-/libp2p-record-0.9.0.tgz",
+      "integrity": "sha512-8FlhzP+UlXTYOR+9D8nYoGOIJ6S8XogKD625bqzHJbXJQyJNCNaW3tZPHqrQrvUW7o6GsAeyQAfCp5WLEH0FZg==",
       "dev": true,
       "requires": {
-        "buffer": "^5.6.0",
         "err-code": "^2.0.0",
-        "multihashes": "~0.4.15",
-        "multihashing-async": "^0.8.0",
-        "protons": "^1.0.1"
-      },
-      "dependencies": {
-        "multibase": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.7.0.tgz",
-          "integrity": "sha512-TW8q03O0f6PNFTQDvh3xxH03c8CjGaaYrjkl9UQPG6rz53TQzzxJVCIWVjzcbN/Q5Y53Zd0IBQBMVktVgNx4Fg==",
-          "dev": true,
-          "requires": {
-            "base-x": "^3.0.8",
-            "buffer": "^5.5.0"
-          }
-        },
-        "multihashes": {
-          "version": "0.4.21",
-          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-0.4.21.tgz",
-          "integrity": "sha512-uVSvmeCWf36pU2nB4/1kzYZjsXD9vofZKpgudqkceYY5g2aZZXJ5r9lxuzoRLl1OAp28XljXsEJ/X/85ZsKmKw==",
-          "dev": true,
-          "requires": {
-            "buffer": "^5.5.0",
-            "multibase": "^0.7.0",
-            "varint": "^5.0.0"
-          }
-        }
+        "multihashes": "^3.0.1",
+        "multihashing-async": "^2.0.1",
+        "protons": "^2.0.0",
+        "uint8arrays": "^1.1.0"
       }
     },
     "libp2p-secio": {
-      "version": "0.12.6",
-      "resolved": "https://registry.npmjs.org/libp2p-secio/-/libp2p-secio-0.12.6.tgz",
-      "integrity": "sha512-SPuXcQsXXix7Lkmx5fv+woKay+DWycFxv7xkWi+8CD5oa15/4U1E8qqqnE7Lwjj2Ub1i0DuE74GRRzap46sxTQ==",
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/libp2p-secio/-/libp2p-secio-0.13.1.tgz",
+      "integrity": "sha512-1rJBqaCTeKAyA1BedfGCjG8SKB+fOqWXPJLklkaRBcdwmtoNdvCLuLt5So81Z/5sqrbETM1vAQRVdMpyTfPrKw==",
       "dev": true,
       "requires": {
         "bl": "^4.0.0",
@@ -14830,97 +12387,34 @@
         "it-pair": "^1.0.0",
         "it-pb-rpc": "^0.1.4",
         "it-pipe": "^1.1.0",
-        "libp2p-crypto": "^0.17.3",
-        "libp2p-interfaces": "^0.2.1",
-        "multiaddr": "^7.2.1",
-        "multihashing-async": "^0.8.0",
-        "peer-id": "^0.13.6",
-        "protons": "^1.0.2"
+        "libp2p-crypto": "^0.18.0",
+        "libp2p-interfaces": "^0.4.0",
+        "multiaddr": "^8.0.0",
+        "multihashing-async": "^2.0.1",
+        "peer-id": "^0.14.0",
+        "protons": "^2.0.0",
+        "uint8arrays": "^1.1.0"
       },
       "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
         "libp2p-crypto": {
-          "version": "0.17.9",
-          "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.17.9.tgz",
-          "integrity": "sha512-nH3vTfQ4UqhZ1SORTP7HOsmFdJBs604Qy0Xi3IFFtU6ofYt+rFAZ2QNgo4MH1ZTT38/LEM374N9K7yzj1IQm0g==",
+          "version": "0.18.0",
+          "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.18.0.tgz",
+          "integrity": "sha512-zNMHDwf2J4t1LRjrBPMiSa4+14u0SfZRu66FyIVZtOnBGo3V/8imbJsOp8RPT8IgeHRN7EVIUt9lp8dcgXHMOw==",
           "dev": true,
           "requires": {
-            "buffer": "^5.5.0",
             "err-code": "^2.0.0",
             "is-typedarray": "^1.0.0",
             "iso-random-stream": "^1.1.0",
             "keypair": "^1.0.1",
-            "multibase": "^1.0.1",
-            "multicodec": "^1.0.4",
-            "multihashing-async": "^0.8.1",
+            "multibase": "^3.0.0",
+            "multicodec": "^2.0.0",
+            "multihashing-async": "^2.0.1",
             "node-forge": "^0.9.1",
             "pem-jwk": "^2.0.0",
-            "protons": "^1.2.1",
+            "protons": "^2.0.0",
             "secp256k1": "^4.0.0",
-            "uint8arrays": "^1.0.0",
+            "uint8arrays": "^1.1.0",
             "ursa-optional": "^0.10.1"
-          }
-        },
-        "libp2p-interfaces": {
-          "version": "0.2.8",
-          "resolved": "https://registry.npmjs.org/libp2p-interfaces/-/libp2p-interfaces-0.2.8.tgz",
-          "integrity": "sha512-Uzjlzbjk7Bx9giSU2z3qbQv/N8iV9ARL7GV5g9UNCXEYV+lPx0CUX8egnUlxf7/EMjUTz1PsSsf8C7nOZDbVJQ==",
-          "dev": true,
-          "requires": {
-            "abort-controller": "^3.0.0",
-            "abortable-iterator": "^3.0.0",
-            "buffer": "^5.6.0",
-            "chai": "^4.2.0",
-            "chai-checkmark": "^1.0.1",
-            "class-is": "^1.1.0",
-            "detect-node": "^2.0.4",
-            "dirty-chai": "^2.0.1",
-            "err-code": "^2.0.0",
-            "it-goodbye": "^2.0.1",
-            "it-pair": "^1.0.0",
-            "it-pipe": "^1.0.1",
-            "libp2p-tcp": "^0.14.1",
-            "multiaddr": "^7.4.3",
-            "p-limit": "^2.3.0",
-            "p-wait-for": "^3.1.0",
-            "peer-id": "^0.13.11",
-            "peer-info": "^0.17.0",
-            "sinon": "^9.0.2",
-            "streaming-iterables": "^4.1.0"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        },
-        "multibase": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
-          "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
-          "dev": true,
-          "requires": {
-            "base-x": "^3.0.8",
-            "buffer": "^5.5.0"
-          }
-        },
-        "multicodec": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-1.0.4.tgz",
-          "integrity": "sha512-NDd7FeS3QamVtbgfvu5h7fd1IlbaC4EQ0/pgU4zqE2vdHCmBGsUa0TiM8/TdSeG6BMPC92OOCf8F1ocE/Wkrrg==",
-          "dev": true,
-          "requires": {
-            "buffer": "^5.6.0",
-            "varint": "^5.0.0"
           }
         },
         "node-gyp-build": {
@@ -14939,82 +12433,42 @@
             "node-addon-api": "^2.0.0",
             "node-gyp-build": "^4.2.0"
           }
-        },
-        "streaming-iterables": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/streaming-iterables/-/streaming-iterables-4.1.2.tgz",
-          "integrity": "sha512-IzhmKnQ2thkNMUcaGsjedrxdAoXPhtIFn8hUlmSqSqafa2p0QmZudu6ImG7ckvPNfazpMfr6Ef8cxUWyIyxpxA==",
-          "dev": true
         }
       }
     },
     "libp2p-tcp": {
-      "version": "0.14.6",
-      "resolved": "https://registry.npmjs.org/libp2p-tcp/-/libp2p-tcp-0.14.6.tgz",
-      "integrity": "sha512-DeOdaH5QGVMKZflJmZq3dSWROxzD/YU1MFDxfi+DT4JVMcxfVMd+SpVEPMyk2wyA28H4AdGIRsH78yPjlFIyZQ==",
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/libp2p-tcp/-/libp2p-tcp-0.15.1.tgz",
+      "integrity": "sha512-alvgZ3lSNUyiz4vJOqvm6RpMQN9d17gSJa+VT+2pYLGf82o8pX3QvyhltMkBG7u9I+qZAkD6L27s8o0h38dpOg==",
       "dev": true,
       "requires": {
         "abortable-iterator": "^3.0.0",
         "class-is": "^1.1.0",
         "debug": "^4.1.1",
         "err-code": "^2.0.0",
-        "libp2p-utils": "^0.1.2",
-        "mafmt": "^7.1.0",
-        "multiaddr": "^7.5.0",
+        "libp2p-utils": "^0.2.0",
+        "mafmt": "^8.0.0",
+        "multiaddr": "^8.0.0",
         "stream-to-it": "^0.2.2"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        }
       }
     },
     "libp2p-utils": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/libp2p-utils/-/libp2p-utils-0.1.3.tgz",
-      "integrity": "sha512-ApiQu45O+wTArSuAA8I0FR+CRf9lqoVTR1iGqSPx57x3iCzAtf3uKEOFxUDkgdWCnhpo04VKr2TLzxEYvkxd/w==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/libp2p-utils/-/libp2p-utils-0.2.0.tgz",
+      "integrity": "sha512-tZmqu27SULiIvfV+RZg5WOomxXIqM/SEd9FwKuirYTHHU1eet2bLzVQBhigatrdyQxebqi8GVnwbKmqdRElgCA==",
       "dev": true,
       "requires": {
         "abortable-iterator": "^3.0.0",
         "debug": "^4.1.1",
         "err-code": "^2.0.3",
         "ip-address": "^6.1.0",
-        "multiaddr": "^7.5.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        }
+        "multiaddr": "^8.0.0"
       }
     },
     "libp2p-webrtc-peer": {
-      "version": "9.7.2",
-      "resolved": "https://registry.npmjs.org/libp2p-webrtc-peer/-/libp2p-webrtc-peer-9.7.2.tgz",
-      "integrity": "sha512-r/JzhV9EDYRU2bWHHUT5XsvmVaKb3wCESUbf8TyFBZ3iC11/43tYlK1gNyHvLpmsDLUC2XMRpHCsfxexnHUo0g==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/libp2p-webrtc-peer/-/libp2p-webrtc-peer-10.0.1.tgz",
+      "integrity": "sha512-Qi/YVrSI5sjU+iBvr1iAjGrakIEvzCS8S76v4q43jjlDb6Wj+S4OnFLH/uRlt7eLXcx4vlaI6huMzYrUAoopMg==",
       "dev": true,
       "requires": {
         "debug": "^4.0.1",
@@ -15023,112 +12477,53 @@
         "queue-microtask": "^1.1.0",
         "randombytes": "^2.0.3",
         "readable-stream": "^3.4.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        }
       }
     },
     "libp2p-webrtc-star": {
-      "version": "0.18.6",
-      "resolved": "https://registry.npmjs.org/libp2p-webrtc-star/-/libp2p-webrtc-star-0.18.6.tgz",
-      "integrity": "sha512-rrA0hQ7RwIW8rvwd2R9BnkmVVnH9jG98XaNykmlJ3At5jQOHcVYY13sqfEz8y0I5+5zbSd3xfvV9etBqyT8dRQ==",
+      "version": "0.20.1",
+      "resolved": "https://registry.npmjs.org/libp2p-webrtc-star/-/libp2p-webrtc-star-0.20.1.tgz",
+      "integrity": "sha512-VQNL24A3rN1/9U0fTO8MqUx3+6d99iz/HvPI3p+IzHb6MgBe7er+rgbvRep7uheZ2894IxiJI848Vs0ZNypn2w==",
       "dev": true,
       "requires": {
-        "@hapi/hapi": "^18.4.0",
-        "@hapi/inert": "^5.2.2",
+        "@hapi/hapi": "^20.0.0",
+        "@hapi/inert": "^6.0.2",
         "abortable-iterator": "^3.0.0",
-        "buffer": "^5.6.0",
         "class-is": "^1.1.0",
         "debug": "^4.1.1",
         "err-code": "^2.0.0",
-        "ipfs-utils": "^2.3.0",
+        "ipfs-utils": "^3.0.0",
         "it-pipe": "^1.0.1",
-        "libp2p-utils": "^0.1.0",
-        "libp2p-webrtc-peer": "^9.7.2",
-        "mafmt": "^7.0.1",
+        "libp2p-utils": "^0.2.0",
+        "libp2p-webrtc-peer": "^10.0.1",
+        "mafmt": "^8.0.0",
         "menoetius": "0.0.2",
         "minimist": "^1.2.0",
-        "multiaddr": "^7.1.0",
+        "multiaddr": "^8.0.0",
         "p-defer": "^3.0.0",
-        "peer-id": "~0.13.12",
+        "peer-id": "^0.14.0",
         "prom-client": "^12.0.0",
         "socket.io": "^2.3.0",
         "socket.io-client": "^2.3.0",
-        "stream-to-it": "^0.2.0",
-        "streaming-iterables": "^4.1.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        },
-        "streaming-iterables": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/streaming-iterables/-/streaming-iterables-4.1.2.tgz",
-          "integrity": "sha512-IzhmKnQ2thkNMUcaGsjedrxdAoXPhtIFn8hUlmSqSqafa2p0QmZudu6ImG7ckvPNfazpMfr6Ef8cxUWyIyxpxA==",
-          "dev": true
-        }
+        "stream-to-it": "^0.2.2",
+        "streaming-iterables": "^5.0.2"
       }
     },
     "libp2p-websockets": {
-      "version": "0.13.6",
-      "resolved": "https://registry.npmjs.org/libp2p-websockets/-/libp2p-websockets-0.13.6.tgz",
-      "integrity": "sha512-3M2Fht4QtwIOrIxESJIFqsltmLGB2FQhtZXD4SxnLhBADqe3CYyrad+zsDjQRXlXU7u08l9lWM5gHWDtmqX7Aw==",
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/libp2p-websockets/-/libp2p-websockets-0.14.0.tgz",
+      "integrity": "sha512-UeI0uqw2xYXFhImJucewG7fuL6hOR2tnSwlSAAxilyK0Z3Yya+GeVkqy7Vufj9ax3EWFx6lPO8mC3uBl30TkpA==",
       "dev": true,
       "requires": {
         "abortable-iterator": "^3.0.0",
-        "buffer": "^5.5.0",
         "class-is": "^1.1.0",
         "debug": "^4.1.1",
         "err-code": "^2.0.0",
         "it-ws": "^3.0.0",
-        "libp2p-utils": "~0.1.0",
-        "mafmt": "^7.0.0",
-        "multiaddr": "^7.1.0",
-        "multiaddr-to-uri": "^5.0.0",
+        "libp2p-utils": "^0.2.0",
+        "mafmt": "^8.0.0",
+        "multiaddr": "^8.0.0",
+        "multiaddr-to-uri": "^6.0.0",
         "p-timeout": "^3.2.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        }
       }
     },
     "liftoff": {
@@ -15538,13 +12933,12 @@
       }
     },
     "lru-cache": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
       "dev": true,
       "requires": {
-        "pseudomap": "^1.0.2",
-        "yallist": "^2.1.2"
+        "yallist": "^3.0.2"
       }
     },
     "ltgt": {
@@ -15559,12 +12953,12 @@
       "dev": true
     },
     "mafmt": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/mafmt/-/mafmt-7.1.0.tgz",
-      "integrity": "sha512-vpeo9S+hepT3k2h5iFxzEHvvR0GPBx9uKaErmnRzYNcaKb03DgOArjEMlgG4a9LcuZZ89a3I8xbeto487n26eA==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/mafmt/-/mafmt-8.0.0.tgz",
+      "integrity": "sha512-MdaeaqZxjoYYWvlhr1GQ7sbsR3+L3s8QL0VtCuja+Iax3EhqAEgluSWPJezSDLyns7Ds4DGRyoq5+eIU7UDang==",
       "dev": true,
       "requires": {
-        "multiaddr": "^7.3.0"
+        "multiaddr": "^8.0.0"
       }
     },
     "make-dir": {
@@ -15817,17 +13211,8 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-2.0.0.tgz",
       "integrity": "sha512-S7xYIeWHl2ZUKF7SDeBhGg6rfv5bKxVBdk95s/I7wVF8d+hjLSztJ/B271cnUiF6CAFduEQ5Zn3HYwAjT16DlQ==",
-      "dev": true,
       "requires": {
         "is-plain-obj": "^2.0.0"
-      },
-      "dependencies": {
-        "is-plain-obj": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
-          "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
-          "dev": true
-        }
       }
     },
     "merge-source-map": {
@@ -15995,14 +13380,12 @@
     "mime-db": {
       "version": "1.44.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
-      "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==",
-      "dev": true
+      "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg=="
     },
     "mime-types": {
       "version": "2.1.27",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
       "integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
-      "dev": true,
       "requires": {
         "mime-db": "1.44.0"
       }
@@ -16039,7 +13422,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -16066,6 +13448,12 @@
           "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
           "dev": true
         },
+        "is-plain-obj": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+          "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
+          "dev": true
+        },
         "kind-of": {
           "version": "6.0.3",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
@@ -16082,14 +13470,6 @@
       "requires": {
         "safe-buffer": "^5.1.2",
         "yallist": "^3.0.0"
-      },
-      "dependencies": {
-        "yallist": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-          "dev": true
-        }
       }
     },
     "minizlib": {
@@ -16238,15 +13618,6 @@
             "readdirp": "~3.4.0"
           }
         },
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
         "escape-string-regexp": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
@@ -16332,12 +13703,6 @@
           "requires": {
             "p-locate": "^5.0.0"
           }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
         },
         "normalize-path": {
           "version": "3.0.0",
@@ -16429,12 +13794,6 @@
           "requires": {
             "ms": "^2.1.1"
           }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
         }
       }
     },
@@ -16505,18 +13864,18 @@
       }
     },
     "mongodb-memory-server": {
-      "version": "6.7.4",
-      "resolved": "https://registry.npmjs.org/mongodb-memory-server/-/mongodb-memory-server-6.7.4.tgz",
-      "integrity": "sha512-VucLjrv6PBzmz36KlReBv62uPg4JkAywHvDHUXO/LXtAroWcH7HjECbCSTlwJIhGwpWcoeuZstlsrgu2btsn7A==",
+      "version": "6.7.6",
+      "resolved": "https://registry.npmjs.org/mongodb-memory-server/-/mongodb-memory-server-6.7.6.tgz",
+      "integrity": "sha512-dxAo6wik3r0H1HnAgrCZ+qR4wE54TeTdKHhvw/eL51Ez6F+0Kq+ojfGIlyK5yrV/KJ+4jGkdLg68FfAL0LCWfA==",
       "dev": true,
       "requires": {
-        "mongodb-memory-server-core": "6.7.4"
+        "mongodb-memory-server-core": "6.7.6"
       }
     },
     "mongodb-memory-server-core": {
-      "version": "6.7.4",
-      "resolved": "https://registry.npmjs.org/mongodb-memory-server-core/-/mongodb-memory-server-core-6.7.4.tgz",
-      "integrity": "sha512-jvlx5+OUpJOagSyQXHHH/HhT63cJtdN5yruvSrjQ5Ivfq1lITI7fq6vTxZe4USlGoygqQiJN+MX8b1JYX2sLnw==",
+      "version": "6.7.6",
+      "resolved": "https://registry.npmjs.org/mongodb-memory-server-core/-/mongodb-memory-server-core-6.7.6.tgz",
+      "integrity": "sha512-q6qLVI8C56wDZ7HAZSZ+GNL7qz2Aj42nd8CNGO7dTGlOsoThPTVnHAJfFR7qMz/xLPLxEyjR618XVuLaGtXxpA==",
       "dev": true,
       "requires": {
         "@types/tmp": "^0.2.0",
@@ -16543,15 +13902,6 @@
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.0.0.tgz",
           "integrity": "sha512-8KMDF1Vz2gzOq54ONPJS65IvTUaB1cHJ2DMM7MbPmLZljDH1qpzzLsWdiN9pHh6qvkRVDTi/07+eNGch/oLU4w==",
           "dev": true
-        },
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
         },
         "find-cache-dir": {
           "version": "3.3.1",
@@ -16599,12 +13949,6 @@
               "dev": true
             }
           }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
         },
         "p-locate": {
           "version": "4.1.0",
@@ -16748,102 +14092,29 @@
       "dev": true
     },
     "ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-      "dev": true
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "multiaddr": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-7.5.0.tgz",
-      "integrity": "sha512-GvhHsIGDULh06jyb6ev+VfREH9evJCFIRnh3jUt9iEZ6XDbyoisZRFEI9bMvK/AiR6y66y6P+eoBw9mBYMhMvw==",
-      "dev": true,
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-8.0.0.tgz",
+      "integrity": "sha512-4OOyr0u0i4lvh9MY/mvuCNmH5eqoTamcnGeXz6umFGc0eaVQUGPDQNbp52YfFY92NlZ76pO6h4K2HkXsT5X43w==",
       "requires": {
-        "buffer": "^5.5.0",
-        "cids": "~0.8.0",
+        "cids": "^1.0.0",
         "class-is": "^1.1.0",
         "is-ip": "^3.1.0",
-        "multibase": "^0.7.0",
+        "multibase": "^3.0.0",
+        "uint8arrays": "^1.1.0",
         "varint": "^5.0.0"
-      },
-      "dependencies": {
-        "cids": {
-          "version": "0.8.3",
-          "resolved": "https://registry.npmjs.org/cids/-/cids-0.8.3.tgz",
-          "integrity": "sha512-yoXTbV3llpm+EBGWKeL9xKtksPE/s6DPoDSY4fn8I8TEW1zehWXPSB0pwAXVDlLaOlrw+sNynj995uD9abmPhA==",
-          "dev": true,
-          "requires": {
-            "buffer": "^5.6.0",
-            "class-is": "^1.1.0",
-            "multibase": "^1.0.0",
-            "multicodec": "^1.0.1",
-            "multihashes": "^1.0.1"
-          },
-          "dependencies": {
-            "multibase": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
-              "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
-              "dev": true,
-              "requires": {
-                "base-x": "^3.0.8",
-                "buffer": "^5.5.0"
-              }
-            }
-          }
-        },
-        "multibase": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.7.0.tgz",
-          "integrity": "sha512-TW8q03O0f6PNFTQDvh3xxH03c8CjGaaYrjkl9UQPG6rz53TQzzxJVCIWVjzcbN/Q5Y53Zd0IBQBMVktVgNx4Fg==",
-          "dev": true,
-          "requires": {
-            "base-x": "^3.0.8",
-            "buffer": "^5.5.0"
-          }
-        },
-        "multicodec": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-1.0.4.tgz",
-          "integrity": "sha512-NDd7FeS3QamVtbgfvu5h7fd1IlbaC4EQ0/pgU4zqE2vdHCmBGsUa0TiM8/TdSeG6BMPC92OOCf8F1ocE/Wkrrg==",
-          "dev": true,
-          "requires": {
-            "buffer": "^5.6.0",
-            "varint": "^5.0.0"
-          }
-        },
-        "multihashes": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
-          "integrity": "sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==",
-          "dev": true,
-          "requires": {
-            "buffer": "^5.6.0",
-            "multibase": "^1.0.1",
-            "varint": "^5.0.0"
-          },
-          "dependencies": {
-            "multibase": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
-              "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
-              "dev": true,
-              "requires": {
-                "base-x": "^3.0.8",
-                "buffer": "^5.5.0"
-              }
-            }
-          }
-        }
       }
     },
     "multiaddr-to-uri": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/multiaddr-to-uri/-/multiaddr-to-uri-5.1.0.tgz",
-      "integrity": "sha512-rIlMLkw3yk3RJmf2hxYYzeqPXz4Vx7C4M/hg7BVWhmksDW0rDVNMEyoVb0H1A+sh3deHOh5EAFK87XcW+mFimA==",
-      "dev": true,
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/multiaddr-to-uri/-/multiaddr-to-uri-6.0.0.tgz",
+      "integrity": "sha512-OjpkVHOXEmIKMO8WChzzQ7aZQcSQX8squxmvtDbRpy7/QNmJ3Z7jv6qyD74C28QtaeNie8O8ngW2AkeiMmKP7A==",
       "requires": {
-        "multiaddr": "^7.2.1"
+        "multiaddr": "^8.0.0"
       }
     },
     "multibase": {
@@ -16931,72 +14202,33 @@
       }
     },
     "multihashing-async": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.8.2.tgz",
-      "integrity": "sha512-2lKa1autuCy8x7KIEj9aVNbAb3aIMRFYIwN7mq/zD4pxgNIVgGlm+f6GKY4880EOF2Y3GktHYssRy7TAJQ2DyQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-2.0.1.tgz",
+      "integrity": "sha512-LZcH8PqW4iEKymaJ3RpsgpSJhXF29kAvO02ccqbysiXkQhZpVce8rrg+vzRKWO89hhyIBnQHI2e/ZoRVxmiJ2Q==",
       "requires": {
         "blakejs": "^1.1.0",
-        "buffer": "^5.4.3",
         "err-code": "^2.0.0",
         "js-sha3": "^0.8.0",
-        "multihashes": "^1.0.1",
-        "murmurhash3js-revisited": "^3.0.0"
-      },
-      "dependencies": {
-        "multibase": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
-          "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
-          "requires": {
-            "base-x": "^3.0.8",
-            "buffer": "^5.5.0"
-          }
-        },
-        "multihashes": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
-          "integrity": "sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==",
-          "requires": {
-            "buffer": "^5.6.0",
-            "multibase": "^1.0.1",
-            "varint": "^5.0.0"
-          }
-        }
+        "multihashes": "^3.0.1",
+        "murmurhash3js-revisited": "^3.0.0",
+        "uint8arrays": "^1.0.0"
       }
     },
     "multistream-select": {
-      "version": "0.15.2",
-      "resolved": "https://registry.npmjs.org/multistream-select/-/multistream-select-0.15.2.tgz",
-      "integrity": "sha512-uoINaq+/9AkiUnyz0/bAZGqHUeWfRICuL9kqUnfuLPKwEr08HH0nbZFBsgfxP+1zzg22kabw8caNztE8ZSPncg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/multistream-select/-/multistream-select-1.0.0.tgz",
+      "integrity": "sha512-82riQ+qZ0RPY+KbRdeeKKQnFSBCVpUbZ15EniGU2nfwM8NdrpPIeUYXFw4a/pyprcNeRfMgLlG9aCh874p8nJg==",
       "dev": true,
       "requires": {
         "bl": "^4.0.0",
-        "buffer": "^5.2.1",
         "debug": "^4.1.1",
         "err-code": "^2.0.0",
-        "it-handshake": "^1.0.0",
+        "it-handshake": "^1.0.2",
         "it-length-prefixed": "^3.0.0",
         "it-pipe": "^1.0.1",
-        "it-pushable": "^1.3.1",
         "it-reader": "^2.0.0",
-        "p-defer": "^3.0.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        }
+        "p-defer": "^3.0.0",
+        "uint8arrays": "^1.1.0"
       }
     },
     "murmurhash3js": {
@@ -17029,8 +14261,7 @@
     "nanoid": {
       "version": "3.1.12",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.12.tgz",
-      "integrity": "sha512-1qstj9z5+x491jfiC4Nelk+f8XBad7LN20PmyWINJEMRSf3wcAjAWysw1qaA8z6NSKe2sjq1hRSDpBH5paCb6A==",
-      "dev": true
+      "integrity": "sha512-1qstj9z5+x491jfiC4Nelk+f8XBad7LN20PmyWINJEMRSf3wcAjAWysw1qaA8z6NSKe2sjq1hRSDpBH5paCb6A=="
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -17101,12 +14332,6 @@
           "requires": {
             "ms": "^2.1.1"
           }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
         }
       }
     },
@@ -17156,8 +14381,7 @@
     "node-fetch": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
-      "dev": true
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
     },
     "node-forge": {
       "version": "0.9.2",
@@ -17395,12 +14619,6 @@
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.3"
           }
-        },
-        "yallist": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-          "dev": true
         }
       }
     },
@@ -17798,12 +15016,22 @@
       }
     },
     "orbit-db-access-controllers": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/orbit-db-access-controllers/-/orbit-db-access-controllers-0.2.6.tgz",
-      "integrity": "sha512-A/gi/ROEM1BDM44z5XeU80+gS6Q1uSc3jTOf6N1ripw//iQYTaTFihCcLPBGSnD2uDVXWU0wql3wSUD0k7JQ5Q==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/orbit-db-access-controllers/-/orbit-db-access-controllers-0.3.0.tgz",
+      "integrity": "sha512-H7xfgpcyAx9ToFYMvpP7StCt269uaqM33lnMdY9T1o3gbP8IYe0wPurkPQwg6IVZHrDeeBvTDA7kbOqShf9vJw==",
       "requires": {
-        "orbit-db-io": "^0.2.0",
-        "p-map-series": "^2.1.0"
+        "orbit-db-io": "^0.3.0",
+        "p-map-series": "^1.0.0"
+      },
+      "dependencies": {
+        "p-map-series": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/p-map-series/-/p-map-series-1.0.0.tgz",
+          "integrity": "sha1-v5j+V1cFZYqeE1G++4WuTB8Hvco=",
+          "requires": {
+            "p-reduce": "^1.0.0"
+          }
+        }
       }
     },
     "orbit-db-cache": {
@@ -17815,17 +15043,17 @@
       }
     },
     "orbit-db-counterstore": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/orbit-db-counterstore/-/orbit-db-counterstore-1.11.0.tgz",
-      "integrity": "sha512-CnHWU4/JfxLDfZ9LMW66AhF8GWnyCW/wiD5uDPls51zk0iI+FhMrxLHZgSFdlkIvfakZiufnRqly6rWSfh1hMg==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/orbit-db-counterstore/-/orbit-db-counterstore-1.12.0.tgz",
+      "integrity": "sha512-ElaW8OXsSOORtuLREkq3IJ2xZPZXGzLZ6SUP9/VxqyNZQz+XNX7G7DE/kl4hy2kHjahF2+6M3BngJSvuJmc1Bw==",
       "requires": {
         "crdts": "~0.1.2"
       }
     },
     "orbit-db-docstore": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/orbit-db-docstore/-/orbit-db-docstore-1.11.0.tgz",
-      "integrity": "sha512-3RjR1sA1hcDWL+paYwYDsVqEMWljVTykDq7ExwHUlvxWnSscwIXSJe71E2cX8CFSipzraiPl4flPkVFEYyPbsA==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/orbit-db-docstore/-/orbit-db-docstore-1.12.0.tgz",
+      "integrity": "sha512-AivU+G1y55qon2M8KY2SOV0nlCqzkc1+UpaFqtRtzH2NSPjsjnyr4Bhv+X/K+lXKQJPFnOMCiga+FspDjiKe3w==",
       "requires": {
         "p-map": "~1.1.1"
       },
@@ -17838,16 +15066,16 @@
       }
     },
     "orbit-db-eventstore": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/orbit-db-eventstore/-/orbit-db-eventstore-1.11.0.tgz",
-      "integrity": "sha512-fXDlvJg3SJSosf/V9LcPO+UVnx5hlMWf8jO5UijglZzXE5QYkCsCF6MQTuj3rTffvgBW8XdpHhun6/b68g+n2g=="
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/orbit-db-eventstore/-/orbit-db-eventstore-1.12.0.tgz",
+      "integrity": "sha512-KOTBa5Xj4EGlOEqNTNVdHeoMoJRc90x1LQrOfXKkF3XjN6qL92peIfBvVReLhbwG1mDRVdmtRpMNRcaA9eDI5Q=="
     },
     "orbit-db-feedstore": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/orbit-db-feedstore/-/orbit-db-feedstore-1.11.0.tgz",
-      "integrity": "sha512-UpRe8fBt6PsnlxEKB+CWG1MDYzwIyYpGchqiob4PvpBGQ/vdg4Bymm4WBYwG1Gl6v2TFuVJSYnR+qXYAHf3nvg==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/orbit-db-feedstore/-/orbit-db-feedstore-1.12.0.tgz",
+      "integrity": "sha512-hsNJTMb+AJI0ZeIKJVeTVngNbW9Zsh9/PF4qDFykITOwH7uqdNYosm3rR7psmmXtUmIgzPNolrHvyI2KmMsOIQ==",
       "requires": {
-        "orbit-db-eventstore": "~1.11.0"
+        "orbit-db-eventstore": "~1.12.0"
       }
     },
     "orbit-db-identity-provider": {
@@ -17860,65 +15088,12 @@
       }
     },
     "orbit-db-io": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/orbit-db-io/-/orbit-db-io-0.2.0.tgz",
-      "integrity": "sha512-wOunD4ZRgtTsAXJEu9NNEeJ8s98tZTtFlrLiI/ThuDKBy4AwpIvr+vMkzMD0DMSUTurRtK+xz7AfkP0nd9bcxQ==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/orbit-db-io/-/orbit-db-io-0.3.0.tgz",
+      "integrity": "sha512-yWyhDR9vqw2+8tuOT+erKWkc9cL2QuemSVZgPjEm7nn+zkBzbacbfUdbgKtbtgUp8VDKhCzph2LfEEVhs6F5HA==",
       "requires": {
-        "cids": "^0.7.1",
-        "ipld-dag-pb": "^0.18.1"
-      },
-      "dependencies": {
-        "cids": {
-          "version": "0.7.5",
-          "resolved": "https://registry.npmjs.org/cids/-/cids-0.7.5.tgz",
-          "integrity": "sha512-zT7mPeghoWAu+ppn8+BS1tQ5qGmbMfB4AregnQjA/qHY3GC1m1ptI9GkWNlgeu38r7CuRdXB47uY2XgAYt6QVA==",
-          "requires": {
-            "buffer": "^5.5.0",
-            "class-is": "^1.1.0",
-            "multibase": "~0.6.0",
-            "multicodec": "^1.0.0",
-            "multihashes": "~0.4.15"
-          }
-        },
-        "multibase": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.6.1.tgz",
-          "integrity": "sha512-pFfAwyTjbbQgNc3G7D48JkJxWtoJoBMaR4xQUOuB8RnCgRqaYmWNFeJTTvrJ2w51bjLq2zTby6Rqj9TQ9elSUw==",
-          "requires": {
-            "base-x": "^3.0.8",
-            "buffer": "^5.5.0"
-          }
-        },
-        "multicodec": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-1.0.4.tgz",
-          "integrity": "sha512-NDd7FeS3QamVtbgfvu5h7fd1IlbaC4EQ0/pgU4zqE2vdHCmBGsUa0TiM8/TdSeG6BMPC92OOCf8F1ocE/Wkrrg==",
-          "requires": {
-            "buffer": "^5.6.0",
-            "varint": "^5.0.0"
-          }
-        },
-        "multihashes": {
-          "version": "0.4.21",
-          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-0.4.21.tgz",
-          "integrity": "sha512-uVSvmeCWf36pU2nB4/1kzYZjsXD9vofZKpgudqkceYY5g2aZZXJ5r9lxuzoRLl1OAp28XljXsEJ/X/85ZsKmKw==",
-          "requires": {
-            "buffer": "^5.5.0",
-            "multibase": "^0.7.0",
-            "varint": "^5.0.0"
-          },
-          "dependencies": {
-            "multibase": {
-              "version": "0.7.0",
-              "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.7.0.tgz",
-              "integrity": "sha512-TW8q03O0f6PNFTQDvh3xxH03c8CjGaaYrjkl9UQPG6rz53TQzzxJVCIWVjzcbN/Q5Y53Zd0IBQBMVktVgNx4Fg==",
-              "requires": {
-                "base-x": "^3.0.8",
-                "buffer": "^5.5.0"
-              }
-            }
-          }
-        }
+        "cids": "^1.0.0",
+        "ipld-dag-pb": "^0.20.0"
       }
     },
     "orbit-db-keystore": {
@@ -17948,14 +15123,14 @@
       }
     },
     "orbit-db-kvstore": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/orbit-db-kvstore/-/orbit-db-kvstore-1.11.0.tgz",
-      "integrity": "sha512-IIsEwFqXJfFoGp1j3KvhANq5QRCHnnfE3R45QLrL1eiwGYRvXQwrIIEw6HzDgynj+Ae/2brnvav/3isM4pzjnQ=="
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/orbit-db-kvstore/-/orbit-db-kvstore-1.12.0.tgz",
+      "integrity": "sha512-v4V0bG17WhXlk5GPt9ICnP/owCds3uhIWaTgrix9nwnolfCMlX0hKDjrTrrZ8HKsTn1cm5Me/ID8i7WJvi5xoA=="
     },
     "orbit-db-pubsub": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/orbit-db-pubsub/-/orbit-db-pubsub-0.5.7.tgz",
-      "integrity": "sha512-NVB1iTsohVs0juIxtPS72ijJDs5Gx/v/RFi1G3z8DJ5Aplyaonfa8KghApUDW9Gd3k3NVKifPyZHEN1nHQDRPA==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/orbit-db-pubsub/-/orbit-db-pubsub-0.6.0.tgz",
+      "integrity": "sha512-+hQoeev6rl0S4805KDHVz7tU3zUk97a8udCH8LLtKG0Lh1xjc+qCIk5Pcknu6OjppkECmEz68e2wcYyfEqXufw==",
       "requires": {
         "ipfs-pubsub-peer-monitor": "~0.0.5",
         "logplease": "~1.2.14",
@@ -17982,14 +15157,14 @@
       }
     },
     "orbit-db-store": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/orbit-db-store/-/orbit-db-store-3.5.0.tgz",
-      "integrity": "sha512-y17PSbZwKCIax2zNHXRVcMQzOd/rCXx1Oei9gX/XHW9+nlqBKx96BWVnkw01TAWtf1GJlj0sJwvxAkWlWVcM5A==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/orbit-db-store/-/orbit-db-store-4.0.1.tgz",
+      "integrity": "sha512-6xgK4sil6BG/PFiaMOzrzYefs/c/qDwZ/328/CDcUlq5mB7+0DX7pRZa9IS2N/SjbHyIxX9DXA9FzSMcW3CW1w==",
       "requires": {
-        "ipfs-log": "~4.6.4",
+        "ipfs-log": "~5.0.0",
         "it-to-stream": "^0.1.2",
         "logplease": "^1.2.14",
-        "orbit-db-io": "~0.2.0",
+        "orbit-db-io": "~0.3.0",
         "p-each-series": "^2.1.0",
         "p-map": "^4.0.0",
         "p-queue": "^6.6.1",
@@ -17997,15 +15172,15 @@
       }
     },
     "orbit-db-test-utils": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/orbit-db-test-utils/-/orbit-db-test-utils-0.10.3.tgz",
-      "integrity": "sha512-Ci4s+zrxks6c7RG9ZuL1eZ5SoiLN3dXxtg9nSolAjy6pIiFr383x6GrbdOmPmm4yPYI6ckdaJZY+xgDI3MW5ew==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/orbit-db-test-utils/-/orbit-db-test-utils-0.12.0.tgz",
+      "integrity": "sha512-kPjoQOQxz7g0tP+2ZY2XITiPn0kt543GtCO4p6r/dm/mnijaQzM6IW0BubmBrNeFoOxNZXZapRXqddAO3MNFyA==",
       "dev": true,
       "requires": {
         "fruitdown": "^1.0.2",
         "go-ipfs": "^0.6.0",
-        "ipfs": "^0.49.0",
-        "ipfs-http-client": "~46.0.0",
+        "ipfs": "^0.50.2",
+        "ipfs-http-client": "~47.0.1",
         "ipfs-repo": "^6.0.3",
         "ipfsd-ctl": "^7.0.0",
         "js-combinatorics": "0.6.1",
@@ -18019,22 +15194,6 @@
         "redisdown": "^0.1.12",
         "sqldown": "^2.1.0",
         "sqlite3": "^5.0.0"
-      },
-      "dependencies": {
-        "multihashing-async": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-2.0.1.tgz",
-          "integrity": "sha512-LZcH8PqW4iEKymaJ3RpsgpSJhXF29kAvO02ccqbysiXkQhZpVce8rrg+vzRKWO89hhyIBnQHI2e/ZoRVxmiJ2Q==",
-          "dev": true,
-          "requires": {
-            "blakejs": "^1.1.0",
-            "err-code": "^2.0.0",
-            "js-sha3": "^0.8.0",
-            "multihashes": "^3.0.1",
-            "murmurhash3js-revisited": "^3.0.0",
-            "uint8arrays": "^1.0.0"
-          }
-        }
       }
     },
     "os-browserify": {
@@ -18192,9 +15351,9 @@
       "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
     },
     "p-forever": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/p-forever/-/p-forever-1.0.1.tgz",
-      "integrity": "sha512-9IVAxJdPk88BFMvPjzE+WTZLmAt/FBa47mYY49E2elBki4yJJmQ57XHu3o3Dm1GMde+Xf2d+PzElJIogAPwkug=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/p-forever/-/p-forever-2.1.0.tgz",
+      "integrity": "sha512-kqZrNBsD8fUPCpZLYJoHTiONQVrdkA2nKwSsTfIr5h7P8jGpSy+Vzkxu6nVcZcz3c/rSx/Ys3AACd/BkMKvqbw=="
     },
     "p-limit": {
       "version": "2.3.0",
@@ -18225,7 +15384,8 @@
     "p-map-series": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/p-map-series/-/p-map-series-2.1.0.tgz",
-      "integrity": "sha512-RpYIIK1zXSNEOdwxcfe7FdvGcs7+y5n8rifMhMNWvaxRNMPINJHF5GDeuVxWqnfrcHPSCnp7Oo5yNXHId9Av2Q=="
+      "integrity": "sha512-RpYIIK1zXSNEOdwxcfe7FdvGcs7+y5n8rifMhMNWvaxRNMPINJHF5GDeuVxWqnfrcHPSCnp7Oo5yNXHId9Av2Q==",
+      "dev": true
     },
     "p-queue": {
       "version": "6.6.1",
@@ -18434,8 +15594,7 @@
     "parse-duration": {
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/parse-duration/-/parse-duration-0.4.4.tgz",
-      "integrity": "sha512-KbAJuYGUhZkB9gotDiKLnZ7Z3VTacK3fgwmDdB6ZVDtJbMBT6MfLga0WJaYpPDu0mzqT0NgHtHDt5PY4l0nidg==",
-      "dev": true
+      "integrity": "sha512-KbAJuYGUhZkB9gotDiKLnZ7Z3VTacK3fgwmDdB6ZVDtJbMBT6MfLga0WJaYpPDu0mzqT0NgHtHDt5PY4l0nidg=="
     },
     "parse-entities": {
       "version": "2.0.0",
@@ -18633,84 +15792,39 @@
       }
     },
     "peer-id": {
-      "version": "0.13.13",
-      "resolved": "https://registry.npmjs.org/peer-id/-/peer-id-0.13.13.tgz",
-      "integrity": "sha512-5FpBXN6PDTcHs51gkHWPf0OIQZAO3Z10i6lWc+GaoxTU4bQHtsoKFnhxoXo5Ze04JblpzIrtowkluLSCLP1WYg==",
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/peer-id/-/peer-id-0.14.1.tgz",
+      "integrity": "sha512-QSEyJy9fEOtgB/NVrlJvlxO1Q8ZKpTLJ/HBVTj7bGJFGnm4febqSB/KlEL4WYm/fgvriHM+Wkfea3yD1Uacllw==",
       "dev": true,
       "requires": {
-        "buffer": "^5.5.0",
-        "cids": "^0.8.0",
+        "cids": "^1.0.0",
         "class-is": "^1.1.0",
-        "libp2p-crypto": "^0.17.7",
+        "libp2p-crypto": "^0.18.0",
         "minimist": "^1.2.5",
-        "multihashes": "^1.0.1",
-        "protons": "^1.0.2"
+        "multihashes": "^3.0.1",
+        "protons": "^2.0.0",
+        "uint8arrays": "^1.1.0"
       },
       "dependencies": {
-        "cids": {
-          "version": "0.8.3",
-          "resolved": "https://registry.npmjs.org/cids/-/cids-0.8.3.tgz",
-          "integrity": "sha512-yoXTbV3llpm+EBGWKeL9xKtksPE/s6DPoDSY4fn8I8TEW1zehWXPSB0pwAXVDlLaOlrw+sNynj995uD9abmPhA==",
-          "dev": true,
-          "requires": {
-            "buffer": "^5.6.0",
-            "class-is": "^1.1.0",
-            "multibase": "^1.0.0",
-            "multicodec": "^1.0.1",
-            "multihashes": "^1.0.1"
-          }
-        },
         "libp2p-crypto": {
-          "version": "0.17.9",
-          "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.17.9.tgz",
-          "integrity": "sha512-nH3vTfQ4UqhZ1SORTP7HOsmFdJBs604Qy0Xi3IFFtU6ofYt+rFAZ2QNgo4MH1ZTT38/LEM374N9K7yzj1IQm0g==",
+          "version": "0.18.0",
+          "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.18.0.tgz",
+          "integrity": "sha512-zNMHDwf2J4t1LRjrBPMiSa4+14u0SfZRu66FyIVZtOnBGo3V/8imbJsOp8RPT8IgeHRN7EVIUt9lp8dcgXHMOw==",
           "dev": true,
           "requires": {
-            "buffer": "^5.5.0",
             "err-code": "^2.0.0",
             "is-typedarray": "^1.0.0",
             "iso-random-stream": "^1.1.0",
             "keypair": "^1.0.1",
-            "multibase": "^1.0.1",
-            "multicodec": "^1.0.4",
-            "multihashing-async": "^0.8.1",
+            "multibase": "^3.0.0",
+            "multicodec": "^2.0.0",
+            "multihashing-async": "^2.0.1",
             "node-forge": "^0.9.1",
             "pem-jwk": "^2.0.0",
-            "protons": "^1.2.1",
+            "protons": "^2.0.0",
             "secp256k1": "^4.0.0",
-            "uint8arrays": "^1.0.0",
+            "uint8arrays": "^1.1.0",
             "ursa-optional": "^0.10.1"
-          }
-        },
-        "multibase": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
-          "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
-          "dev": true,
-          "requires": {
-            "base-x": "^3.0.8",
-            "buffer": "^5.5.0"
-          }
-        },
-        "multicodec": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-1.0.4.tgz",
-          "integrity": "sha512-NDd7FeS3QamVtbgfvu5h7fd1IlbaC4EQ0/pgU4zqE2vdHCmBGsUa0TiM8/TdSeG6BMPC92OOCf8F1ocE/Wkrrg==",
-          "dev": true,
-          "requires": {
-            "buffer": "^5.6.0",
-            "varint": "^5.0.0"
-          }
-        },
-        "multihashes": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
-          "integrity": "sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==",
-          "dev": true,
-          "requires": {
-            "buffer": "^5.6.0",
-            "multibase": "^1.0.1",
-            "varint": "^5.0.0"
           }
         },
         "node-gyp-build": {
@@ -18730,18 +15844,6 @@
             "node-gyp-build": "^4.2.0"
           }
         }
-      }
-    },
-    "peer-info": {
-      "version": "0.17.5",
-      "resolved": "https://registry.npmjs.org/peer-info/-/peer-info-0.17.5.tgz",
-      "integrity": "sha512-ebbbnvdCnb0onWuW+QNXO4KvLPuQ+kih3zezhov2uxHqA6VLbtzMUyQ06IHtwYLr50AYYWyBOSn17g4zEBsFpw==",
-      "dev": true,
-      "requires": {
-        "mafmt": "^7.1.0",
-        "multiaddr": "^7.3.0",
-        "peer-id": "~0.13.2",
-        "unique-by": "^1.0.0"
       }
     },
     "pem-jwk": {
@@ -18778,57 +15880,78 @@
       "dev": true
     },
     "pino": {
-      "version": "5.17.0",
-      "resolved": "https://registry.npmjs.org/pino/-/pino-5.17.0.tgz",
-      "integrity": "sha512-LqrqmRcJz8etUjyV0ddqB6OTUutCgQULPFg2b4dtijRHUsucaAdBgSUW58vY6RFSX+NT8963F+q0tM6lNwGShA==",
+      "version": "6.6.1",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-6.6.1.tgz",
+      "integrity": "sha512-DOgm7rn6ctBkBYemHXSLj7+j3o3U1q1FWBXbHcprur8mA93QcJSycEkEqhqKiFB9Mx/3Qld2FGr6+9yfQza0kA==",
       "dev": true,
       "requires": {
         "fast-redact": "^2.0.0",
         "fast-safe-stringify": "^2.0.7",
         "flatstr": "^1.0.12",
         "pino-std-serializers": "^2.4.2",
-        "quick-format-unescaped": "^3.0.3",
-        "sonic-boom": "^0.7.5"
+        "quick-format-unescaped": "^4.0.1",
+        "sonic-boom": "^1.0.2"
       }
     },
     "pino-pretty": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-3.6.1.tgz",
-      "integrity": "sha512-S3bal+Yd313OEaPijbf7V+jPxVaTaRO5RQX8S/Mwdtb/8+JOgo1KolDeJTfMDTU2/k6+MHvEbxv+T1ZRfGlnjA==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-4.2.1.tgz",
+      "integrity": "sha512-WyO/n6c6T2gj0ioYGFUFbrvyUoERK37Lu0liLxMIJnp1YaaG+XZBU2TAQB0yVJNb+7T+oDh9t8HGMzk00jy+tw==",
       "dev": true,
       "requires": {
-        "@hapi/bourne": "^1.3.2",
+        "@hapi/bourne": "^2.0.0",
         "args": "^5.0.1",
-        "chalk": "^2.4.2",
+        "chalk": "^4.0.0",
         "dateformat": "^3.0.3",
         "fast-safe-stringify": "^2.0.7",
         "jmespath": "^0.15.0",
         "joycon": "^2.2.5",
         "pump": "^3.0.0",
-        "readable-stream": "^3.4.0",
+        "readable-stream": "^3.6.0",
         "split2": "^3.1.1",
-        "strip-json-comments": "^3.0.1"
+        "strip-json-comments": "^3.1.1"
       },
       "dependencies": {
         "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
           }
         },
         "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
           }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
         },
         "pump": {
           "version": "3.0.0",
@@ -18840,13 +15963,19 @@
             "once": "^1.3.1"
           }
         },
+        "strip-json-comments": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+          "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+          "dev": true
+        },
         "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "^4.0.0"
           }
         }
       }
@@ -18907,10 +16036,25 @@
         "simple-backoff": "^1.0.0"
       },
       "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
         "double-ended-queue": {
           "version": "2.1.0-0",
           "resolved": "https://registry.npmjs.org/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz",
           "integrity": "sha1-ED01J/0xUo9AGIEwyEHv3XgmTlw=",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         }
       }
@@ -18943,12 +16087,6 @@
           "requires": {
             "minimist": "^1.2.5"
           }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
         }
       }
     },
@@ -19110,9 +16248,9 @@
       }
     },
     "protobufjs": {
-      "version": "6.8.8",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.8.8.tgz",
-      "integrity": "sha512-AAmHtD5pXgZfi7GMpllpO3q1Xw1OYldr+dMUlAnffGTAhqkg72WdmSY71uKBF/JuyiKs8psYbtKrhi0ASCD8qw==",
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.10.1.tgz",
+      "integrity": "sha512-pb8kTchL+1Ceg4lFd5XUpK8PdWacbvV5SK2ULH2ebrYtl4GjJmS24m6CKME67jzV53tbJxHlnNOSqQHbTsR9JQ==",
       "dev": true,
       "requires": {
         "@protobufjs/aspromise": "^1.1.2",
@@ -19125,15 +16263,15 @@
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
         "@protobufjs/utf8": "^1.1.0",
-        "@types/long": "^4.0.0",
-        "@types/node": "^10.1.0",
+        "@types/long": "^4.0.1",
+        "@types/node": "^13.7.0",
         "long": "^4.0.0"
       },
       "dependencies": {
         "@types/node": {
-          "version": "10.17.32",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.32.tgz",
-          "integrity": "sha512-EUq+cjH/3KCzQHikGnNbWAGe548IFLSm93Vl8xA7EuYEEATiyOVDyEVuGkowL7c9V69FF/RiZSAOCFPApMs/ig==",
+          "version": "13.13.21",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.21.tgz",
+          "integrity": "sha512-tlFWakSzBITITJSxHV4hg4KvrhR/7h3xbJdSFbYJBVzKubrASbnnIFuSgolUh7qKGo/ZeJPKUfbZ0WS6Jp14DQ==",
           "dev": true
         }
       }
@@ -19144,13 +16282,13 @@
       "integrity": "sha512-G/2kcamPF2S49W5yaMGdIpkG6+5wZF0fzBteLKgEHjbNzqjZQ85aAs1iJGto31EJaSTkNvHs5IXuHSaTLWBAiA=="
     },
     "protons": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/protons/-/protons-1.2.1.tgz",
-      "integrity": "sha512-2oqDyc/SN+tNcJf8XxrXhYL7sQn2/OMl8mSdD7NVGsWjMEmAbks4eDVnCyf0vAoRbBWyWTEXWk4D8XfuKVl3zg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/protons/-/protons-2.0.0.tgz",
+      "integrity": "sha512-BTrE9D6/d1NGis+0D8TqAO1THdn4evHQhfjapA0NUaRH4+ecJJcbqaF7TE/DKv5czE9VB/TeOllBOmCyJhHnhg==",
       "requires": {
-        "buffer": "^5.5.0",
         "protocol-buffers-schema": "^3.3.1",
         "signed-varint": "^2.0.1",
+        "uint8arrays": "^1.0.0",
         "varint": "^5.0.0"
       }
     },
@@ -19263,15 +16401,6 @@
           "integrity": "sha512-TMeqbNl2fMW0nMjTEPOwe3J/PRFP4vqeoNuQMG0HlMrtm5QxKqdvAkZ1pRBQ/ulIyDD5Yq0nJ7YbdD8ey0TO3g==",
           "dev": true
         },
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
         "find-up": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -19300,12 +16429,6 @@
           "requires": {
             "p-locate": "^4.1.0"
           }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
         },
         "p-locate": {
           "version": "4.1.0",
@@ -19368,9 +16491,9 @@
       "dev": true
     },
     "quick-format-unescaped": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-3.0.3.tgz",
-      "integrity": "sha512-dy1yjycmn9blucmJLXOfZDx1ikZJUi6E8bBZLnhPG5gBrVhHXx2xVyqqgKBubVNEXmx51dBACMHpoMQK/N/AXQ==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.1.tgz",
+      "integrity": "sha512-RyYpQ6Q5/drsJyOhrWHYMWTedvjTIat+FTwv0K4yoUxzvekw2aRHMQJLlnvt8UantkZg2++bEzD9EdxXqkWf4A==",
       "dev": true
     },
     "quick-lru": {
@@ -19391,23 +16514,6 @@
         "minimist": "^1.2.0",
         "node-fetch": "^2.6.0",
         "readable-stream": "^3.6.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        }
       }
     },
     "randomatic": {
@@ -19624,6 +16730,16 @@
                 "is-extendable": "^0.1.0"
               }
             }
+          }
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ms": "2.0.0"
           }
         },
         "expand-brackets": {
@@ -19880,6 +16996,13 @@
             "snapdragon": "^0.8.1",
             "to-regex": "^3.0.2"
           }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true,
+          "optional": true
         },
         "readable-stream": {
           "version": "2.3.7",
@@ -20336,8 +17459,7 @@
     "reset": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/reset/-/reset-0.1.0.tgz",
-      "integrity": "sha1-n8cxQXGZWubLC35YsGznUir0uvs=",
-      "dev": true
+      "integrity": "sha1-n8cxQXGZWubLC35YsGznUir0uvs="
     },
     "resolve": {
       "version": "1.17.0",
@@ -20485,7 +17607,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/run/-/run-1.4.0.tgz",
       "integrity": "sha1-4X2ekEOrL+F3dsspnhI3848LT/o=",
-      "dev": true,
       "requires": {
         "minimatch": "*"
       }
@@ -20751,23 +17872,6 @@
       "dev": true,
       "requires": {
         "debug": "^4.0.1"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        }
       }
     },
     "sinon": {
@@ -20858,6 +17962,15 @@
         "use": "^3.1.0"
       },
       "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
         "define-property": {
           "version": "0.2.5",
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
@@ -20875,6 +17988,12 @@
           "requires": {
             "is-extendable": "^0.1.0"
           }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
         }
       }
     },
@@ -20962,23 +18081,6 @@
         "socket.io-adapter": "~1.1.0",
         "socket.io-client": "2.3.0",
         "socket.io-parser": "~3.4.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        }
       }
     },
     "socket.io-adapter": {
@@ -21015,15 +18117,6 @@
           "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
           "dev": true
         },
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
         "isarray": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
@@ -21031,9 +18124,9 @@
           "dev": true
         },
         "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         },
         "socket.io-parser": {
@@ -21055,12 +18148,6 @@
               "requires": {
                 "ms": "2.0.0"
               }
-            },
-            "ms": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-              "dev": true
             }
           }
         }
@@ -21083,33 +18170,18 @@
           "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
           "dev": true
         },
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
         "isarray": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
           "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4=",
           "dev": true
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
         }
       }
     },
     "sonic-boom": {
-      "version": "0.7.7",
-      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-0.7.7.tgz",
-      "integrity": "sha512-Ei5YOo5J64GKClHIL/5evJPgASXFVpfVYbJV9PILZQytTK6/LCwHvsZJW2Ig4p9FMC2OrBrMnXKgRN/OEoAWfg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-1.1.0.tgz",
+      "integrity": "sha512-JyOf+Xt7GBN4tAic/DD1Bitw6OMgSHAnswhPeOiLpfRoSjPNjEIi73UF3OxHzhSNn9WavxGuCZzprFCGFSNwog==",
       "dev": true,
       "requires": {
         "atomic-sleep": "^1.0.0",
@@ -21123,14 +18195,6 @@
       "dev": true,
       "requires": {
         "is-plain-obj": "^2.0.0"
-      },
-      "dependencies": {
-        "is-plain-obj": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
-          "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
-          "dev": true
-        }
       }
     },
     "source-list-map": {
@@ -21259,9 +18323,9 @@
       }
     },
     "spdx-license-ids": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
-      "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.6.tgz",
+      "integrity": "sha512-+orQK83kyMva3WyPf59k1+Y525csj5JejicWut55zeTWANuN17qSiSLUXWtzHeNWORSvT7GLDJ/E/XiIWoXBTw==",
       "dev": true
     },
     "split-string": {
@@ -21313,10 +18377,25 @@
             "xtend": "~4.0.0"
           }
         },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
         "isarray": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
           "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         },
         "readable-stream": {
@@ -21591,7 +18670,6 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/stream-to-it/-/stream-to-it-0.2.2.tgz",
       "integrity": "sha512-waULBmQpVdr6TkDzci6t1P7dIaSZ0bHC1TaPXDUeJC5PpSK7U3T0H0Zeo/LWUnd6mnhXOmGGDKAkjUCHw5IOng==",
-      "dev": true,
       "requires": {
         "get-iterator": "^1.0.2"
       }
@@ -22499,12 +19577,6 @@
           "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
           "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==",
           "dev": true
-        },
-        "is-plain-obj": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
-          "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
-          "dev": true
         }
       }
     },
@@ -22748,15 +19820,6 @@
             "typedarray": "^0.0.6"
           }
         },
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
         "ignore": {
           "version": "5.1.8",
           "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
@@ -22767,18 +19830,6 @@
           "version": "2.0.4",
           "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
           "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==",
-          "dev": true
-        },
-        "is-plain-obj": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
-          "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
-          "dev": true
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         }
       }
@@ -22799,12 +19850,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
       "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=",
-      "dev": true
-    },
-    "unique-by": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/unique-by/-/unique-by-1.0.0.tgz",
-      "integrity": "sha1-UiDIa6e8Vy+3E610ZRRwy2RCEr0=",
       "dev": true
     },
     "unique-filename": {
@@ -22900,8 +19945,7 @@
     "universalify": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
-      "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==",
-      "dev": true
+      "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug=="
     },
     "unset-value": {
       "version": "1.0.0",
@@ -23060,13 +20104,13 @@
       }
     },
     "uri-to-multiaddr": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/uri-to-multiaddr/-/uri-to-multiaddr-3.0.2.tgz",
-      "integrity": "sha512-I2AO1Y/3hUI7KfHiB6Py64lZ02jAB+hqlMVBzDRn4u6d85x+7tJhRwGzdKEYn8/1kDBtWFZVkHvgepF7Z+C1og==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/uri-to-multiaddr/-/uri-to-multiaddr-4.0.0.tgz",
+      "integrity": "sha512-6zQ1uBlE+F//46CBA3lx3vBMhybSvdGJqgNyQPobSDsWGrDDdmJM/f95GPaswXAGFlRHPqOjrGKT11IcKmIfaA==",
       "dev": true,
       "requires": {
         "is-ip": "^3.1.0",
-        "multiaddr": "^7.2.1"
+        "multiaddr": "^8.0.0"
       }
     },
     "urix": {
@@ -23245,6 +20289,12 @@
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
           "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
+          "dev": true
+        },
+        "is-plain-obj": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+          "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
           "dev": true
         },
         "load-json-file": {
@@ -23427,21 +20477,12 @@
       "integrity": "sha1-2Ca4n3SQcy+rwMDtaT7Uddyynr8="
     },
     "varint-decoder": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/varint-decoder/-/varint-decoder-0.4.0.tgz",
-      "integrity": "sha512-1TGstvah6UbxTJCKMNV9eqR3u8lP7R3zmF52/sXQGyUYbHhh5HxW2dMEGADkuboqrCgOgheBn+z02YvN4bYGFg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/varint-decoder/-/varint-decoder-1.0.0.tgz",
+      "integrity": "sha512-JkOvdztASWGUAsXshCFHrB9f6AgR2Q8W08CEyJ+43b1qtFocmI8Sp1R/M0E/hDOY2FzVIqk63tOYLgDYWuJ7IQ==",
       "dev": true,
       "requires": {
-        "is-buffer": "^2.0.4",
         "varint": "^5.0.0"
-      },
-      "dependencies": {
-        "is-buffer": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
-          "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==",
-          "dev": true
-        }
       }
     },
     "varuint-bitcoin": {
@@ -23829,6 +20870,16 @@
             "upath": "^1.1.1"
           }
         },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
         "expand-brackets": {
           "version": "2.1.4",
           "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
@@ -24124,6 +21175,13 @@
             "to-regex": "^3.0.2"
           }
         },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true,
+          "optional": true
+        },
         "normalize-path": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -24134,9 +21192,9 @@
       }
     },
     "web-encoding": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/web-encoding/-/web-encoding-1.0.3.tgz",
-      "integrity": "sha512-Ajn64qJ0Z3oMwOIwBtxajFPA+4guB12n4EfmY1Mtlgb9296WJxwH1q/ykedmQrBNpjcKCM207S5OM2wpJfl4VA=="
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/web-encoding/-/web-encoding-1.0.4.tgz",
+      "integrity": "sha512-DcXs2lbVPzuJmn2kuDEwul2oZg7p4YMa5J2f0YzsOBHaAnBYGPNUB/rJ74DTjTKpw7F0+lSsVM8sFHE2UyBixg=="
     },
     "webcrypto": {
       "version": "0.1.1",
@@ -24224,6 +21282,15 @@
                 "is-extendable": "^0.1.0"
               }
             }
+          }
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
           }
         },
         "eslint-scope": {
@@ -24478,6 +21545,12 @@
             "minimist": "^1.2.5"
           }
         },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        },
         "schema-utils": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
@@ -24593,6 +21666,15 @@
             "semver": "^5.5.0",
             "shebang-command": "^1.2.0",
             "which": "^1.2.9"
+          }
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
           }
         },
         "expand-brackets": {
@@ -24860,6 +21942,12 @@
             "snapdragon": "^0.8.1",
             "to-regex": "^3.0.2"
           }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
         },
         "path-key": {
           "version": "2.0.1",
@@ -25257,9 +22345,9 @@
       "dev": true
     },
     "yallist": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true
     },
     "yargs": {
@@ -25351,6 +22439,12 @@
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
           "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "is-plain-obj": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+          "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
           "dev": true
         },
         "string-width": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "orbit-db",
-  "version": "0.25.3",
+  "version": "0.26.0-rc4",
   "description": "Distributed p2p database on IPFS",
   "author": "Haad",
   "license": "MIT",
@@ -19,19 +19,19 @@
     "localstorage-down": "^0.6.7",
     "logplease": "^1.2.14",
     "multihashes": "~3.0.1",
-    "orbit-db-access-controllers": "^0.2.6",
+    "orbit-db-access-controllers": "^0.3.0",
     "orbit-db-cache": "~0.3.0",
-    "orbit-db-counterstore": "~1.11.0",
-    "orbit-db-docstore": "~1.11.0",
-    "orbit-db-eventstore": "~1.11.0",
-    "orbit-db-feedstore": "~1.11.0",
+    "orbit-db-counterstore": "~1.12.0",
+    "orbit-db-docstore": "~1.12.0",
+    "orbit-db-eventstore": "~1.12.0",
+    "orbit-db-feedstore": "~1.12.0",
     "orbit-db-identity-provider": "~0.3.0",
-    "orbit-db-io": "~0.2.0",
+    "orbit-db-io": "~0.3.0",
     "orbit-db-keystore": "~0.3.0",
-    "orbit-db-kvstore": "~1.11.0",
-    "orbit-db-pubsub": "~0.5.5",
+    "orbit-db-kvstore": "~1.12.0",
+    "orbit-db-pubsub": "~0.6.0",
     "orbit-db-storage-adapter": "~0.5.3",
-    "orbit-db-store": "~3.5.0"
+    "orbit-db-store": "~4.0.1"
   },
   "devDependencies": {
     "adm-zip": "^0.4.16",
@@ -49,7 +49,7 @@
     "markdown-toc": "^1.2.0",
     "mkdirp": "^1.0.4",
     "mocha": "^8.1.1",
-    "orbit-db-test-utils": "0.10.3",
+    "orbit-db-test-utils": "^0.12.0",
     "p-each-series": "^2.1.0",
     "p-map": "^4.0.0",
     "p-map-series": "^2.1.0",
@@ -72,7 +72,7 @@
     "examples:browser-windows": "start examples/browser/browser.html",
     "lint:docs": "remark -qf -u validate-links .",
     "test:all": "npm run test:browser-multiple-tabs && npm run test",
-    "test": "cross-env TEST=js mocha && cross-env TEST=go mocha;",
+    "test": "cross-env TEST=all mocha",
     "test:browser-multiple-tabs": "npm run build:dist && cpy dist/orbitdb.min.js ./test/browser --rename=orbitdb.js && cpy node_modules/ipfs/dist/index.min.js ./test/browser --rename=ipfs.js && cpy node_modules/orbit-db-identity-provider/dist/index-browser.min.js ./test/browser --rename=identities.js && cpy node_modules/ipfs-log/dist/ipfslog.min.js ./test/browser && mocha ./test/browser/concurrent.spec.js",
     "build": "npm run build:es5 && npm run build:debug && npm run build:dist && npm run build:examples && npm run build:docs/toc",
     "build:examples": "webpack --config conf/webpack.example.config.js --sort-modules-by size",
@@ -80,9 +80,6 @@
     "build:debug": "webpack --config conf/webpack.debug.config.js --sort-modules-by size && mkdirp examples/browser/lib && cpy dist/orbitdb.js examples/browser/lib && cpy dist/orbitdb.js.map examples/browser/lib",
     "build:docs/toc": "markdown-toc --no-first1 -i README.md && markdown-toc --no-first1 -i API.md && markdown-toc --no-first1 -i GUIDE.md && markdown-toc --no-first1 -i CHANGELOG.md && markdown-toc --no-first1 -i FAQ.md ",
     "build:es5": "babel src --out-dir ./dist/es5/ --presets babel-preset-env --plugins babel-plugin-transform-runtime"
-  },
-  "go-ipfs": {
-    "version": "v0.5.1"
   },
   "standard": {
     "env": "mocha",

--- a/src/exchange-heads.js
+++ b/src/exchange-heads.js
@@ -15,7 +15,7 @@ const getHeadsForDatabase = async store => {
 
 const exchangeHeads = async (ipfs, address, peer, getStore, getDirectConnection, onMessage, onChannelCreated) => {
   const _handleMessage = message => {
-    const msg = JSON.parse(message.data)
+    const msg = JSON.parse(Buffer.from(message.data).toString())
     const { address, heads } = msg
     onMessage(address, heads)
   }

--- a/test/counterdb.test.js
+++ b/test/counterdb.test.js
@@ -16,8 +16,6 @@ const {
 
 const dbPath1 = './orbitdb/tests/counters/peer1'
 const dbPath2 = './orbitdb/tests/counters/peer2'
-const ipfsPath1 = './orbitdb/tests/counters/peer1/ipfs'
-const ipfsPath2 = './orbitdb/tests/counters/peer2/ipfs'
 
 Object.keys(testAPIs).forEach(API => {
   describe(`orbit-db - Counters (${API})`, function () {
@@ -29,8 +27,6 @@ Object.keys(testAPIs).forEach(API => {
     before(async () => {
       rmrf.sync(dbPath1)
       rmrf.sync(dbPath2)
-      config.daemon1.repo = ipfsPath1
-      config.daemon2.repo = ipfsPath2
       ipfsd1 = await startIpfs(API, config.daemon1)
       ipfsd2 = await startIpfs(API, config.daemon2)
       ipfs1 = ipfsd1.api

--- a/test/create-open.test.js
+++ b/test/create-open.test.js
@@ -22,7 +22,6 @@ const {
 } = require('orbit-db-test-utils')
 
 const dbPath = path.join('./orbitdb', 'tests', 'create-open')
-const ipfsPath = path.join('./orbitdb', 'tests', 'create-open', 'ipfs')
 const migrationFixturePath = path.join('./test', 'fixtures', 'migration', 'cache-schema-test')
 const ipfsFixturesDir = path.join('./test', 'fixtures', 'ipfs')
 
@@ -42,8 +41,6 @@ Object.keys(testAPIs).forEach(API => {
     }
 
     before(async () => {
-      config.daemon1.repo = ipfsPath
-      rmrf.sync(config.daemon1.repo)
       rmrf.sync(dbPath)
       ipfsd = await startIpfs(API, config.daemon1)
       ipfs = ipfsd.api

--- a/test/create-type.test.js
+++ b/test/create-type.test.js
@@ -14,7 +14,6 @@ const {
 } = require('orbit-db-test-utils')
 
 const dbPath = './orbitdb/tests/create-open'
-const ipfsPath = './orbitdb/tests/create-open/ipfs'
 
 class CustomStore extends DocumentStore {
   constructor (ipfs, id, dbname, options) {
@@ -34,8 +33,6 @@ Object.keys(testAPIs).forEach(API => {
     let ipfsd, ipfs, orbitdb
 
     before(async () => {
-      config.daemon1.repo = ipfsPath
-      rmrf.sync(config.daemon1.repo)
       rmrf.sync(dbPath)
       ipfsd = await startIpfs(API, config.daemon1)
       ipfs = ipfsd.api

--- a/test/custom-cache.test.js
+++ b/test/custom-cache.test.js
@@ -21,7 +21,6 @@ const {
 } = require('./utils')
 
 const dbPath = './orbitdb/tests/customKeystore'
-const ipfsPath = './orbitdb/tests/customKeystore/ipfs'
 
 Object.keys(testAPIs).forEach(API => {
   describe(`orbit-db - Use a Custom Cache (${API})`, function() {
@@ -33,8 +32,6 @@ Object.keys(testAPIs).forEach(API => {
       store = await storage.createStore("local")
       const cache = new CustomCache(store)
 
-      config.daemon1.repo = ipfsPath
-      rmrf.sync(config.daemon1.repo)
       rmrf.sync(dbPath)
       ipfsd = await startIpfs(API, config.daemon1)
       ipfs = ipfsd.api

--- a/test/custom-keystore.test.js
+++ b/test/custom-keystore.test.js
@@ -21,7 +21,6 @@ const {
 Identities.addIdentityProvider(CustomTestKeystore().identityProvider)
 
 const dbPath = './orbitdb/tests/customKeystore'
-const ipfsPath = './orbitdb/tests/customKeystore/ipfs'
 
 Object.keys(testAPIs).forEach(API => {
   describe(`orbit-db - Use a Custom Keystore (${API})`, function() {
@@ -30,8 +29,6 @@ Object.keys(testAPIs).forEach(API => {
     let ipfsd, ipfs, orbitdb1
 
     before(async () => {
-      config.daemon1.repo = ipfsPath
-      rmrf.sync(config.daemon1.repo)
       rmrf.sync(dbPath)
       ipfsd = await startIpfs(API, config.daemon1)
       ipfs = ipfsd.api

--- a/test/docstore.test.js
+++ b/test/docstore.test.js
@@ -14,7 +14,6 @@ const {
 } = require('orbit-db-test-utils')
 
 const dbPath = './orbitdb/tests/docstore'
-const ipfsPath = './orbitdb/tests/docstore/ipfs'
 
 Object.keys(testAPIs).forEach(API => {
   describe(`orbit-db - Document Store (${API})`, function() {
@@ -23,8 +22,6 @@ Object.keys(testAPIs).forEach(API => {
     let ipfsd, ipfs, orbitdb1, db
 
     before(async () => {
-      config.daemon1.repo = ipfsPath
-      rmrf.sync(config.daemon1.repo)
       ipfsd = await startIpfs(API, config.daemon1)
       ipfs = ipfsd.api
       orbitdb1 = await OrbitDB.createInstance(ipfs, { directory: path.join(dbPath, '1') })

--- a/test/drop.test.js
+++ b/test/drop.test.js
@@ -15,7 +15,6 @@ const {
 } = require('orbit-db-test-utils')
 
 const dbPath = './orbitdb/tests/drop'
-const ipfsPath = './orbitdb/tests/drop/ipfs'
 
 Object.keys(testAPIs).forEach(API => {
   describe(`orbit-db - Drop Database (${API})`, function() {
@@ -25,8 +24,6 @@ Object.keys(testAPIs).forEach(API => {
     let localDataPath
 
     before(async () => {
-      config.daemon1.repo = ipfsPath
-      rmrf.sync(config.daemon1.repo)
       rmrf.sync(dbPath)
       ipfsd = await startIpfs(API, config.daemon1)
       ipfs = ipfsd.api

--- a/test/eventlog.test.js
+++ b/test/eventlog.test.js
@@ -17,7 +17,6 @@ const {
 const last = arr => arr[arr.length - 1]
 
 const dbPath = './orbitdb/tests/eventlog'
-const ipfsPath = './orbitdb/tests/eventlog/ipfs'
 
 Object.keys(testAPIs).forEach(API => {
   describe(`orbit-db - Log Database (${API})`, function() {
@@ -26,8 +25,6 @@ Object.keys(testAPIs).forEach(API => {
     let ipfsd, ipfs, orbitdb1
 
     before(async () => {
-      config.daemon1.repo = ipfsPath
-      rmrf.sync(config.daemon1.repo)
       rmrf.sync(dbPath)
       ipfsd = await startIpfs(API, config.daemon1)
       ipfs = ipfsd.api

--- a/test/feed-load.test.js
+++ b/test/feed-load.test.js
@@ -17,7 +17,6 @@ const {
 const last = arr => arr[arr.length - 1]
 
 const dbPath = './orbitdb/tests/feed-load'
-const ipfsPath = './orbitdb/tests/feed-load/ipfs'
 
 Object.keys(testAPIs).forEach(API => {
   describe(`orbit-db - Feed Load Amount (${API})`, function() {
@@ -26,8 +25,6 @@ Object.keys(testAPIs).forEach(API => {
     let ipfsd, ipfs, orbitdb1, db, address
 
     before(async () => {
-      config.daemon1.repo = ipfsPath
-      rmrf.sync(config.daemon1.repo)
       rmrf.sync(dbPath)
       ipfsd = await startIpfs(API, config.daemon1)
       ipfs = ipfsd.api

--- a/test/feed.test.js
+++ b/test/feed.test.js
@@ -17,7 +17,6 @@ const {
 const last = arr => arr[arr.length - 1]
 
 const dbPath = './orbitdb/tests/feed'
-const ipfsPath = './orbitdb/tests/feed/ipfs'
 
 Object.keys(testAPIs).forEach(API => {
   describe(`orbit-db - Feed Database (${API})`, function() {
@@ -26,8 +25,6 @@ Object.keys(testAPIs).forEach(API => {
     let ipfsd, ipfs, orbitdb1, address
 
     before(async () => {
-      config.daemon1.repo = ipfsPath
-      rmrf.sync(config.daemon1.repo)
       rmrf.sync(dbPath)
       ipfsd = await startIpfs(API, config.daemon1)
       ipfs = ipfsd.api

--- a/test/kvstore.test.js
+++ b/test/kvstore.test.js
@@ -14,7 +14,6 @@ const {
 } = require('orbit-db-test-utils')
 
 const dbPath = './orbitdb/tests/kvstore'
-const ipfsPath = './orbitdb/tests/kvstore/ipfs'
 
 Object.keys(testAPIs).forEach(API => {
   describe(`orbit-db - Key-Value Database (${API})`, function() {
@@ -23,8 +22,6 @@ Object.keys(testAPIs).forEach(API => {
     let ipfsd, ipfs, orbitdb1
 
     before(async () => {
-      config.daemon1.repo = ipfsPath
-      rmrf.sync(config.daemon1.repo)
       rmrf.sync(dbPath)
       ipfsd = await startIpfs(API, config.daemon1)
       ipfs = ipfsd.api

--- a/test/multiple-databases.test.js
+++ b/test/multiple-databases.test.js
@@ -17,8 +17,6 @@ const {
 
 const dbPath1 = './orbitdb/tests/multiple-databases/1'
 const dbPath2 = './orbitdb/tests/multiple-databases/2'
-const ipfsPath1 = './orbitdb/tests/multiple-databases/1/ipfs'
-const ipfsPath2 = './orbitdb/tests/multiple-databases/2/ipfs'
 
 const databaseInterfaces = [
   {
@@ -68,10 +66,6 @@ Object.keys(testAPIs).forEach(API => {
 
     // Create two IPFS instances and two OrbitDB instances (2 nodes/peers)
     before(async () => {
-      config.daemon1.repo = ipfsPath1
-      config.daemon2.repo = ipfsPath2
-      rmrf.sync(config.daemon1.repo)
-      rmrf.sync(config.daemon2.repo)
       rmrf.sync(dbPath1)
       rmrf.sync(dbPath2)
       ipfsd1 = await startIpfs(API, config.daemon1)

--- a/test/offline-mode.js
+++ b/test/offline-mode.js
@@ -21,7 +21,6 @@ const {
 
 const dbPath1 = './orbitdb/tests/offline/db1'
 const dbPath2 = './orbitdb/tests/offline/db2'
-const ipfsPath = './orbitdb/tests/offline/ipfs'
 
 Object.keys(testAPIs).forEach(API => {
   describe(`orbit-db - Offline mode (${API})`, function() {
@@ -32,11 +31,6 @@ Object.keys(testAPIs).forEach(API => {
     let localDataPath
 
     before(async () => {
-      config.daemon1.repo = path.join(ipfsPath, '/1')
-      config.daemon2.repo = path.join(ipfsPath, '/2')
-      rmrf.sync(config.daemon1.repo)
-      rmrf.sync(config.daemon2.repo)
-      rmrf.sync(path.join(ipfsPath, '/2'))
       rmrf.sync('./orbitdb/tests/offline')
       rmrf.sync(dbPath1)
       rmrf.sync(dbPath2)

--- a/test/orbit-db-address.test.js
+++ b/test/orbit-db-address.test.js
@@ -6,7 +6,6 @@ const OrbitDB = require('../src/OrbitDB')
 const OrbitDBAddress = require('../src/orbit-db-address')
 
 const dbPath = './orbitdb/tests/orbit-db-address'
-const ipfsPath = './orbitdb/tests/orbit-db-address/ipfs'
 
 const {
   config,
@@ -22,8 +21,6 @@ Object.keys(testAPIs).forEach(API => {
     let ipfsd, ipfs, orbitdb
 
     before(async () => {
-      config.daemon1.repo = ipfsPath
-      rmrf.sync(config.daemon1.repo)
       rmrf.sync(dbPath)
       ipfsd = await startIpfs(API, config.daemon1)
       ipfs = ipfsd.api

--- a/test/persistency.js
+++ b/test/persistency.js
@@ -19,7 +19,6 @@ const {
 } = require('orbit-db-test-utils')
 
 const dbPath = './orbitdb/tests/persistency'
-const ipfsPath = './orbitdb/tests/persistency/ipfs'
 
 const tests = [
   {
@@ -51,8 +50,6 @@ Object.keys(testAPIs).forEach(API => {
           options.cache = new Cache(customStore)
         }
 
-        config.daemon1.repo = ipfsPath
-        rmrf.sync(config.daemon1.repo)
         rmrf.sync(dbPath)
         ipfsd = await startIpfs(API, config.daemon1)
         ipfs = ipfsd.api

--- a/test/replicate-and-load.test.js
+++ b/test/replicate-and-load.test.js
@@ -17,8 +17,6 @@ const {
 
 const dbPath1 = './orbitdb/tests/replicate-and-load/1'
 const dbPath2 = './orbitdb/tests/replicate-and-load/2'
-const ipfsPath1 = './orbitdb/tests/replicate-and-load/1/ipfs'
-const ipfsPath2 = './orbitdb/tests/replicate-and-load/2/ipfs'
 
 Object.keys(testAPIs).forEach(API => {
   describe(`orbit-db - Replicate and Load (${API})`, function() {
@@ -28,10 +26,6 @@ Object.keys(testAPIs).forEach(API => {
     let orbitdb1, orbitdb2
 
     before(async () => {
-      config.daemon1.repo = ipfsPath1
-      config.daemon2.repo = ipfsPath2
-      rmrf.sync(config.daemon1.repo)
-      rmrf.sync(config.daemon2.repo)
       rmrf.sync(dbPath1)
       rmrf.sync(dbPath2)
       ipfsd1 = await startIpfs(API, config.daemon1)

--- a/test/replicate-automatically.test.js
+++ b/test/replicate-automatically.test.js
@@ -17,8 +17,6 @@ const {
 
 const dbPath1 = './orbitdb/tests/replicate-automatically/1'
 const dbPath2 = './orbitdb/tests/replicate-automatically/2'
-const ipfsPath1 = './orbitdb/tests/replicate-automatically/1/ipfs'
-const ipfsPath2 = './orbitdb/tests/replicate-automatically/2/ipfs'
 
 Object.keys(testAPIs).forEach(API => {
   describe(`orbit-db - Automatic Replication (${API})`, function() {
@@ -28,10 +26,6 @@ Object.keys(testAPIs).forEach(API => {
     let orbitdb1, orbitdb2, db1, db2, db3, db4
 
     before(async () => {
-      config.daemon1.repo = ipfsPath1
-      config.daemon2.repo = ipfsPath2
-      rmrf.sync(config.daemon1.repo)
-      rmrf.sync(config.daemon2.repo)
       rmrf.sync(dbPath1)
       rmrf.sync(dbPath2)
       ipfsd1 = await startIpfs(API, config.daemon1)

--- a/test/replicate.test.js
+++ b/test/replicate.test.js
@@ -18,8 +18,6 @@ const {
 
 const dbPath1 = './orbitdb/tests/replication/1'
 const dbPath2 = './orbitdb/tests/replication/2'
-const ipfsPath1 = './orbitdb/tests/replication/1/ipfs'
-const ipfsPath2 = './orbitdb/tests/replication/2/ipfs'
 
 Object.keys(testAPIs).forEach(API => {
   describe(`orbit-db - Replication (${API})`, function() {
@@ -33,10 +31,6 @@ Object.keys(testAPIs).forEach(API => {
     let options
 
     before(async () => {
-      config.daemon1.repo = ipfsPath1
-      config.daemon2.repo = ipfsPath2
-      rmrf.sync(config.daemon1.repo)
-      rmrf.sync(config.daemon2.repo)
       rmrf.sync(dbPath1)
       rmrf.sync(dbPath2)
       ipfsd1 = await startIpfs(API, config.daemon1)

--- a/test/replication-status.test.js
+++ b/test/replication-status.test.js
@@ -20,7 +20,6 @@ const {
 
 const dbPath1 = './orbitdb/tests/create-open/1'
 const dbPath2 = './orbitdb/tests/create-open/2'
-const ipfsPath = './orbitdb/tests/create-open/ipfs'
 
 Object.keys(testAPIs).forEach(API => {
   describe(`orbit-db - Replication Status (${API})`, function() {
@@ -30,8 +29,6 @@ Object.keys(testAPIs).forEach(API => {
     let localDataPath
 
     before(async () => {
-      config.daemon1.repo = ipfsPath
-      rmrf.sync(config.daemon1.repo)
       rmrf.sync(dbPath1)
       rmrf.sync(dbPath2)
       ipfsd = await startIpfs(API, config.daemon1)

--- a/test/set-identity.test.js
+++ b/test/set-identity.test.js
@@ -20,7 +20,6 @@ const {
 
 const keysPath = './orbitdb/identity/identitykeys'
 const dbPath = './orbitdb/tests/change-identity'
-const ipfsPath = './orbitdb/tests/change-identity/ipfs'
 
 Object.keys(testAPIs).forEach(API => {
   describe(`orbit-db - Set identities (${API})`, function() {
@@ -31,8 +30,6 @@ Object.keys(testAPIs).forEach(API => {
     let localDataPath
 
     before(async () => {
-      config.daemon1.repo = ipfsPath
-      rmrf.sync(config.daemon1.repo)
       rmrf.sync(dbPath)
       ipfsd = await startIpfs(API, config.daemon1)
       ipfs = ipfsd.api

--- a/test/write-permissions.test.js
+++ b/test/write-permissions.test.js
@@ -18,7 +18,6 @@ const {
 } = require('./utils')
 
 const dbPath = './orbitdb/tests/write-permissions'
-const ipfsPath = './orbitdb/tests/write-permissions/ipfs'
 
 Object.keys(testAPIs).forEach(API => {
   describe(`orbit-db - Write Permissions (${API})`, function() {
@@ -27,8 +26,6 @@ Object.keys(testAPIs).forEach(API => {
     let ipfsd, ipfs, orbitdb1, orbitdb2
 
     before(async () => {
-      config.daemon1.repo = ipfsPath
-      rmrf.sync(config.daemon1.repo)
       rmrf.sync(dbPath)
       ipfsd = await startIpfs(API, config.daemon1)
       ipfs = ipfsd.api


### PR DESCRIPTION
TODO:

- [x] ~Update the `ipfs-pubsub-*` repos one way or another~
- [x] Update the `orbit-db-****store` repos `peerDependency` field as they are in master (:tada: the first of the Roadmap items to be done!)
- [x] https://github.com/orbitdb/orbit-db-store/pull/98