### PR TITLE
wrong ipfs.js reference in browser examples 

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,14 +160,14 @@ to redo the local package-lock.json with working native dependencies.
 ### Browser example
 
 ```
-npm run build
-npm run examples:browser
+make
+npm run examples:browser # if browser isn't opening, open examples/browser/browser.html in your browser
 ```
 
 Using Webpack:
 ```
-npm run build
-npm run examples:browser-webpack
+make
+npm run examples:browser-webpack # if browser isn't opening, open examples/browser/browser-webpack-example/index.html in your browser
 ```
 
 <p align="left">

--- a/examples/browser/browser.html
+++ b/examples/browser/browser.html
@@ -52,7 +52,7 @@
     <div id="writerText"></div>
 
     <script type="text/javascript" src="../../dist/orbitdb.js" charset="utf-8"></script>
-    <script type="text/javascript" src="../../node_modules/ipfs/dist/index.min.js" charset="utf-8"></script>
+    <script type="text/javascript" src="../../node_modules/ipfs/index.min.js" charset="utf-8"></script>
     <script type="text/javascript" src="example.js" charset="utf-8"></script>
     <script type="text/javascript" charset="utf-8">
       // Start the example

--- a/examples/browser/browser.html
+++ b/examples/browser/browser.html
@@ -51,8 +51,8 @@
     </div>
     <div id="writerText"></div>
 
-    <script type="text/javascript" src="../../dist/orbitdb.js" charset="utf-8"></script>
-    <script type="text/javascript" src="../../node_modules/ipfs/index.min.js" charset="utf-8"></script>
+    <script type="text/javascript" src="lib/orbitdb.js" charset="utf-8"></script>
+    <script type="text/javascript" src="lib/ipfs.js" charset="utf-8"></script>
     <script type="text/javascript" src="example.js" charset="utf-8"></script>
     <script type="text/javascript" charset="utf-8">
       // Start the example


### PR DESCRIPTION
1.  corrected reference to ipfs.js
2.  corrected build instructions so browser libs are correctly copied
3.  added workaround to README in case browser isn't opening (under MacOS) 