### PR TITLE
use png logo for readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # OrbitDB
 
 <p align="left">
-  <img src="images/orbit_db_logo_color.jpg" width="256" />
+  <img src="images/orbit_db_logo_color.png" width="256" />
 </p>
 
 [![Gitter](https://img.shields.io/gitter/room/nwjs/nw.js.svg)](https://gitter.im/orbitdb/Lobby) [![Matrix](https://img.shields.io/badge/matrix-%23orbit--db%3Amatrix.org-blue.svg)](https://riot.im/app/#/room/#orbit-db:matrix.org) [![Discord](https://img.shields.io/discord/475789330380488707?color=blueviolet&label=discord)](https://discord.gg/v3RNE3M) [![CircleCI Status](https://circleci.com/gh/orbitdb/orbit-db.svg?style=shield)](https://circleci.com/gh/orbitdb/orbit-db) [![npm version](https://badge.fury.io/js/orbit-db.svg)](https://www.npmjs.com/package/orbit-db) [![node](https://img.shields.io/node/v/orbit-db.svg)](https://www.npmjs.com/package/orbit-db)


### PR DESCRIPTION
This pr changes the logo file used in README.md 
from 
`images/orbit_db_logo_color.jpg`
to
`images/orbit_db_logo_color.png`

Both files existed previously.
The purpose of this pr is to play nicer with the new Dark Theme [appearance](https://github.com/settings/appearance).
@aphelionz brought this issue/improvement up in the community chat.

Test out how it looks in the branches preview
https://github.com/tabcat/orbit-db/tree/png-logo