### PR TITLE
Fixed: ReferenceError: Ipfs is not defined

### DIFF
--- a/examples/browser/browser.html
+++ b/examples/browser/browser.html
@@ -52,7 +52,7 @@
     <div id="writerText"></div>
 
     <script type="text/javascript" src="../../dist/orbitdb.js" charset="utf-8"></script>
-    <script type="text/javascript" src="../../node_modules/ipfs/dist/index.min.js" charset="utf-8"></script>
+    <script type="text/javascript" src="../../node_modules/ipfs/index.min.js" charset="utf-8"></script>
     <script type="text/javascript" src="example.js" charset="utf-8"></script>
     <script type="text/javascript" charset="utf-8">
       // Start the example


### PR DESCRIPTION
The browser examples didn't start because of wrong reference to the ipfs lib.