### PR TITLE
build dist before publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "build:debug": "webpack --config conf/webpack.debug.config.js --sort-modules-by size",
     "build:docs/toc": "markdown-toc --no-first1 -i README.md && markdown-toc --no-first1 -i API.md && markdown-toc --no-first1 -i GUIDE.md && markdown-toc --no-first1 -i CHANGELOG.md && markdown-toc --no-first1 -i FAQ.md ",
     "build:es5": "babel src --out-dir ./dist/es5/ --presets babel-preset-env --plugins babel-plugin-transform-runtime",
-    "release": "npm run build && npm publish"
+    "prepublishOnly": "npm run build"
   },
   "standard": {
     "env": "mocha",


### PR DESCRIPTION
makes sure dist is published with the package so `orbitdb.min.js` can be used directly or via a service like jsDeliver