### PR TITLE
docs: Remove sections about community calls.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,6 @@ This is the Javascript implementation and it works both in **Browsers** and **No
 
 To use with older versions of Node.js, we provide an ES5-compatible build through the npm package, located in `dist/es5/` when installed through npm.
 
-#### Community Calls
-We also have regular community calls, which we announce in the issues in [the @orbitdb welcome repository](https://github.com/orbitdb/welcome/issues). Join us!
-
 ## Table of Contents
 
 <!-- toc -->
@@ -325,7 +322,6 @@ The best place to find out what is out there and what is being actively worked o
 
 As far as code goes, we would be happy to accept PRs! If you want to work on something, it'd be good to talk beforehand to make sure nobody else is working on it. You can reach us [on Gitter](https://gitter.im/orbitdb/Lobby), or in the [issues section](https://github.com/orbitdb/orbit-db/issues).
 
-We also have **regular community calls**, which we announce in the issues in [the @orbitdb welcome repository](https://github.com/orbitdb/welcome/issues). Join us!
 
 If you want to code but don't know where to start, check out the issues labelled ["help wanted"](https://github.com/orbitdb/orbit-db/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22+sort%3Areactions-%2B1-desc).
 


### PR DESCRIPTION
We no longer hold these regularly. Happy to have them again, but it seems disingenuous to keep them in this doc.