### PR TITLE
update orbit-db-test-utils

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "markdown-toc": "^1.2.0",
     "mkdirp": "^1.0.4",
     "mocha": "^8.1.1",
-    "orbit-db-test-utils": "^0.12.0",
+    "orbit-db-test-utils": "github:tabcat/orbit-db-test-utils#support-latest",
     "p-each-series": "^2.1.0",
     "p-map": "^4.0.0",
     "p-map-series": "^2.1.0",


### PR DESCRIPTION
This pr updates orbit-db-test-utils if https://github.com/orbitdb/orbit-db-test-utils/pull/30 is merged.

The update will use newer versions of ipfs, js-ipfs 0.52.0 and go-ipfs v0.7.0, and potentially reduces frequency of test timeouts.

clone or pull https://github.com/tabcat/orbit-db/tree/update-test-util to install and run tests