### PR TITLE
ipfs.id() is not a string

### DIFF
--- a/src/OrbitDB.js
+++ b/src/OrbitDB.js
@@ -106,7 +106,7 @@ class OrbitDB {
     }
 
     if (!options.keystore) {
-      const keystorePath = path.join(options.directory, id, '/keystore')
+      const keystorePath = path.join(options.directory, typeof id !== 'object' ? id : id.toString(), '/keystore')
       const keyStorage = await options.storage.createStore(keystorePath)
       options.keystore = new Keystore(keyStorage)
     }

--- a/src/OrbitDB.js
+++ b/src/OrbitDB.js
@@ -119,12 +119,12 @@ class OrbitDB {
     }
 
     if (!options.cache) {
-      const cachePath = path.join(options.directory, id, '/cache')
+      const cachePath = path.join(options.directory, typeof id !== 'object' ? id : id.toString(), '/cache')
       const cacheStorage = await options.storage.createStore(cachePath)
       options.cache = new Cache(cacheStorage)
     }
 
-    const finalOptions = Object.assign({}, options, { peerId: id })
+    const finalOptions = Object.assign({}, options, { peerId: typeof id !== 'object' ? id : id.toString() })
     return new OrbitDB(ipfs, options.identity, finalOptions)
   }
 


### PR DESCRIPTION
While creating an instance with:
```javascript
import { create } from 'ipfs-core'
import OrbitDB from 'orbit-db'

create({
  repo: './orbitdb/pinner',
  start: true,
  EXPERIMENTAL: {
    ipnsPubsub: true
  },
  config: {}
}).then((ipfs) => {
  OrbitDB.createInstance(ipfs,
    {directory:'.'
  })
    .then((db) => {
    console.log(db.id)
  })
})
````
I get this error:
```bash
TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received an instance of Ed25519PeerIdImpl
    at new NodeError (node:internal/errors:372:5)
    at validateString (node:internal/validators:120:11)
    at Object.join (node:path:1172:7)
    at Function.createInstance (/Users/ME/Development/orbitdb-server/node_modules/orbit-db/src/OrbitDB.js:109:33) {
  code: 'ERR_INVALID_ARG_TYPE'
```
This is my workaround:
```javascript
typeof id !== 'object' ? id : id.toString()
```