### PR TITLE
Add a Github Action config for running tests on all branches on push

### DIFF
--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -1,0 +1,18 @@
+---
+name: Run Tests
+
+on: push
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 'lts/*'
+          registry-url: https://registry.npmjs.org/
+      - name: Install dependencies
+        run: npm ci
+      - name: Run tests
+        run: npm test


### PR DESCRIPTION
This PR adds a Github Actions script to run the tests (`npm test`) on every push to all branches.

Once all working properly, this will make CircleCI obsolete.