### PR TITLE
require address with prefix

### DIFF
--- a/test/orbit-db-address.test.js
+++ b/test/orbit-db-address.test.js
@@ -60,6 +60,20 @@ Object.keys(testAPIs).forEach(API => {
         assert.equal(result.toString().indexOf('zd'), 9)
       })
 
+      it('parse with missing db address name', () => {
+        const address = '/orbitdb/zdpuAuK3BHpS7NvMBivynypqciYCuy2UW77XYBPUYRnLjnw13'
+        const result = OrbitDB.parseAddress(address)
+
+        const isInstanceOf = result instanceof OrbitDBAddress
+        assert.equal(isInstanceOf, true)
+
+        assert.equal(result.root, 'zdpuAuK3BHpS7NvMBivynypqciYCuy2UW77XYBPUYRnLjnw13')
+        assert.equal(result.path, '')
+
+        assert.equal(result.toString().indexOf('/orbitdb'), 0)
+        assert.equal(result.toString().indexOf('zd'), 9)
+      })
+
       it('parse address with backslashes (win32) successfully', () => {
         const address = '\\orbitdb\\Qmdgwt7w4uBsw8LXduzCd18zfGXeTmBsiR8edQ1hSfzcJC\\first-database'
         const result = OrbitDB.parseAddress(address)
@@ -72,6 +86,26 @@ Object.keys(testAPIs).forEach(API => {
 
         assert.equal(result.toString().indexOf('/orbitdb'), 0)
         assert.equal(result.toString().indexOf('Qm'), 9)
+      })
+
+      it('fail to parse with missing orbitdb prefix', () => {
+        const address = 'zdpuAuK3BHpS7NvMBivynypqciYCuy2UW77XYBPUYRnLjnw13/first-database'
+
+        try {
+          OrbitDB.parseAddress(address)
+        } catch (e) {
+          assert(e.toString(), 'Error: Not a valid OrbitDB address: ' + address)
+        }
+      })
+
+      it('fail to parse with invalid multihash', () => {
+        const address = '/orbitdb/Qmdgwt7w4uBsw8LXduzCd18zfGXeTmBsiR8edQ1hSfzc/first-database'
+
+        try {
+          OrbitDB.parseAddress(address)
+        } catch (e) {
+          assert(e.toString(), 'Error: Not a valid OrbitDB address: ' + address)
+        }
       })
     })
 
@@ -92,7 +126,7 @@ Object.keys(testAPIs).forEach(API => {
         const address = 'zdpuAuK3BHpS7NvMBivynypqciYCuy2UW77XYBPUYRnLjnw13/first-database'
         const result = OrbitDB.isValidAddress(address)
 
-        assert.equal(result, true)
+        assert.equal(result, false)
       })
 
       it('handle missing db address name', () => {


### PR DESCRIPTION
Changes the valid address format to always include the `/orbitdb/` prefix and optionally include the `/<name>` suffix. Previous tests showed addresses starting with the manifest hash as valid.
This might look like a large change on the address format but should have very little impact.

Also cleaned up some parts and added a few tests. Would like to see about moving away from the `path` module if we only need it for the join method.
Another thing, it seems like it would be fine to use posix paths always. What is the reason Windows paths are used sometimes?