### PR TITLE
Fix fs-shim error in electron renderer process

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "MIT",
       "dependencies": {
         "ipfs-pubsub-1on1": "0.0.8",
-        "is-electron": "^2.2.0",
         "is-node": "^1.0.2",
         "localstorage-down": "^0.6.7",
         "logplease": "^1.2.14",
@@ -27,7 +26,8 @@
         "orbit-db-kvstore": "~1.12.0",
         "orbit-db-pubsub": "~0.6.0",
         "orbit-db-storage-adapter": "~0.5.3",
-        "orbit-db-store": "^4.3.3"
+        "orbit-db-store": "^4.3.3",
+        "wherearewe": "^1.0.2"
       },
       "devDependencies": {
         "adm-zip": "^0.4.16",
@@ -69,7 +69,7 @@
         "webpack-cli": "^3.3.10"
       },
       "engines": {
-        "node": ">=10.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -28616,11 +28616,15 @@
       }
     },
     "node_modules/wherearewe": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/wherearewe/-/wherearewe-1.0.0.tgz",
-      "integrity": "sha512-oQnRsAfMCqNAC7U4JrBdmFXAhBRLOkPGOfU5+nw9fs2D3g8O6EV7hn7BhpXtt0yno4pxFiRD55rMyt0fsLMqlw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wherearewe/-/wherearewe-1.0.2.tgz",
+      "integrity": "sha512-HyLZ7n1Yox+w1qWaFEgP/sMs5D7ka2UXmoVNaY0XzbEHLGljo4ScBchYm6cWRYNO33tmFX3Mgg4BiZkDOjihyw==",
       "dependencies": {
         "is-electron": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
       }
     },
     "node_modules/which": {
@@ -52130,9 +52134,9 @@
       }
     },
     "wherearewe": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/wherearewe/-/wherearewe-1.0.0.tgz",
-      "integrity": "sha512-oQnRsAfMCqNAC7U4JrBdmFXAhBRLOkPGOfU5+nw9fs2D3g8O6EV7hn7BhpXtt0yno4pxFiRD55rMyt0fsLMqlw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wherearewe/-/wherearewe-1.0.2.tgz",
+      "integrity": "sha512-HyLZ7n1Yox+w1qWaFEgP/sMs5D7ka2UXmoVNaY0XzbEHLGljo4ScBchYm6cWRYNO33tmFX3Mgg4BiZkDOjihyw==",
       "requires": {
         "is-electron": "^2.2.0"
       }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
   "main": "src/OrbitDB.js",
   "dependencies": {
     "ipfs-pubsub-1on1": "0.0.8",
-    "is-electron": "^2.2.0",
     "is-node": "^1.0.2",
     "localstorage-down": "^0.6.7",
     "logplease": "^1.2.14",
@@ -35,7 +34,8 @@
     "orbit-db-kvstore": "~1.12.0",
     "orbit-db-pubsub": "~0.6.0",
     "orbit-db-storage-adapter": "~0.5.3",
-    "orbit-db-store": "^4.3.3"
+    "orbit-db-store": "^4.3.3",
+    "wherearewe": "^1.0.2"
   },
   "devDependencies": {
     "adm-zip": "^0.4.16",

--- a/src/fs-shim.js
+++ b/src/fs-shim.js
@@ -1,6 +1,6 @@
 /* eslint-disable */
-const isElectron = require('is-electron')
+const where = require('wherearewe')
 
-const fs = (!isElectron() && (typeof window === 'object' || typeof self === 'object')) ? null : eval('require("fs")')
+const fs = (!where.isElectronMain && (typeof window === 'object' || typeof self === 'object')) ? null : eval('require("fs")')
 
 module.exports = fs


### PR DESCRIPTION
is-electron returns true for the electron renderer process, which leads to a `require is not defined` error. Using wherearewe instead and explicitly checking for the electron main process resolves this issue.