### PR TITLE
remove obsolete makefile line

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,6 @@ clean:
 
 clean-dependencies: clean
 	rm -f package-lock.json
-	rm -rf examples/browser/lib
 
 rebuild: | clean-dependencies build
 


### PR DESCRIPTION
this line is no longer needed as a result of https://github.com/orbitdb/orbit-db/pull/854 browser.html not using this folder anymore