### PR TITLE
Run linter on publishing next version

### DIFF
--- a/.github/workflows/npm-publish-next.yml
+++ b/.github/workflows/npm-publish-next.yml
@@ -10,12 +10,13 @@ jobs:
   publish-npm:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: 'lts/*'
           registry-url: https://registry.npmjs.org/
       - run: npm ci
+      - run: npm run lint
       - run: npm test
       - run: |
           npm version prerelease --no-git-tag-version \


### PR DESCRIPTION
This PR adds a command to run the linter when publishing the "next" tag version to npm.