### PR TITLE
Fix for "Ipfs not defined in webpack example"

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,14 +160,14 @@ to redo the local package-lock.json with working native dependencies.
 ### Browser example
 
 ```
-npm run build
-npm run examples:browser
+make
+npm run examples:browser # if browser isn't opening, open examples/browser/browser.html in your browser
 ```
 
 Using Webpack:
 ```
-npm run build
-npm run examples:browser-webpack
+make
+npm run examples:browser-webpack # if browser isn't opening, open examples/browser/browser-webpack-example/index.html in your browser
 ```
 
 <p align="left">

--- a/examples/browser/browser-webpack-example/index.js
+++ b/examples/browser/browser-webpack-example/index.js
@@ -11,7 +11,7 @@
  */
 
 // Import IPFS module
-import IPFS from 'ipfs'
+const IPFS = require('ipfs')
 
 // Import OrbitDB module from 'orbit-db', eg. directory to its package.json
 import OrbitDB from '../../..'

--- a/examples/browser/browser.html
+++ b/examples/browser/browser.html
@@ -52,7 +52,7 @@
     <div id="writerText"></div>
 
     <script type="text/javascript" src="../../dist/orbitdb.js" charset="utf-8"></script>
-    <script type="text/javascript" src="../../node_modules/ipfs/dist/index.min.js" charset="utf-8"></script>
+    <script type="text/javascript" src="../../node_modules/ipfs/index.min.js" charset="utf-8"></script>
     <script type="text/javascript" src="example.js" charset="utf-8"></script>
     <script type="text/javascript" charset="utf-8">
       // Start the example

--- a/examples/browser/browser.html
+++ b/examples/browser/browser.html
@@ -51,8 +51,8 @@
     </div>
     <div id="writerText"></div>
 
-    <script type="text/javascript" src="../../dist/orbitdb.js" charset="utf-8"></script>
-    <script type="text/javascript" src="../../node_modules/ipfs/index.min.js" charset="utf-8"></script>
+    <script type="text/javascript" src="lib/orbitdb.js" charset="utf-8"></script>
+    <script type="text/javascript" src="lib/ipfs.js" charset="utf-8"></script>
     <script type="text/javascript" src="example.js" charset="utf-8"></script>
     <script type="text/javascript" charset="utf-8">
       // Start the example


### PR DESCRIPTION
When running the examples as described in Readme, after opening the browser console shows "Ipfs not found". 
The import Ipfs from "ipfs" doesn't seem to resolve for some reason.  But if replaced with a 

const Ipfs = require('ipfs') 

the whole example works like a sharm (as the other browser example too)
We fixed a similar problem in the other browser example lately but didn't see that the webpack example doesn't work either. Now it does. 