### PR TITLE
Expose applyOperation for backup and restore purpose

### DIFF
--- a/src/database.js
+++ b/src/database.js
@@ -213,6 +213,7 @@ const Database = async ({ ipfs, identity, address, name, access, directory, meta
     close,
     drop,
     addOperation,
+    applyOperation,
     /**
      * The underlying [operations log]{@link module:Log~Log} of the database.
      * @†ype {module:Log~Log}


### PR DESCRIPTION
Hello Team. 
I'm using applyOperation for restore purpose. 
 @helia/car & @ipld/car helps with backup and restore but for rebuilt indexes I have to call applyOperation. 
Follow the example
 `
const reader = await CarReader.fromIterable(readableStream);//car file stream
await car(ipfs).import(reader, {
        onProgress: () => {
          blocksCount++;
        },
      });
for (const cid of await reader.getRoots()) {
        const block = await reader.get(cid);
        if(block) {
            const entry = logEntryDecoder(block);
            const database = getDatabaseByAddress(entry.id);
            database.applyOperation(entry);
        }

`
Is this action correct or I have to use another way to do this ?